### PR TITLE
Require explicit API base URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ BASIC_AUTH_USERNAME=demo
 BASIC_AUTH_EMAIL=demo@example.com
 BASIC_AUTH_PASSWORD=password
 BASIC_AUTH_NAME=Demo User
+# Required in hosted environments so the frontend can reach the backend API.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 NEXT_PUBLIC_MOCK_MODE=true
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ packages/
 
 ## Environment variables
 
-Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. Ensure `NEXT_PUBLIC_API_BASE_URL` and `DATABASE_URL` are set so the frontend can reach the backend during account creation.
+Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. `NEXT_PUBLIC_API_BASE_URL` must point to the backend API for server-side flows (such as NextAuth) and should always be set in hosted environments. During local development, browser-only code falls back to `window.location.origin`, but the server process still requires an explicit value. Configure `DATABASE_URL` so the backend can persist accounts created through the UI.
 
 ## Local development
 
@@ -61,7 +61,7 @@ Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to acti
 
 1. Connect the repository to Vercel.
 2. Set the project root to `apps/frontend`.
-3. Configure environment variables (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `BASIC_AUTH_USERNAME`, `BASIC_AUTH_EMAIL`, `BASIC_AUTH_PASSWORD`, optional `BASIC_AUTH_NAME`, `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_MOCK_MODE`).
+3. Configure environment variables (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `BASIC_AUTH_USERNAME`, `BASIC_AUTH_EMAIL`, `BASIC_AUTH_PASSWORD`, optional `BASIC_AUTH_NAME`, **required** `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_MOCK_MODE`).
 4. Trigger a build—Vercel will install dependencies with pnpm automatically.
 
 ### Backend (Render)
@@ -71,7 +71,7 @@ Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to acti
 3. Set the start command to `pnpm --filter apps/backend start`.
 4. Provision a Postgres instance and Redis (or supply external connection strings) and expose them via `DATABASE_URL` and `REDIS_URL` env vars. Include `FRONTEND_ORIGIN` so CORS is configured correctly.
 
-> For preview environments, be sure to share the backend URL with the frontend via `NEXT_PUBLIC_API_BASE_URL` and `NEXTAUTH_URL`.
+> For preview environments, be sure to share the backend URL with the frontend via `NEXT_PUBLIC_API_BASE_URL` and `NEXTAUTH_URL`. Without `NEXT_PUBLIC_API_BASE_URL`, server-side code in the frontend cannot contact the API.
 
 ## CI
 

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -5,8 +5,21 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const apiBaseUrl =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001";
+export const apiBaseUrl = (() => {
+  const envValue = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (typeof window === "undefined") {
+    if (!envValue) {
+      throw new Error(
+        "NEXT_PUBLIC_API_BASE_URL must be set so the frontend can reach the backend."
+      );
+    }
+
+    return envValue;
+  }
+
+  return envValue ?? window.location.origin;
+})();
 
 export const isMockMode = () =>
   process.env.NEXT_PUBLIC_MOCK_MODE === "true" || process.env.MOCK_MODE === "true";


### PR DESCRIPTION
## Summary
- update the frontend API base URL helper to require NEXT_PUBLIC_API_BASE_URL on the server while falling back to window.location.origin in the browser
- document the requirement for configuring NEXT_PUBLIC_API_BASE_URL in hosted environments and update the example env file

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68dd35b378008322a06e97f139f64b46