### PR TITLE
Fix dashboard occupancy type narrowing before rendering metrics

### DIFF
--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -42,17 +42,23 @@ export function DashboardView() {
     );
   }
 
+  const occupancy = occupancyQuery.data;
+  const pipeline = pipelineQuery.data;
+  const cost = costQuery.data;
+  const reviews = reviewsQuery.data;
+  const report = reportQuery.data;
+
   if (
     occupancyQuery.error ||
     pipelineQuery.error ||
     costQuery.error ||
     reviewsQuery.error ||
     reportQuery.error ||
-    !occupancyQuery.data ||
-    !pipelineQuery.data ||
-    !costQuery.data ||
-    !reviewsQuery.data ||
-    !reportQuery.data
+    !occupancy ||
+    !pipeline ||
+    !cost ||
+    !reviews ||
+    !report
   ) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -60,12 +66,6 @@ export function DashboardView() {
       </div>
     );
   }
-
-  const occupancy = occupancyQuery.data;
-  const pipeline = pipelineQuery.data;
-  const cost = costQuery.data;
-  const reviews = reviewsQuery.data;
-  const report = reportQuery.data;
 
   return (
     <DashboardShell user={meQuery.data}>


### PR DESCRIPTION
## Summary
- instantiate dashboard metric query results before the shared error guard so TypeScript narrows them correctly during rendering

## Testing
- pnpm --filter apps-frontend build *(fails: Next.js cannot download Inter font in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc771c23888322ad279e20966ba7bd