### PR TITLE
Fix shared package NodeNext typecheck configuration

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./schemas";
+export * from "./schemas.js";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "esnext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "emitDeclarationOnly": false,
     "outDir": "dist",


### PR DESCRIPTION
## Summary
- align the shared package TypeScript configuration with NodeNext module settings
- update the shared index re-export to use the .js extension required by NodeNext resolution

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68dc1061b59c8322abc4b9f5dc5482f7