### PR TITLE
Add pnpm lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "astalla",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.13.1"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## Summary
- initialize the repository with a basic package.json so pnpm can manage dependencies
- generate and commit the pnpm-lock.yaml file for package manager detection

## Testing
- pnpm install --lockfile-only

------
https://chatgpt.com/codex/tasks/task_e_68db3652d0308322998fadd34d1c7242