### PR TITLE
Fix Next.js output tracing for Vercel deployment

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -1,9 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true
-  }
+  },
+  outputFileTracingRoot: path.join(__dirname, "../..")
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js to trace files from the monorepo root so shared packages deploy on Vercel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc612032848322a28c2e956c8387c6