### PR TITLE
Clean up authentication files to resolve build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,7 @@ packages/
 
 ## Environment variables
 
- codex/fix-deployment-issue-on-vercel-6wxxpp
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
- codex/fix-deployment-issue-on-vercel-rnbuxy
- main
- main
-Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The
-frontend's basic-auth flow will accept either the configured credentials or any accounts that users
-create through the new `/register` page backed by the Nest API. Make sure `NEXT_PUBLIC_API_BASE_URL`
-and `DATABASE_URL` are configured so the frontend can reach the backend when creating accounts.
- codex/fix-deployment-issue-on-vercel-6wxxpp
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
-
-Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed.
- main
- main
- main
+Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. Ensure `NEXT_PUBLIC_API_BASE_URL` and `DATABASE_URL` are set so the frontend can reach the backend during account creation.
 
 ## Local development
 

--- a/apps/frontend/components/auth/login-card.tsx
+++ b/apps/frontend/components/auth/login-card.tsx
@@ -2,18 +2,7 @@
 
 import type { FormEvent } from "react";
 import { useState } from "react";
- codex/fix-deployment-issue-on-vercel-6wxxpp
 import Link from "next/link";
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-import Link from "next/link";
-
- codex/fix-deployment-issue-on-vercel-rnbuxy
-import Link from "next/link";
-
- main
- main
- main
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 
@@ -52,24 +41,15 @@ export function LoginCard() {
     }
   };
 
+  const inputClasses =
+    "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
   return (
     <div className="mx-auto w-full max-w-md rounded-2xl border bg-card p-10 text-left shadow-sm">
       <div className="space-y-2 text-center">
         <h1 className="text-2xl font-semibold text-foreground">Sign in to continue</h1>
         <p className="text-sm text-muted-foreground">
- codex/fix-deployment-issue-on-vercel-6wxxpp
-          Use your Astalla email or username with your password to access the dashboard.
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-          Use your Astalla email or username with your password to access the dashboard.
-
- codex/fix-deployment-issue-on-vercel-rnbuxy
-          Use your Astalla email or username with your password to access the dashboard.
-
           Use your Astalla email or username with the shared password to access the dashboard.
- main
- main
- main
         </p>
       </div>
       <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
@@ -85,7 +65,7 @@ export function LoginCard() {
             required
             value={identifier}
             onChange={(event) => setIdentifier(event.target.value)}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className={inputClasses}
           />
         </div>
         <div className="space-y-2">
@@ -100,7 +80,7 @@ export function LoginCard() {
             required
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className={inputClasses}
           />
         </div>
         {error ? (
@@ -116,27 +96,12 @@ export function LoginCard() {
           {isSubmitting ? "Signing in..." : "Sign in"}
         </Button>
       </form>
- codex/fix-deployment-issue-on-vercel-6wxxpp
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
- codex/fix-deployment-issue-on-vercel-rnbuxy
- main
- main
       <p className="mt-6 text-center text-sm text-muted-foreground">
         Need an account?{" "}
         <Link className="font-medium text-primary hover:underline" href="/register">
           Create one
         </Link>
       </p>
- codex/fix-deployment-issue-on-vercel-6wxxpp
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
-
- main
- main
- main
     </div>
   );
 }

--- a/apps/frontend/lib/auth-options.ts
+++ b/apps/frontend/lib/auth-options.ts
@@ -4,24 +4,18 @@ import type { NextAuthOptions } from "next-auth";
 import { apiBaseUrl } from "@/lib/utils";
 import { basicAuthLoginResponseSchema } from "@shared/api";
 
- codex/fix-deployment-issue-on-vercel-6wxxpp
 type Account = {
-
-type EnvironmentAccount = {
- main
   id: string;
   name: string;
   email: string;
 };
 
+type EnvironmentAccount = Account;
+
 const isMockMode =
   process.env.NEXT_PUBLIC_MOCK_MODE === "true" || process.env.MOCK_MODE === "true";
 
- codex/fix-deployment-issue-on-vercel-6wxxpp
-const fallbackAccount = {
-
 const fallbackUser = {
- main
   id: "demo-user",
   name: "Demo User",
   email: "demo@example.com",
@@ -30,50 +24,19 @@ const fallbackUser = {
 
 const envEmail = process.env.BASIC_AUTH_EMAIL;
 const envUsername = process.env.BASIC_AUTH_USERNAME;
- codex/fix-deployment-issue-on-vercel-6wxxpp
 const envPassword = process.env.BASIC_AUTH_PASSWORD ?? "password";
 const envDisplayName = process.env.BASIC_AUTH_NAME;
 
-function resolveEnvironmentAccount(
-  normalizedIdentifier: string,
-  password: string
-): Account | null {
-  const matchesEmail = envEmail ? normalizedIdentifier === envEmail.toLowerCase() : false;
-  const matchesUsername = envUsername ? normalizedIdentifier === envUsername.toLowerCase() : false;
-
-  if (!matchesEmail && !matchesUsername) {
-    return null;
-  }
-
-  if (password !== envPassword) {
-    return null;
-  }
-
-  const resolvedEmail = matchesEmail ? envEmail! : envEmail ?? fallbackAccount.email;
-  const resolvedName =
-    envDisplayName ?? (matchesUsername ? envUsername ?? fallbackAccount.name : fallbackAccount.name);
-  const resolvedId = matchesUsername
-    ? envUsername ?? fallbackAccount.id
-    : envEmail ?? fallbackAccount.id;
-
 const configuredEmail = envEmail?.toLowerCase();
 const configuredUsername = envUsername?.toLowerCase();
-const configuredPassword = process.env.BASIC_AUTH_PASSWORD ?? "password";
-const configuredDisplayName = process.env.BASIC_AUTH_NAME;
+const configuredPassword = envPassword;
+const configuredDisplayName = envDisplayName;
 
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
- codex/fix-deployment-issue-on-vercel-rnbuxy
- main
 function resolveEnvironmentAccount(
   normalizedIdentifier: string,
   password: string
 ): EnvironmentAccount | null {
- codex/fix-deployment-issue-on-vercel-k6bm9d
-  const configuredIdentifiers: Array<{
-    normalized: string;
-    source: "email" | "username";
-  }> = [];
+  const configuredIdentifiers: Array<{ normalized: string; source: "email" | "username" }> = [];
 
   if (configuredEmail) {
     configuredIdentifiers.push({ normalized: configuredEmail, source: "email" });
@@ -88,14 +51,6 @@ function resolveEnvironmentAccount(
   );
 
   if (!matchedIdentifier) {
-
-  const matchesEmail = configuredEmail ? normalizedIdentifier === configuredEmail : false;
-  const matchesUsername = configuredUsername
-    ? normalizedIdentifier === configuredUsername
-    : false;
-
-  if (!matchesEmail && !matchesUsername) {
- main
     return null;
   }
 
@@ -103,10 +58,10 @@ function resolveEnvironmentAccount(
     return null;
   }
 
- codex/fix-deployment-issue-on-vercel-k6bm9d
-  const email = matchedIdentifier.source === "email"
-    ? envEmail ?? configuredEmail ?? fallbackUser.email
-    : envEmail ?? fallbackUser.email;
+  const email =
+    matchedIdentifier.source === "email"
+      ? envEmail ?? configuredEmail ?? fallbackUser.email
+      : envEmail ?? fallbackUser.email;
 
   const name =
     configuredDisplayName ??
@@ -114,35 +69,16 @@ function resolveEnvironmentAccount(
       ? envUsername ?? configuredUsername ?? fallbackUser.name
       : fallbackUser.name);
 
-  const id = matchedIdentifier.source === "username"
-    ? envUsername ?? configuredUsername ?? fallbackUser.id
-    : envEmail ?? configuredEmail ?? fallbackUser.id;
+  const id =
+    matchedIdentifier.source === "username"
+      ? envUsername ?? configuredUsername ?? fallbackUser.id
+      : envEmail ?? configuredEmail ?? fallbackUser.id;
 
   return {
     id,
     name,
     email
-
-  const resolvedEmail = matchesEmail && envEmail ? envEmail : envEmail ?? fallbackUser.email;
-  const resolvedName =
-    configuredDisplayName || (matchesUsername && envUsername ? envUsername : fallbackUser.name);
-  const resolvedId = matchesUsername && envUsername
-    ? envUsername
-    : matchesEmail && envEmail
-      ? envEmail
-      : fallbackUser.id;
- main
-
-  return {
-    id: resolvedId,
-    name: resolvedName,
-    email: resolvedEmail
- codex/fix-deployment-issue-on-vercel-6wxxpp
-  } satisfies Account;
-
- main
   };
- main
 }
 
 async function attemptBackendLogin(identifier: string, password: string) {
@@ -163,32 +99,19 @@ async function attemptBackendLogin(identifier: string, password: string) {
 
     return {
       id: payload.id,
- codex/fix-deployment-issue-on-vercel-6wxxpp
-      name: payload.name ?? fallbackAccount.name,
-      email: payload.email
-    } satisfies Account;
-
       name: payload.name ?? fallbackUser.name,
-      email: payload.email
+      email: payload.email ?? fallbackUser.email
     } satisfies EnvironmentAccount;
- main
   } catch (error) {
     console.error("Failed to verify credentials with backend", error);
     return null;
   }
 }
 
- codex/fix-deployment-issue-on-vercel-6wxxpp
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
 const acceptedIdentifiers = [configuredEmail, configuredUsername].filter(
   (value): value is string => Boolean(value)
 );
- main
 
- main
- main
 export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
@@ -197,11 +120,7 @@ export const authOptions: NextAuthOptions = {
         identifier: {
           label: "Email or username",
           type: "text",
- codex/fix-deployment-issue-on-vercel-6wxxpp
-          placeholder: envEmail ?? envUsername ?? fallbackAccount.email
-
           placeholder: envEmail ?? envUsername ?? fallbackUser.email
- main
         },
         password: { label: "Password", type: "password" }
       },
@@ -215,27 +134,14 @@ export const authOptions: NextAuthOptions = {
 
         if (isMockMode) {
           return {
-            id: "mock-user",
- codex/fix-deployment-issue-on-vercel-6wxxpp
-            name: fallbackAccount.name,
-            email: identifier.includes("@") ? identifier : fallbackAccount.email
-          } satisfies Account;
-        }
-
-        const normalizedIdentifier = identifier.toLowerCase();
-
-
+            id: fallbackUser.id,
             name: fallbackUser.name,
             email: identifier.includes("@") ? identifier : fallbackUser.email
-          };
+          } satisfies EnvironmentAccount;
         }
 
         const normalizedIdentifier = identifier.toLowerCase();
- codex/fix-deployment-issue-on-vercel-k6bm9d
 
- codex/fix-deployment-issue-on-vercel-rnbuxy
- main
- main
         const environmentAccount = resolveEnvironmentAccount(normalizedIdentifier, password);
         if (environmentAccount) {
           return environmentAccount;
@@ -245,61 +151,6 @@ export const authOptions: NextAuthOptions = {
         if (backendAccount) {
           return backendAccount;
         }
-
- codex/fix-deployment-issue-on-vercel-6wxxpp
-        if (envEmail || envUsername) {
-          return null;
-        }
-
-        const fallbackIdentifiers = [
-          fallbackAccount.email.toLowerCase(),
-          fallbackAccount.username.toLowerCase()
-        ];
-
-        if (!fallbackIdentifiers.includes(normalizedIdentifier)) {
-          return null;
-        }
-
-        if (password !== envPassword) {
-          return null;
-        }
-
-        return {
-          id: fallbackAccount.id,
-          name: fallbackAccount.name,
-          email: fallbackAccount.email
-        } satisfies Account;
-
-        if (configuredEmail || configuredUsername) {
-          return null;
-        }
-
- codex/fix-deployment-issue-on-vercel-k6bm9d
-        const fallbackIdentifiers = [
-          fallbackUser.email.toLowerCase(),
-          fallbackUser.username.toLowerCase()
-        ];
-
-        if (!fallbackIdentifiers.includes(normalizedIdentifier)) {
-
-        const matchesFallbackEmail = normalizedIdentifier === fallbackUser.email.toLowerCase();
-        const matchesFallbackUsername = normalizedIdentifier === fallbackUser.username.toLowerCase();
-
-        if (!matchesFallbackEmail && !matchesFallbackUsername) {
- main
-          return null;
-        }
-
-        if (password !== configuredPassword) {
-          return null;
-        }
-
-        return {
-          id: fallbackUser.id,
-          name: fallbackUser.name,
-          email: fallbackUser.email
- codex/fix-deployment-issue-on-vercel-k6bm9d
-
 
         const identifiersToMatch =
           acceptedIdentifiers.length > 0
@@ -318,23 +169,25 @@ export const authOptions: NextAuthOptions = {
           ? normalizedIdentifier === configuredUsername
           : false;
 
-        const resolvedEmail = matchesEmail && envEmail ? envEmail : envEmail ?? fallbackUser.email;
-        const resolvedName =
-          configuredDisplayName || (matchesUsername && envUsername ? envUsername : fallbackUser.name);
-        const resolvedId = matchesUsername && envUsername
-          ? envUsername
-          : matchesEmail && envEmail
-            ? envEmail
+        const email = matchesEmail
+          ? envEmail ?? configuredEmail ?? fallbackUser.email
+          : fallbackUser.email;
+
+        const name =
+          configuredDisplayName ||
+          (matchesUsername ? envUsername ?? configuredUsername ?? fallbackUser.name : fallbackUser.name);
+
+        const id = matchesUsername
+          ? envUsername ?? configuredUsername ?? fallbackUser.id
+          : matchesEmail
+            ? envEmail ?? configuredEmail ?? fallbackUser.id
             : fallbackUser.id;
 
         return {
-          id: resolvedId,
-          name: resolvedName,
-          email: resolvedEmail
- main
- main
-        };
- main
+          id,
+          name,
+          email
+        } satisfies EnvironmentAccount;
       }
     })
   ],
@@ -342,13 +195,8 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async session({ session }) {
       if (session.user) {
- codex/fix-deployment-issue-on-vercel-6wxxpp
-        session.user.name = session.user.name ?? fallbackAccount.name;
-        session.user.email = session.user.email ?? fallbackAccount.email;
-
         session.user.name = session.user.name ?? fallbackUser.name;
         session.user.email = session.user.email ?? fallbackUser.email;
- main
       }
       return session;
     }


### PR DESCRIPTION
## Summary
- clean the login card component and reuse shared input styling
- rebuild the NextAuth credentials configuration without Codex artifacts and with consistent fallbacks
- refresh the README environment variables section to remove placeholder markers

## Testing
- `pnpm --filter apps-frontend lint`
- `pnpm --filter apps-frontend build` *(fails: Next.js could not download the Inter font because the sandbox blocks external network requests)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8c1a92508322b6eda0d03e2431d9