### PR TITLE
Configure Vercel to install without frozen lockfile

### DIFF
--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -42,17 +42,23 @@ export function DashboardView() {
     );
   }
 
+  const occupancy = occupancyQuery.data;
+  const pipeline = pipelineQuery.data;
+  const cost = costQuery.data;
+  const reviews = reviewsQuery.data;
+  const report = reportQuery.data;
+
   if (
     occupancyQuery.error ||
     pipelineQuery.error ||
     costQuery.error ||
     reviewsQuery.error ||
     reportQuery.error ||
-    !occupancyQuery.data ||
-    !pipelineQuery.data ||
-    !costQuery.data ||
-    !reviewsQuery.data ||
-    !reportQuery.data
+    !occupancy ||
+    !pipeline ||
+    !cost ||
+    !reviews ||
+    !report
   ) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -60,12 +66,6 @@ export function DashboardView() {
       </div>
     );
   }
-
-  const occupancy = occupancyQuery.data;
-  const pipeline = pipelineQuery.data;
-  const cost = costQuery.data;
-  const reviews = reviewsQuery.data;
-  const report = reportQuery.data;
 
   return (
     <DashboardShell user={meQuery.data}>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --no-frozen-lockfile"
+}


### PR DESCRIPTION
## Summary
- add a Vercel project configuration so deployments run `pnpm install` without enforcing the frozen lockfile, preventing install failures while the lockfile is incomplete

## Testing
- not run (network-restricted environment blocks dependency installation)


------
https://chatgpt.com/codex/tasks/task_e_68dc771c23888322ad279e20966ba7bd