### PR TITLE
Harden API base URL handling for hosted builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ BASIC_AUTH_USERNAME=demo
 BASIC_AUTH_EMAIL=demo@example.com
 BASIC_AUTH_PASSWORD=password
 BASIC_AUTH_NAME=Demo User
+# Required in hosted environments so the frontend can reach the backend API.
+# During local development, browser code only falls back to window.location.origin
+# when the app itself is served from a localhost hostname. Hosted deployments
+# fall back to NEXTAUTH_URL/VERCEL_URL if this value still points at localhost.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 NEXT_PUBLIC_MOCK_MODE=true
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ packages/
 
 ## Environment variables
 
-Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. Ensure `NEXT_PUBLIC_API_BASE_URL` and `DATABASE_URL` are set so the frontend can reach the backend during account creation.
+Copy `.env.example` to `.env` in the repo root and adjust the basic auth credentials as needed. The frontend's basic-auth flow accepts either the configured credentials or accounts created through the `/register` page backed by the Nest API. `NEXT_PUBLIC_API_BASE_URL` must point to the backend API for server-side flows (such as NextAuth) and must always be set in hosted environments. During local development the browser can fall back to `window.location.origin`, but only when the app is loaded from a localhost hostname; the Next.js server process still requires an explicit value. Hosted builds automatically refuse localhost targets and fall back to `NEXTAUTH_URL`/`VERCEL_URL` so requests remain reachable, but you should still configure a deployable backend URL. Configure `DATABASE_URL` so the backend can persist accounts created through the UI.
 
 ## Local development
 
@@ -61,7 +61,7 @@ Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to acti
 
 1. Connect the repository to Vercel.
 2. Set the project root to `apps/frontend`.
-3. Configure environment variables (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `BASIC_AUTH_USERNAME`, `BASIC_AUTH_EMAIL`, `BASIC_AUTH_PASSWORD`, optional `BASIC_AUTH_NAME`, `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_MOCK_MODE`).
+3. Configure environment variables (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `BASIC_AUTH_USERNAME`, `BASIC_AUTH_EMAIL`, `BASIC_AUTH_PASSWORD`, optional `BASIC_AUTH_NAME`, **required** `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_MOCK_MODE`).
 4. Trigger a build—Vercel will install dependencies with pnpm automatically.
 
 ### Backend (Render)
@@ -71,7 +71,7 @@ Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to acti
 3. Set the start command to `pnpm --filter apps/backend start`.
 4. Provision a Postgres instance and Redis (or supply external connection strings) and expose them via `DATABASE_URL` and `REDIS_URL` env vars. Include `FRONTEND_ORIGIN` so CORS is configured correctly.
 
-> For preview environments, be sure to share the backend URL with the frontend via `NEXT_PUBLIC_API_BASE_URL` and `NEXTAUTH_URL`.
+> For preview environments, be sure to share the backend URL with the frontend via `NEXT_PUBLIC_API_BASE_URL` and `NEXTAUTH_URL`. Without `NEXT_PUBLIC_API_BASE_URL`, server-side code in the frontend cannot contact the API.
 
 ## CI
 

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -5,8 +5,107 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const apiBaseUrl =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001";
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
+
+function parseUrl(value: string | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value);
+  } catch (error) {
+    return null;
+  }
+}
+
+const hostedServerFallbackOrigins = [
+  process.env.NEXTAUTH_URL,
+  process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined
+]
+  .filter((value): value is string => Boolean(value))
+  .map((value) => ({ value, parsed: parseUrl(value) }))
+  .filter((entry): entry is { value: string; parsed: URL } => {
+    if (!entry.parsed) {
+      return false;
+    }
+
+    return !LOCAL_HOSTNAMES.has(entry.parsed.hostname);
+  });
+
+const isHostedEnvironment = Boolean(
+  process.env.VERCEL || hostedServerFallbackOrigins.length > 0
+);
+
+export const apiBaseUrl = (() => {
+  const envValue = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const parsedEnv = parseUrl(envValue);
+  const isServer = typeof window === "undefined";
+
+  if (isServer) {
+    if (!envValue) {
+      throw new Error(
+        "NEXT_PUBLIC_API_BASE_URL must be set so the frontend can reach the backend."
+      );
+    }
+
+    if (!parsedEnv) {
+      throw new Error(
+        "NEXT_PUBLIC_API_BASE_URL must be a valid URL so the frontend can reach the backend."
+      );
+    }
+
+    if (LOCAL_HOSTNAMES.has(parsedEnv.hostname) && isHostedEnvironment) {
+      const fallbackOrigin = hostedServerFallbackOrigins[0];
+
+      if (fallbackOrigin) {
+        console.warn(
+          "NEXT_PUBLIC_API_BASE_URL points to a localhost address. Falling back to a hosted origin so server-side requests remain reachable.",
+          { fallbackOrigin: fallbackOrigin.value }
+        );
+
+        return fallbackOrigin.value;
+      }
+
+      throw new Error(
+        "NEXT_PUBLIC_API_BASE_URL points to a localhost address, but hosted environments require a reachable backend URL."
+      );
+    }
+
+    return envValue;
+  }
+
+  const isLocalClient = LOCAL_HOSTNAMES.has(window.location.hostname);
+
+  if (!envValue || !parsedEnv) {
+    if (isLocalClient) {
+      if (!envValue || !parsedEnv) {
+        console.warn(
+          "NEXT_PUBLIC_API_BASE_URL is missing or invalid. Falling back to window.location.origin for local development."
+        );
+      }
+
+      return window.location.origin;
+    }
+
+    throw new Error(
+      "NEXT_PUBLIC_API_BASE_URL must be configured in hosted environments so the frontend can reach the backend."
+    );
+  }
+
+  if (
+    LOCAL_HOSTNAMES.has(parsedEnv.hostname) &&
+    !LOCAL_HOSTNAMES.has(window.location.hostname)
+  ) {
+    console.warn(
+      "NEXT_PUBLIC_API_BASE_URL points to a localhost address, but the app is running on a non-localhost origin. Falling back to window.location.origin so requests stay on the deployed domain."
+    );
+
+    return window.location.origin;
+  }
+
+  return envValue;
+})();
 
 export const isMockMode = () =>
   process.env.NEXT_PUBLIC_MOCK_MODE === "true" || process.env.MOCK_MODE === "true";


### PR DESCRIPTION
## Summary
- harden the `apiBaseUrl` helper so hosted builds validate the configured URL, refuse localhost targets, and fall back to NEXTAUTH_URL/VERCEL_URL when available
- clarify the README and example env file to document the hosted fallback and emphasize configuring a reachable backend URL

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68dd35b378008322a06e97f139f64b46