### PR TITLE
Handle localhost API base URL on deployed clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ BASIC_AUTH_USERNAME=demo
 BASIC_AUTH_EMAIL=demo@example.com
 BASIC_AUTH_PASSWORD=password
 BASIC_AUTH_NAME=Demo User
+# Required in hosted environments so the frontend can reach the backend API.
+# Deployed builds ignore localhost values and fall back to the site's origin.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 NEXT_PUBLIC_MOCK_MODE=true
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ packages/
 
 ## Environment variables
 
-Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. Ensure `NEXT_PUBLIC_API_BASE_URL` and `DATABASE_URL` are set so the frontend can reach the backend during account creation.
+Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. `NEXT_PUBLIC_API_BASE_URL` must point to the backend API for server-side flows (such as NextAuth) and should always be set in hosted environments. During local development, browser-only code falls back to `window.location.origin`, but the server process still requires an explicit value. When a deployed build runs in the browser with a `NEXT_PUBLIC_API_BASE_URL` that targets `localhost`, the helper falls back to the deployed origin to avoid unreachable requests. Configure `DATABASE_URL` so the backend can persist accounts created through the UI.
 
 ## Local development
 
@@ -61,7 +61,7 @@ Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to acti
 
 1. Connect the repository to Vercel.
 2. Set the project root to `apps/frontend`.
-3. Configure environment variables (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `BASIC_AUTH_USERNAME`, `BASIC_AUTH_EMAIL`, `BASIC_AUTH_PASSWORD`, optional `BASIC_AUTH_NAME`, `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_MOCK_MODE`).
+3. Configure environment variables (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `BASIC_AUTH_USERNAME`, `BASIC_AUTH_EMAIL`, `BASIC_AUTH_PASSWORD`, optional `BASIC_AUTH_NAME`, **required** `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_MOCK_MODE`).
 4. Trigger a build—Vercel will install dependencies with pnpm automatically.
 
 ### Backend (Render)
@@ -71,7 +71,7 @@ Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to acti
 3. Set the start command to `pnpm --filter apps/backend start`.
 4. Provision a Postgres instance and Redis (or supply external connection strings) and expose them via `DATABASE_URL` and `REDIS_URL` env vars. Include `FRONTEND_ORIGIN` so CORS is configured correctly.
 
-> For preview environments, be sure to share the backend URL with the frontend via `NEXT_PUBLIC_API_BASE_URL` and `NEXTAUTH_URL`.
+> For preview environments, be sure to share the backend URL with the frontend via `NEXT_PUBLIC_API_BASE_URL` and `NEXTAUTH_URL`. Without `NEXT_PUBLIC_API_BASE_URL`, server-side code in the frontend cannot contact the API.
 
 ## CI
 

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -5,8 +5,49 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const apiBaseUrl =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001";
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
+
+export const apiBaseUrl = (() => {
+  const envValue = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (typeof window === "undefined") {
+    if (!envValue) {
+      throw new Error(
+        "NEXT_PUBLIC_API_BASE_URL must be set so the frontend can reach the backend."
+      );
+    }
+
+    return envValue;
+  }
+
+  if (!envValue) {
+    return window.location.origin;
+  }
+
+  try {
+    const { hostname } = new URL(envValue);
+
+    if (
+      LOCAL_HOSTNAMES.has(hostname) &&
+      !LOCAL_HOSTNAMES.has(window.location.hostname)
+    ) {
+      console.warn(
+        "NEXT_PUBLIC_API_BASE_URL points to a localhost address, but the app is running on a non-localhost origin. Falling back to window.location.origin so requests stay on the deployed domain."
+      );
+
+      return window.location.origin;
+    }
+  } catch (error) {
+    console.warn(
+      "NEXT_PUBLIC_API_BASE_URL is not a valid URL. Falling back to window.location.origin.",
+      error
+    );
+
+    return window.location.origin;
+  }
+
+  return envValue;
+})();
 
 export const isMockMode = () =>
   process.env.NEXT_PUBLIC_MOCK_MODE === "true" || process.env.MOCK_MODE === "true";


### PR DESCRIPTION
## Summary
- ensure the frontend falls back to the deployed origin when NEXT_PUBLIC_API_BASE_URL resolves to localhost in the browser
- warn when the configured API base URL is invalid and document the fallback behaviour for hosted environments
- update the example env file to clarify how localhost values are treated during deployment

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68dd35b378008322a06e97f139f64b46