### PR TITLE
UI polish + pro table (contrast, theming, DnD, editable cells)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ BASIC_AUTH_NAME=Demo User
  main
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 NEXT_PUBLIC_MOCK_MODE=true
+NEXT_PUBLIC_THEME_DEFAULT=system
+NEXT_PUBLIC_DATA_PERSISTENCE=true
 
 # Backend
 # Registration requires a reachable database so the Nest API can persist accounts.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Copy `.env.example` to `.env` in the repo root and adjust the basic auth credent
 
 Set `MOCK_MODE=true` (and `NEXT_PUBLIC_MOCK_MODE=true` for the frontend) to activate MSW-powered mocks in the UI and sample data providers in the API. This lets you explore the dashboard without configuring external integrations.
 
+## Theming & contrast
+
+The frontend now exposes design tokens backed by CSS variables and Tailwind theme entries to keep light and dark palettes in sync with Radix color scales. You can tune the appearance by editing `apps/frontend/app/globals.css`:
+
+- `--bg`, `--panel`, `--card`, and `--card-contrast` control surface layers.
+- `--border` and `--ring` set border and focus accents.
+- `--muted`/`--muted-foreground` target subtle backgrounds and text.
+- `--accent`/`--accent-contrast` define the primary action hue.
+
+Tailwind aliases (for example `bg-card`, `text-muted-foreground`, and `ring-ring`) resolve to these tokens, so updating the CSS variables automatically lifts every component. To change the default theme, override `NEXT_PUBLIC_THEME_DEFAULT` in `.env`; to disable persisted table layout, set `NEXT_PUBLIC_DATA_PERSISTENCE=false`.
+
 ## Deployment
 
 ### Frontend (Vercel)

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -3,52 +3,102 @@
 @tailwind utilities;
 
 :root {
-  --background: 30 48% 98%;
-  --foreground: 24 35% 16%;
-  --card: 0 0% 100%;
-  --card-foreground: 24 35% 16%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 24 35% 16%;
-  --primary: 25 94% 52%;
-  --primary-foreground: 33 100% 96%;
-  --secondary: 28 60% 94%;
-  --secondary-foreground: 24 35% 16%;
-  --muted: 27 52% 95%;
-  --muted-foreground: 24 22% 45%;
-  --accent: 27 52% 95%;
-  --accent-foreground: 24 35% 16%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 27 36% 90%;
-  --input: 27 36% 90%;
-  --ring: 25 94% 52%;
-  --radius: 0.75rem;
+  color-scheme: light;
+  --slate-1: 210 33% 99%;
+  --slate-2: 210 23% 97%;
+  --slate-3: 209 21% 94%;
+  --slate-4: 209 19% 92%;
+  --slate-5: 208 17% 89%;
+  --slate-6: 208 15% 86%;
+  --slate-7: 207 14% 82%;
+  --slate-8: 206 13% 75%;
+  --slate-9: 205 10% 56%;
+  --slate-10: 205 10% 52%;
+  --slate-11: 210 11% 43%;
+  --slate-12: 210 24% 14%;
+
+  --violet-6: 253 94% 82%;
+  --violet-7: 255 92% 78%;
+  --violet-8: 255 90% 74%;
+  --violet-9: 252 95% 68%;
+  --violet-11: 255 88% 62%;
+  --violet-12: 255 98% 95%;
+
+  --tomato-9: 358 75% 59%;
+  --tomato-12: 350 100% 95%;
+
+  --bg: var(--slate-1);
+  --panel: var(--slate-2);
+  --card: var(--slate-1);
+  --card-contrast: var(--slate-3);
+  --card-foreground: var(--foreground);
+  --border: var(--slate-6);
+  --muted: var(--slate-3);
+  --muted-foreground: var(--slate-11);
+  --foreground: var(--slate-12);
+  --accent: var(--violet-9);
+  --accent-contrast: var(--violet-12);
+  --ring: var(--violet-8);
+  --destructive: var(--tomato-9);
+  --destructive-foreground: var(--tomato-12);
+  --radius: 1.25rem;
+
+  /* Legacy tokens mapped to new system */
+  --background: var(--bg);
+  --card-foreground: var(--card-foreground);
+  --primary: var(--accent);
+  --primary-foreground: var(--accent-contrast);
+  --secondary: var(--panel);
+  --secondary-foreground: var(--foreground);
+  --accent-foreground: var(--accent-contrast);
+  --muted-foreground: var(--muted-foreground);
 }
 
 .dark {
-  --background: 222.2 84% 4.9%;
-  --foreground: 210 40% 98%;
-  --card: 222.2 84% 4.9%;
-  --card-foreground: 210 40% 98%;
-  --popover: 222.2 84% 4.9%;
-  --popover-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
-  --secondary: 217.2 32.6% 17.5%;
-  --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
-  --accent-foreground: 210 40% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --ring: 212.7 26.8% 83.9%;
+  color-scheme: dark;
+  --slate-1: 210 25% 10%;
+  --slate-2: 215 27% 12%;
+  --slate-3: 210 23% 16%;
+  --slate-4: 211 21% 19%;
+  --slate-5: 210 20% 22%;
+  --slate-6: 209 18% 25%;
+  --slate-7: 206 18% 30%;
+  --slate-8: 206 17% 36%;
+  --slate-9: 205 18% 44%;
+  --slate-10: 205 20% 48%;
+  --slate-11: 210 25% 70%;
+  --slate-12: 210 40% 96%;
+
+  --violet-6: 258 58% 52%;
+  --violet-7: 259 62% 59%;
+  --violet-8: 258 65% 66%;
+  --violet-9: 252 92% 76%;
+  --violet-11: 252 100% 87%;
+  --violet-12: 255 100% 96%;
+
+  --tomato-9: 5 78% 62%;
+  --tomato-12: 5 100% 95%;
+
+  --bg: var(--slate-1);
+  --panel: var(--slate-2);
+  --card: var(--slate-3);
+  --card-contrast: var(--slate-4);
+  --card-foreground: var(--foreground);
+  --border: var(--slate-6);
+  --muted: var(--slate-4);
+  --muted-foreground: var(--slate-11);
+  --foreground: var(--slate-12);
+  --accent: var(--violet-8);
+  --accent-contrast: var(--violet-12);
+  --ring: var(--violet-7);
+  --destructive: var(--tomato-9);
+  --destructive-foreground: var(--tomato-12);
 }
 
 body {
-  background-color: hsl(var(--background));
+  background: radial-gradient(120% 120% at 10% 0%, hsl(var(--accent) / 0.15) 0%, transparent 45%),
+    radial-gradient(100% 100% at 100% 0%, hsl(var(--muted) / 0.12) 0%, transparent 50%),
+    hsl(var(--bg));
   color: hsl(var(--foreground));
 }
 
@@ -56,7 +106,18 @@ body {
   * {
     @apply border-border;
   }
+
+  *:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+  }
+
+  ::selection {
+    background: hsl(var(--accent) / 0.2);
+    color: hsl(var(--foreground));
   }
 }

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   children: ReactNode;
 }) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
       <body className="min-h-screen bg-background font-sans antialiased">
         <AppProviders>{children}</AppProviders>
       </body>

--- a/apps/frontend/components/dashboard/dashboard-card.tsx
+++ b/apps/frontend/components/dashboard/dashboard-card.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+interface DashboardCardProps {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  dense?: boolean;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function DashboardCard({
+  title,
+  description,
+  action,
+  children,
+  dense,
+  className,
+  contentClassName
+}: DashboardCardProps) {
+  return (
+    <Card
+      className={cn(
+        "rounded-3xl border border-border/80 bg-card text-card-foreground shadow-sm transition-all",
+        "supports-[backdrop-filter]:bg-card/90 supports-[backdrop-filter]:backdrop-blur",
+        "hover:shadow-md focus-within:shadow-md",
+        className
+      )}
+    >
+      <div className={cn("flex flex-col", dense ? "p-5" : "p-6")}> 
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold tracking-tight text-foreground sm:text-base">{title}</h2>
+            {description ? (
+              <p className="text-sm text-muted-foreground/90">{description}</p>
+            ) : null}
+          </div>
+          {action ? <div className="shrink-0 space-y-2 text-sm text-muted-foreground">{action}</div> : null}
+        </div>
+        <Separator className="mt-4" />
+        <div className={cn("pt-4", dense ? "space-y-4" : "space-y-5", contentClassName)}>{children}</div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/components/dashboard/dashboard-shell.tsx
+++ b/apps/frontend/components/dashboard/dashboard-shell.tsx
@@ -7,6 +7,8 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { MeResponse } from "@shared/api";
 
+import { ThemeToggle } from "./theme-toggle";
+
 export default function DashboardShell({
   user,
   children
@@ -19,22 +21,23 @@ export default function DashboardShell({
   const initials = displayName.charAt(0).toUpperCase();
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-[#f8f7ff] via-[#fefefe] to-[#fff7f0]">
+    <div className="flex min-h-screen flex-col">
       <header className="px-6 pt-10">
         <div className="mx-auto w-full max-w-7xl">
-          <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-white/60 bg-white/70 px-6 py-4 shadow-sm backdrop-blur">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+          <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-border/70 bg-panel/90 px-6 py-5 shadow-sm supports-[backdrop-filter]:backdrop-blur">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/80">
                 {user.orgId ? user.orgId : "Astalla internal"}
               </p>
               <h1 className="text-2xl font-semibold text-foreground">Operations control center</h1>
             </div>
             <div className="flex flex-wrap items-center gap-3">
-              <div className="hidden items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-2 text-xs text-muted-foreground sm:flex">
-                <Search className="h-4 w-4" />
+              <ThemeToggle />
+              <div className="hidden items-center gap-2 rounded-full border border-border/60 bg-card px-4 py-2 text-xs text-muted-foreground sm:flex">
+                <Search className="h-4 w-4" aria-hidden="true" />
                 <span>Search workspaces</span>
               </div>
-              <div className="flex items-center gap-3 rounded-full border border-white/60 bg-white/80 px-3 py-2 shadow-sm">
+              <div className="flex items-center gap-3 rounded-full border border-border/70 bg-card px-3 py-2 shadow-sm">
                 <div className="text-right">
                   <p className="text-sm font-semibold text-foreground">{displayName}</p>
                   <p className="text-xs text-muted-foreground">{displayEmail}</p>

--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -4,31 +4,24 @@ import { type FormEvent, useEffect, useMemo, useState } from "react";
 import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { useDashboardState } from "@/lib/dashboard-state";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { useDashboardState } from "@/lib/dashboard-state";
 
 import DashboardShell from "./dashboard-shell";
+import { DashboardCard } from "./dashboard-card";
+import { OperationsTable } from "./operations-table";
 
-const fieldClassName =
-  "w-full rounded-xl border border-white/60 bg-white/80 px-3 py-2 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-200 focus:ring-offset-1 focus:ring-offset-white placeholder:text-muted-foreground/70";
+const inputClassName =
+  "w-full rounded-xl border border-border/70 bg-card px-4 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
-const fieldClassName =
-  "w-full rounded-xl border border-white/60 bg-white/80 px-3 py-2 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-200 focus:ring-offset-1 focus:ring-offset-white placeholder:text-muted-foreground/70";
+const textareaClassName = cn(inputClassName, "min-h-[120px] resize-none align-top");
+
+const dashedPlaceholderClass =
+  "rounded-2xl border border-dashed border-border/70 bg-card/60 p-6 text-sm text-muted-foreground";
 
 export function DashboardView() {
-  const {
-    state,
-    updateUser,
-    updateWelcome,
-    addQuickStat,
-    removeQuickStat,
-    createTable,
-    deleteTable,
-    addTableRow,
-    removeTableRow,
-    clearAll
-  } = useDashboardState();
+  const { state, updateUser, updateWelcome, addQuickStat, removeQuickStat, clearAll } = useDashboardState();
 
   const [isEditingWelcome, setIsEditingWelcome] = useState(false);
   const [welcomeDraft, setWelcomeDraft] = useState(state.welcome);
@@ -43,13 +36,6 @@ export function DashboardView() {
   const [quickStatDraft, setQuickStatDraft] = useState({ label: "", value: "", helper: "" });
   const [quickStatError, setQuickStatError] = useState<string | null>(null);
 
-  const [tableFormOpen, setTableFormOpen] = useState(false);
-  const [tableDraft, setTableDraft] = useState({ name: "", description: "", columns: "" });
-  const [tableError, setTableError] = useState<string | null>(null);
-
-  const [rowDrafts, setRowDrafts] = useState<Record<string, string[]>>({});
-  const [rowErrors, setRowErrors] = useState<Record<string, string | null>>({});
-
   useEffect(() => {
     setWelcomeDraft(state.welcome);
   }, [state.welcome]);
@@ -61,29 +47,6 @@ export function DashboardView() {
       orgId: state.user.orgId ?? ""
     });
   }, [state.user.email, state.user.name, state.user.orgId]);
-
-  useEffect(() => {
-    setRowDrafts((previous) => {
-      const next: Record<string, string[]> = {};
-      state.tables.forEach((table) => {
-        const existing = previous[table.id];
-        if (existing && existing.length === table.columns.length) {
-          next[table.id] = existing;
-        } else {
-          next[table.id] = table.columns.map(() => "");
-        }
-      });
-      return next;
-    });
-
-    setRowErrors((previous) => {
-      const next: Record<string, string | null> = {};
-      state.tables.forEach((table) => {
-        next[table.id] = previous[table.id] ?? null;
-      });
-      return next;
-    });
-  }, [state.tables]);
 
   const overviewIsEmpty = useMemo(
     () => !state.welcome.headline && !state.welcome.message && !state.welcome.note,
@@ -116,7 +79,7 @@ export function DashboardView() {
     const value = quickStatDraft.value.trim();
 
     if (!label || !value) {
-      setQuickStatError("Add both a label and value to save this metric.");
+      setQuickStatError("Provide both a label and a value to save this metric.");
       return;
     }
 
@@ -131,570 +94,242 @@ export function DashboardView() {
     setShowQuickStatForm(false);
   };
 
-  const handleCreateTable = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const name = tableDraft.name.trim();
-    const description = tableDraft.description.trim();
-    const columns = tableDraft.columns
-      .split(",")
-      .map((column) => column.trim())
-      .filter(Boolean);
-
-    if (!name) {
-      setTableError("Give the table a name before saving.");
-      return;
-    }
-
-    if (columns.length === 0) {
-      setTableError("Add at least one column, separated by commas.");
-      return;
-    }
-
-    createTable({
-      name,
-      description,
-      columns
-    });
-
-    setTableDraft({ name: "", description: "", columns: "" });
-    setTableError(null);
-    setTableFormOpen(false);
-  };
-
-  const handleRowDraftChange = (tableId: string, columnIndex: number, value: string) => {
-    setRowDrafts((previous) => {
-      const next = { ...previous };
-      const current = next[tableId] ? [...next[tableId]] : [];
-      current[columnIndex] = value;
-      next[tableId] = current;
-      return next;
-    });
-  };
-
-  const handleAddRow = (event: FormEvent<HTMLFormElement>, tableId: string) => {
-    event.preventDefault();
-    const table = state.tables.find((entry) => entry.id === tableId);
-
-    if (!table) {
-      return;
-    }
-
-    const draft = rowDrafts[tableId] ?? [];
-    const values = table.columns.map((_, index) => draft[index]?.trim() ?? "");
-
-    if (values.every((value) => value === "")) {
-      setRowErrors((previous) => ({ ...previous, [tableId]: "Fill in at least one cell to add a row." }));
-      return;
-    }
-
-    addTableRow(tableId, values);
-    setRowDrafts((previous) => ({ ...previous, [tableId]: table.columns.map(() => "") }));
-    setRowErrors((previous) => ({ ...previous, [tableId]: null }));
-  };
-
   const handleClearAll = () => {
     clearAll();
     setIsEditingWelcome(false);
     setQuickStatDraft({ label: "", value: "", helper: "" });
-    setTableDraft({ name: "", description: "", columns: "" });
-    setShowQuickStatForm(false);
-    setTableFormOpen(false);
-    setRowDrafts({});
-    setRowErrors({});
+    setWelcomeDraft({ headline: "", message: "", note: "" });
+    setQuickStatError(null);
   };
 
   return (
     <DashboardShell user={state.user}>
-      <section className="grid gap-6 xl:grid-cols-[2fr,1.2fr]">
-        <Card className="rounded-3xl border border-white/60 bg-gradient-to-br from-orange-50 via-white to-white shadow-sm">
-          <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <CardTitle className="text-base font-semibold text-foreground">Overview</CardTitle>
-              <p className="text-sm text-muted-foreground">Craft the copy that anchors your workspace.</p>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2 text-xs text-foreground"
-              onClick={() => setIsEditingWelcome((value) => !value)}
-            >
+      <section className="grid gap-6 xl:grid-cols-[2fr,1.1fr]">
+        <DashboardCard
+          title="Overview"
+          description="Craft the copy that anchors your workspace."
+          action={
+            <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={() => setIsEditingWelcome((value) => !value)}>
               <Pencil className="h-3.5 w-3.5" />
               {isEditingWelcome ? "Close editor" : "Edit overview"}
             </Button>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            {overviewIsEmpty ? (
-              <p className="text-sm text-muted-foreground">
-                Set a headline, supporting message and optional note to introduce teammates to this dashboard.
-              </p>
-            ) : (
-              <div className="space-y-3">
-                {state.welcome.headline ? (
-                  <h2 className="text-3xl font-semibold text-foreground lg:text-[2rem]">{state.welcome.headline}</h2>
-                ) : null}
-                {state.welcome.message ? (
-                  <p className="text-sm leading-6 text-muted-foreground">{state.welcome.message}</p>
-                ) : null}
-                {state.welcome.note ? (
-                  <div className="rounded-2xl border border-white/60 bg-white/80 px-4 py-3 text-xs text-muted-foreground">
-                    {state.welcome.note}
-                  </div>
-                ) : null}
-              </div>
-            )}
+          }
+        >
+          {overviewIsEmpty ? (
+            <div className={cn(dashedPlaceholderClass, "text-center")}>Use this space to greet collaborators and share context.</div>
+          ) : (
+            <div className="space-y-3">
+              {state.welcome.headline ? (
+                <h2 className="text-3xl font-semibold tracking-tight text-foreground lg:text-[2rem]">
+                  {state.welcome.headline}
+                </h2>
+              ) : null}
+              {state.welcome.message ? (
+                <p className="text-base leading-7 text-muted-foreground">{state.welcome.message}</p>
+              ) : null}
+              {state.welcome.note ? (
+                <div className="rounded-2xl border border-border/70 bg-card px-4 py-3 text-sm text-muted-foreground">
+                  {state.welcome.note}
+                </div>
+              ) : null}
+            </div>
+          )}
 
-            {isEditingWelcome ? (
-              <form className="space-y-4 rounded-2xl border border-dashed border-amber-200/80 bg-white/70 p-4" onSubmit={handleWelcomeSubmit}>
-                <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Headline</label>
-                  <input
-                    className={fieldClassName}
-                    value={welcomeDraft.headline}
-                    onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, headline: event.target.value }))}
-                    placeholder="Give your workspace a title"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Message</label>
-                  <textarea
-                    className={cn(fieldClassName, "min-h-[120px] resize-none")}
-                    value={welcomeDraft.message}
-                    onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, message: event.target.value }))}
-                    placeholder="Share the context for this dashboard"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Note</label>
-                  <textarea
-                    className={cn(fieldClassName, "min-h-[80px] resize-none text-xs")}
-                    value={welcomeDraft.note}
-                    onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, note: event.target.value }))}
-                    placeholder="Optional: add a callout or reminder"
-                  />
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="submit" size="sm" className="gap-2 text-xs text-foreground">
-                    Save overview
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="text-xs text-muted-foreground"
-                    onClick={() => {
-                      setIsEditingWelcome(false);
-                      setWelcomeDraft(state.welcome);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </form>
-            ) : null}
-          </CardContent>
-        </Card>
-
-        <Card className="rounded-3xl border border-white/60 bg-white/80 shadow-sm">
-          <CardHeader>
-            <CardTitle className="text-base font-semibold text-foreground">Workspace identity</CardTitle>
-            <p className="text-sm text-muted-foreground">This information powers the shell header for collaborators.</p>
-          </CardHeader>
-          <CardContent>
-            <form className="space-y-4" onSubmit={handleProfileSubmit}>
+          {isEditingWelcome ? (
+            <form className="space-y-4" onSubmit={handleWelcomeSubmit}>
               <div className="space-y-2">
-                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
-                <input
-                  className={fieldClassName}
-                  value={profileDraft.name}
-                  onChange={(event) => setProfileDraft((previous) => ({ ...previous, name: event.target.value }))}
-                  placeholder="Who is signed in?"
+                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Headline</label>
+                <Input
+                  value={welcomeDraft.headline}
+                  onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, headline: event.target.value }))}
+                  placeholder="Give your workspace a title"
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Email</label>
-                <input
-                  className={fieldClassName}
-                  value={profileDraft.email}
-                  onChange={(event) => setProfileDraft((previous) => ({ ...previous, email: event.target.value }))}
-                  placeholder="user@company.com"
-                  type="email"
+                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Message</label>
+                <textarea
+                  className={textareaClassName}
+                  value={welcomeDraft.message}
+                  onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, message: event.target.value }))}
+                  placeholder="Share the context for this dashboard"
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Org ID</label>
-                <input
-                  className={fieldClassName}
-                  value={profileDraft.orgId}
-                  onChange={(event) => setProfileDraft((previous) => ({ ...previous, orgId: event.target.value }))}
-                  placeholder="internal"
+                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Note</label>
+                <textarea
+                  className={cn(textareaClassName, "min-h-[80px] text-sm")}
+                  value={welcomeDraft.note}
+                  onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, note: event.target.value }))}
+                  placeholder="Optional: add a callout or reminder"
                 />
               </div>
-              <Button type="submit" size="sm" className="gap-2 text-xs text-foreground">
-                Update identity
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button type="submit" size="sm" className="gap-2">
+                  Save overview
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground"
+                  onClick={() => {
+                    setIsEditingWelcome(false);
+                    setWelcomeDraft(state.welcome);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
             </form>
-          </CardContent>
-        </Card>
+          ) : null}
+        </DashboardCard>
+
+        <DashboardCard
+          title="Workspace identity"
+          description="This information powers the shell header for collaborators."
+          dense
+        >
+          <form className="space-y-4" onSubmit={handleProfileSubmit}>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Name</label>
+              <Input
+                value={profileDraft.name}
+                onChange={(event) => setProfileDraft((previous) => ({ ...previous, name: event.target.value }))}
+                placeholder="Who is signed in?"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Email</label>
+              <Input
+                type="email"
+                value={profileDraft.email}
+                onChange={(event) => setProfileDraft((previous) => ({ ...previous, email: event.target.value }))}
+                placeholder="user@company.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Org ID</label>
+              <Input
+                value={profileDraft.orgId}
+                onChange={(event) => setProfileDraft((previous) => ({ ...previous, orgId: event.target.value }))}
+                placeholder="internal"
+              />
+            </div>
+            <Button type="submit" size="sm" className="gap-2">
+              Update identity
+            </Button>
+          </form>
+        </DashboardCard>
       </section>
 
       <section className="grid gap-6 xl:grid-cols-[1.8fr,1fr]">
-        <Card className="rounded-3xl border border-white/60 bg-white/90 shadow-sm">
-          <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <CardTitle className="text-base font-semibold text-foreground">Quick metrics</CardTitle>
-              <p className="text-sm text-muted-foreground">Create mini callouts for the numbers you reference often.</p>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2 text-xs text-foreground"
-              onClick={() => setShowQuickStatForm((value) => !value)}
-            >
+        <DashboardCard
+          title="Quick metrics"
+          description="Create callouts for the numbers you reference often."
+          action={
+            <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={() => setShowQuickStatForm((value) => !value)}>
               <Plus className="h-3.5 w-3.5" />
               {showQuickStatForm ? "Close" : "Add metric"}
             </Button>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            {state.quickStats.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No quick metrics yet. Add your first one to see it here.</p>
-            ) : (
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                {state.quickStats.map((stat) => (
-                  <div
-                    key={stat.id}
-                    className="rounded-2xl border border-white/60 bg-white/80 p-4 shadow-sm backdrop-blur"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="space-y-1">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{stat.label}</p>
-                        <p className="text-2xl font-semibold text-foreground">{stat.value}</p>
-                        {stat.helper ? (
-                          <p className="text-xs text-muted-foreground">{stat.helper}</p>
-                        ) : null}
-                      </div>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground"
-                        onClick={() => removeQuickStat(stat.id)}
-                        aria-label={`Remove ${stat.label}`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+          }
+        >
+          {state.quickStats.length === 0 ? (
+            <div className={dashedPlaceholderClass}>No quick metrics yet. Add your first one to see it here.</div>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {state.quickStats.map((stat) => (
+                <div
+                  key={stat.id}
+                  className="rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm transition hover:border-border"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{stat.label}</p>
+                      <p className="text-2xl font-semibold text-foreground">{stat.value}</p>
+                      {stat.helper ? (
+                        <p className="text-xs text-muted-foreground">{stat.helper}</p>
+                      ) : null}
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {showQuickStatForm ? (
-              <form
-                className="space-y-4 rounded-2xl border border-dashed border-amber-200/80 bg-white/70 p-4"
-                onSubmit={handleAddQuickStat}
-              >
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Label</label>
-                    <input
-                      className={fieldClassName}
-                      value={quickStatDraft.label}
-                      onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, label: event.target.value }))}
-                      placeholder="Metric label"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Value</label>
-                    <input
-                      className={fieldClassName}
-                      value={quickStatDraft.value}
-                      onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, value: event.target.value }))}
-                      placeholder="42, 93%, etc."
-                    />
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Helper text</label>
-                  <input
-                    className={fieldClassName}
-                    value={quickStatDraft.helper}
-                    onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, helper: event.target.value }))}
-                    placeholder="Optional context"
-                  />
-                </div>
-                {quickStatError ? <p className="text-xs text-rose-500">{quickStatError}</p> : null}
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="submit" size="sm" className="gap-2 text-xs text-foreground">
-                    Save metric
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="text-xs text-muted-foreground"
-                    onClick={() => {
-                      setShowQuickStatForm(false);
-                      setQuickStatDraft({ label: "", value: "", helper: "" });
-                      setQuickStatError(null);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </form>
-            ) : null}
-          </CardContent>
-        </Card>
-      </section>
-
-        <Card className="rounded-3xl border border-white/60 bg-white/80 shadow-sm">
-          <CardHeader>
-            <CardTitle className="text-base font-semibold text-foreground">Reset dashboard</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Clear all saved content and start from a blank canvas. This removes locally stored data only.
-            </p>
-          </CardHeader>
-          <CardContent>
-            <Button
-              type="button"
-              variant="ghost"
-              className="gap-2 text-xs text-foreground"
-              onClick={handleClearAll}
-            >
-              <RefreshCw className="h-3.5 w-3.5" />
-              Clear saved data
-            </Button>
-          </CardContent>
-        </Card>
-      </section>
-
-      <section>
-        <Card className="rounded-3xl border border-white/60 bg-white/90 shadow-sm">
-          <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <CardTitle className="text-base font-semibold text-foreground">Data tables</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Structure the datasets you want to connect. Use them as the foundation for future integrations.
-              </p>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2 text-xs text-foreground"
-              onClick={() => setTableFormOpen((value) => !value)}
-            >
-              <Plus className="h-3.5 w-3.5" />
-              {tableFormOpen ? "Close" : "Add table"}
-            </Button>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {tableFormOpen ? (
-              <form
-                className="space-y-4 rounded-2xl border border-dashed border-amber-200/80 bg-white/70 p-4"
-                onSubmit={handleCreateTable}
-              >
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Table name</label>
-                    <input
-                      className={fieldClassName}
-                      value={tableDraft.name}
-                      onChange={(event) => setTableDraft((previous) => ({ ...previous, name: event.target.value }))}
-                      placeholder="Performance summary"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Columns</label>
-                    <input
-                      className={fieldClassName}
-                      value={tableDraft.columns}
-                      onChange={(event) => setTableDraft((previous) => ({ ...previous, columns: event.target.value }))}
-                      placeholder="Name, Status, Owner"
-                    />
-                    <p className="text-[11px] text-muted-foreground">Separate each column with a comma.</p>
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Description</label>
-                  <textarea
-                    className={cn(fieldClassName, "min-h-[80px] resize-none text-sm")}
-                    value={tableDraft.description}
-                    onChange={(event) => setTableDraft((previous) => ({ ...previous, description: event.target.value }))}
-                    placeholder="Optional: explain what this table tracks"
-                  />
-                </div>
-                {tableError ? <p className="text-xs text-rose-500">{tableError}</p> : null}
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="submit" size="sm" className="gap-2 text-xs text-foreground">
-                    Create table
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="text-xs text-muted-foreground"
-                    onClick={() => {
-                      setTableFormOpen(false);
-                      setTableDraft({ name: "", description: "", columns: "" });
-                      setTableError(null);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </form>
-            ) : null}
-
-            {state.tables.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-white/60 bg-white/60 p-6 text-sm text-muted-foreground">
-                No tables yet. Add one to start outlining the data you want to sync with the dashboard.
-              </div>
-            ) : (
-              <div className="space-y-5">
-                {state.tables.map((table) => {
-                  const draft = rowDrafts[table.id] ?? table.columns.map(() => "");
-                  const error = rowErrors[table.id];
-                  const updatedAt = new Date(table.updatedAt || table.createdAt);
-                  const updatedLabel = Number.isNaN(updatedAt.getTime())
-                    ? null
-                    : updatedAt.toLocaleString();
-
-                  return (
-                    <div
-                      key={table.id}
-                      className="space-y-4 rounded-2xl border border-white/60 bg-white/80 p-4 shadow-sm"
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground"
+                      onClick={() => removeQuickStat(stat.id)}
+                      aria-label={`Remove ${stat.label}`}
                     >
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div className="space-y-1">
-                          <p className="text-sm font-semibold text-foreground">{table.name}</p>
-                          {table.description ? (
-                            <p className="text-xs text-muted-foreground">{table.description}</p>
-                          ) : null}
-                          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                            {table.columns.length} columns • {table.rows.length} rows
-                            {updatedLabel ? ` • Updated ${updatedLabel}` : null}
-                          </p>
-                        </div>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="gap-2 text-xs text-muted-foreground"
-                          onClick={() => deleteTable(table.id)}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                          Remove table
-                        </Button>
-                      </div>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
 
-                      <div className="overflow-x-auto">
-                        <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
-                          <thead>
-                            <tr>
-                              {table.columns.map((column) => (
-                                <th
-                                  key={column}
-                                  className="border-b border-white/60 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                                >
-                                  {column}
-                                </th>
-                              ))}
-                              <th className="border-b border-white/60 px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                Actions
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {table.rows.length === 0 ? (
-                              <tr>
-                                <td
-                                  className="px-3 py-6 text-center text-sm text-muted-foreground"
-                                  colSpan={table.columns.length + 1}
-                                >
-                                  No rows yet. Use the form below to add one.
-                                </td>
-                              </tr>
-                            ) : (
-                              table.rows.map((row, rowIndex) => (
-                                <tr key={`${table.id}-${rowIndex}`} className={rowIndex % 2 === 0 ? "bg-white" : "bg-white/70"}>
-                                  {table.columns.map((_, columnIndex) => (
-                                    <td key={`${table.id}-${rowIndex}-${columnIndex}`} className="px-3 py-2 text-sm text-foreground">
-                                      {row[columnIndex] ?? ""}
-                                    </td>
-                                  ))}
-                                  <td className="px-3 py-2 text-right">
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      className="gap-2 text-xs text-muted-foreground"
-                                      onClick={() => removeTableRow(table.id, rowIndex)}
-                                    >
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                      Remove
-                                    </Button>
-                                  </td>
-                                </tr>
-                              ))
-                            )}
-                          </tbody>
-                        </table>
-                      </div>
-
-                      <form
-                        className="space-y-3 rounded-2xl border border-dashed border-amber-200/80 bg-white/70 p-4"
-                        onSubmit={(event) => handleAddRow(event, table.id)}
-                      >
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          Add row
-                        </p>
-                        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-                          {table.columns.map((column, columnIndex) => (
-                            <div key={`${table.id}-draft-${column}`} className="space-y-2">
-                              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                                {column}
-                              </label>
-                              <input
-                                className={fieldClassName}
-                                value={draft[columnIndex] ?? ""}
-                                onChange={(event) => handleRowDraftChange(table.id, columnIndex, event.target.value)}
-                                placeholder={`Enter ${column}`}
-                              />
-                            </div>
-                          ))}
-                        </div>
-                        {error ? <p className="text-xs text-rose-500">{error}</p> : null}
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Button type="submit" size="sm" className="gap-2 text-xs text-foreground">
-                            <Plus className="h-3.5 w-3.5" />
-                            Add row
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="text-xs text-muted-foreground"
-                            onClick={() => {
-                              setRowDrafts((previous) => ({
-                                ...previous,
-                                [table.id]: table.columns.map(() => "")
-                              }));
-                              setRowErrors((previous) => ({ ...previous, [table.id]: null }));
-                            }}
-                          >
-                            Clear values
-                          </Button>
-                        </div>
-                      </form>
-                    </div>
-                  );
-                })}
+          {showQuickStatForm ? (
+            <form className="space-y-4" onSubmit={handleAddQuickStat}>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Label</label>
+                  <Input
+                    value={quickStatDraft.label}
+                    onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, label: event.target.value }))}
+                    placeholder="Metric label"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Value</label>
+                  <Input
+                    value={quickStatDraft.value}
+                    onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, value: event.target.value }))}
+                    placeholder="42, 93%, etc."
+                  />
+                </div>
               </div>
-            )}
-          </CardContent>
-        </Card>
+              <div className="space-y-2">
+                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Helper text</label>
+                <Input
+                  value={quickStatDraft.helper}
+                  onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, helper: event.target.value }))}
+                  placeholder="Optional context"
+                />
+              </div>
+              {quickStatError ? <p className="text-xs text-destructive">{quickStatError}</p> : null}
+              <div className="flex flex-wrap items-center gap-2">
+                <Button type="submit" size="sm" className="gap-2">
+                  Save metric
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground"
+                  onClick={() => {
+                    setShowQuickStatForm(false);
+                    setQuickStatDraft({ label: "", value: "", helper: "" });
+                    setQuickStatError(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          ) : null}
+        </DashboardCard>
+
+        <DashboardCard
+          title="Reset dashboard"
+          description="Clear all saved content and start from a blank canvas. This removes locally stored data only."
+          dense
+        >
+          <Button type="button" variant="ghost" className="gap-2" onClick={handleClearAll}>
+            <RefreshCw className="h-3.5 w-3.5" />
+            Clear saved data
+          </Button>
+        </DashboardCard>
       </section>
+
+      <OperationsTable />
     </DashboardShell>
   );
 }

--- a/apps/frontend/components/dashboard/operations-table.tsx
+++ b/apps/frontend/components/dashboard/operations-table.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+
+import { DataTable } from "@/components/data-table/data-table";
+import type { EditableCellMeta } from "@/components/data-table/editable-cell";
+import { DashboardCard } from "@/components/dashboard/dashboard-card";
+import { isPersistenceEnabled } from "@/lib/utils";
+
+export type PortfolioRow = {
+  id: string;
+  name: string;
+  status: "Green" | "At risk" | "Delayed" | "Planning";
+  owner: string;
+  updatedAt: string;
+  slaHours: number;
+  monthlyCost: number;
+  occupancy: number;
+  incidents: number;
+};
+
+const initialRows: PortfolioRow[] = [
+  {
+    id: "prop-1",
+    name: "Atrium Center",
+    status: "Green",
+    owner: "Casey Wynn",
+    updatedAt: "2024-11-04T15:05:00.000Z",
+    slaHours: 12,
+    monthlyCost: 48000,
+    occupancy: 92,
+    incidents: 1
+  },
+  {
+    id: "prop-2",
+    name: "Harbor Tower",
+    status: "At risk",
+    owner: "Jules Moreno",
+    updatedAt: "2024-11-03T09:20:00.000Z",
+    slaHours: 4,
+    monthlyCost: 72000,
+    occupancy: 87,
+    incidents: 4
+  },
+  {
+    id: "prop-3",
+    name: "North Loop Campus",
+    status: "Delayed",
+    owner: "Sydney Patel",
+    updatedAt: "2024-11-01T12:10:00.000Z",
+    slaHours: 30,
+    monthlyCost: 56000,
+    occupancy: 81,
+    incidents: 3
+  },
+  {
+    id: "prop-4",
+    name: "Quartz Labs",
+    status: "Planning",
+    owner: "Amelia Chen",
+    updatedAt: "2024-10-28T08:12:00.000Z",
+    slaHours: 48,
+    monthlyCost: 39500,
+    occupancy: 68,
+    incidents: 6
+  },
+  {
+    id: "prop-5",
+    name: "Riverside Commons",
+    status: "Green",
+    owner: "Jonah Walker",
+    updatedAt: "2024-11-05T18:30:00.000Z",
+    slaHours: 16,
+    monthlyCost: 61000,
+    occupancy: 95,
+    incidents: 0
+  },
+  {
+    id: "prop-6",
+    name: "Summit Hub",
+    status: "At risk",
+    owner: "Bryn Lee",
+    updatedAt: "2024-11-02T16:02:00.000Z",
+    slaHours: 10,
+    monthlyCost: 45200,
+    occupancy: 78,
+    incidents: 5
+  }
+];
+
+const statusOptions: PortfolioRow["status"][] = ["Green", "At risk", "Delayed", "Planning"];
+
+function validateNonEmpty(value: string) {
+  return value.trim() ? null : "Required";
+}
+
+function validatePositiveNumber(value: string) {
+  return Number(value) >= 0 ? null : "Must be positive";
+}
+
+function validateDate(value: string) {
+  return Number.isNaN(Date.parse(value)) ? "Invalid date" : null;
+}
+
+export function OperationsTable() {
+  const [rows, setRows] = useState(initialRows);
+
+  const columns = useMemo<ColumnDef<PortfolioRow, unknown>[]>(() => {
+    return [
+      {
+        accessorKey: "name",
+        id: "name",
+        header: "Property",
+        meta: {
+          editable: true,
+          validate: validateNonEmpty,
+          placeholder: "Property name"
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "status",
+        id: "status",
+        header: "Status",
+        meta: {
+          editable: true,
+          validate: (value: string) =>
+            statusOptions.includes(value as PortfolioRow["status"]) ? null : "Use a listed status",
+          placeholder: "Green"
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "owner",
+        id: "owner",
+        header: "Owner",
+        meta: {
+          editable: true,
+          validate: validateNonEmpty,
+          placeholder: "Owner"
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "updatedAt",
+        id: "updatedAt",
+        header: "Last updated",
+        meta: {
+          editable: true,
+          formatValue: (value: unknown) => {
+            const parsed = value ? new Date(value as string) : null;
+            return parsed ? format(parsed, "MMM d, yyyy HH:mm") : "";
+          },
+          parseValue: (value: string) => new Date(value).toISOString(),
+          validate: (value: string) => validateDate(value) ?? validateNonEmpty(value),
+          placeholder: "2024-11-05 18:30"
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "slaHours",
+        id: "slaHours",
+        header: "SLA (hrs)",
+        meta: {
+          editable: true,
+          inputType: "number",
+          formatValue: (value) => String(value ?? ""),
+          parseValue: (value: string) => Number(value),
+          validate: validatePositiveNumber
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "monthlyCost",
+        id: "monthlyCost",
+        header: "Monthly cost",
+        meta: {
+          editable: true,
+          inputType: "number",
+          formatValue: (value) =>
+            typeof value === "number" ? `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}` : "",
+          parseValue: (value: string) => Number(value.replace(/[$,\s]/g, "")),
+          validate: validatePositiveNumber
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "occupancy",
+        id: "occupancy",
+        header: "Occupancy %",
+        meta: {
+          editable: true,
+          inputType: "number",
+          formatValue: (value) =>
+            typeof value === "number" ? `${value.toFixed(0)}%` : "",
+          parseValue: (value: string) => Number(value.replace(/%/g, "")),
+          validate: (value: string) => {
+            const numeric = Number(value.replace(/%/g, ""));
+            if (Number.isNaN(numeric)) {
+              return "Enter a number";
+            }
+            if (numeric < 0 || numeric > 100) {
+              return "0 – 100 only";
+            }
+            return null;
+          }
+        } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        accessorKey: "incidents",
+        id: "incidents",
+        header: "Open incidents",
+        meta: {
+          editable: true,
+          inputType: "number",
+          parseValue: (value: string) => Number(value),
+          validate: validatePositiveNumber,
+          formatValue: (value) => String(value ?? "")
+        } satisfies EditableCellMeta<PortfolioRow>
+      }
+    ];
+  }, []);
+
+  return (
+    <DashboardCard
+      title="Portfolio performance"
+      description="Track contracts, SLAs and incident load for high-value properties."
+      action={<p className="text-xs text-muted-foreground">Drag columns or rows to personalize the view.</p>}
+    >
+      <DataTable
+        columns={columns}
+        data={rows}
+        storageKey="astalla:portfolio-table:v2"
+        persistenceEnabled={isPersistenceEnabled()}
+        onDataChange={setRows}
+      />
+    </DashboardCard>
+  );
+}

--- a/apps/frontend/components/dashboard/theme-toggle.tsx
+++ b/apps/frontend/components/dashboard/theme-toggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MoonStar, SunMedium } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="h-10 w-10 rounded-full border border-border/60 bg-panel shadow-sm"
+      aria-label={`Activate ${isDark ? "light" : "dark"} mode`}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      disabled={!mounted}
+    >
+      <span className="sr-only">Toggle theme</span>
+      {mounted ? (
+        isDark ? (
+          <SunMedium className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <MoonStar className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        )
+      ) : null}
+    </Button>
+  );
+}

--- a/apps/frontend/components/data-table/__tests__/data-table.test.tsx
+++ b/apps/frontend/components/data-table/__tests__/data-table.test.tsx
@@ -1,0 +1,109 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ColumnDef } from "@tanstack/react-table";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DataTable } from "../data-table";
+
+interface SampleRow {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const columns: ColumnDef<SampleRow>[] = [
+  {
+    accessorKey: "name",
+    id: "name",
+    header: "Name",
+    meta: {
+      editable: true,
+      placeholder: "Name"
+    }
+  },
+  {
+    accessorKey: "status",
+    id: "status",
+    header: "Status",
+    meta: {
+      editable: true,
+      placeholder: "Status"
+    }
+  }
+];
+
+const rows: SampleRow[] = [
+  { id: "row-1", name: "Alpha", status: "Green" },
+  { id: "row-2", name: "Beta", status: "Delayed" }
+];
+
+describe("DataTable", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("restores column order from persistence", async () => {
+    const key = "astalla:test-table";
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        columnOrder: ["__select", "status", "name"],
+        columnVisibility: {},
+        columnSizing: {},
+        density: "comfortable"
+      })
+    );
+
+    render(<DataTable columns={columns} data={rows} storageKey={key} />);
+
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers.map((header) => header.textContent?.trim())).toEqual([
+      "",
+      "Status",
+      "Name"
+    ]);
+  });
+
+  it("commits and cancels editable cell changes", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<DataTable columns={columns} data={rows} storageKey="astalla:edit" onDataChange={handleChange} />);
+
+    const nameCell = screen.getByRole("textbox", { name: "Name" });
+    await user.dblClick(nameCell);
+    const input = within(nameCell).getByRole("textbox");
+
+    await user.clear(input);
+    await user.type(input, "Gamma");
+    input.blur();
+
+    expect(handleChange).toHaveBeenCalledWith([
+      { id: "row-1", name: "Gamma", status: "Green" },
+      { id: "row-2", name: "Beta", status: "Delayed" }
+    ]);
+
+    await act(async () => {
+      await user.dblClick(nameCell);
+    });
+
+    const secondInput = within(nameCell).getByRole("textbox");
+    await user.clear(secondInput);
+    await user.type(secondInput, "Delta");
+    await user.keyboard("{Escape}");
+
+    expect(nameCell).toHaveTextContent("Gamma");
+  });
+
+  it("toggles density", async () => {
+    const user = userEvent.setup();
+    render(<DataTable columns={columns} data={rows} storageKey="astalla:density" />);
+
+    const compactButton = screen.getByRole("button", { name: /compact/i });
+    await user.click(compactButton);
+
+    const table = screen.getByRole("table");
+    expect(table.className).toContain("[&_td]:py-2");
+  });
+});

--- a/apps/frontend/components/data-table/column-visibility-menu.tsx
+++ b/apps/frontend/components/data-table/column-visibility-menu.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Settings2 } from "lucide-react";
+import type { Table } from "@tanstack/react-table";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+
+interface ColumnVisibilityMenuProps<TData> {
+  table: Table<TData>;
+}
+
+export function ColumnVisibilityMenu<TData>({ table }: ColumnVisibilityMenuProps<TData>) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-2 rounded-full border-border/70 bg-card px-3 text-xs font-medium"
+        >
+          <Settings2 className="h-4 w-4" aria-hidden="true" />
+          Columns
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {table
+          .getAllLeafColumns()
+          .filter((column) => column.getCanHide())
+          .map((column) => {
+            const isPinned = column.getIsPinned();
+            return (
+              <div key={column.id} className="flex items-center gap-2 px-1">
+                <DropdownMenuCheckboxItem
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) => column.toggleVisibility(Boolean(value))}
+                  className="flex-1"
+                >
+                  {column.columnDef.header as string}
+                </DropdownMenuCheckboxItem>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground">
+                      ···
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-40">
+                    <DropdownMenuLabel>Column options</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onSelect={() => column.pin("left")}>Pin left</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => column.pin("right")}>Pin right</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => column.pin(false)} disabled={!isPinned}>
+                      Unpin
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/frontend/components/data-table/data-table.tsx
+++ b/apps/frontend/components/data-table/data-table.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  SortableContext,
+  arrayMove,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy
+} from "@dnd-kit/sortable";
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type ColumnDef,
+  type ColumnOrderState,
+  type ColumnPinningState,
+  type ColumnSizingState,
+  type SortingState,
+  type Table
+} from "@tanstack/react-table";
+import {
+  type RowSelectionState,
+  type VisibilityState,
+  useReactTable
+} from "@tanstack/react-table";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import { ColumnVisibilityMenu } from "./column-visibility-menu";
+import { DragHandle } from "./drag-handle";
+import { EditableCell } from "./editable-cell";
+import {
+  type TableDensity,
+  type TableLayoutState,
+  useTablePersistence
+} from "./use-table-persistence";
+
+interface DataTableProps<TData extends { id: string }> {
+  columns: ColumnDef<TData, unknown>[];
+  data: TData[];
+  storageKey: string;
+  className?: string;
+  persistenceEnabled?: boolean;
+  onDataChange?: (rows: TData[]) => void;
+}
+
+function defaultColumnId<TData>(column: ColumnDef<TData, unknown>, index: number) {
+  if (column.id) {
+    return column.id.toString();
+  }
+  if (column.accessorKey) {
+    return column.accessorKey.toString();
+  }
+  return `col_${index}`;
+}
+
+const densityToRowClass: Record<TableDensity, string> = {
+  comfortable: "text-sm",
+  compact: "text-sm [&_td]:py-2 [&_th]:py-2"
+};
+
+export function DataTable<TData extends { id: string }>({
+  columns,
+  data,
+  storageKey,
+  className,
+  persistenceEnabled = true,
+  onDataChange
+}: DataTableProps<TData>) {
+  const selectionColumn = useMemo<ColumnDef<TData, unknown>>(
+    () => ({
+      id: "__select",
+      header: ({ table }) => (
+        <Checkbox
+          aria-label="Select all rows"
+          checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(Boolean(value))}
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          aria-label={`Select row ${row.index + 1}`}
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
+      size: 48,
+      meta: { disableDrag: true }
+    }),
+    []
+  );
+
+  const tableColumns = useMemo<ColumnDef<TData, unknown>[]>(() => {
+    return [selectionColumn, ...columns.map((column) => ({ ...column, cell: column.cell ?? EditableCell }))];
+  }, [columns, selectionColumn]);
+
+  const columnIds = useMemo(
+    () => tableColumns.map((column, index) => defaultColumnId(column, index)),
+    [tableColumns]
+  );
+
+  const defaultLayout = useMemo<TableLayoutState>(() => ({
+    columnOrder: columnIds,
+    columnVisibility: {},
+    columnSizing: {},
+    density: "comfortable"
+  }), [columnIds]);
+
+  const { layout, updateLayout, reset } = useTablePersistence(storageKey, defaultLayout, persistenceEnabled);
+
+  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(layout.columnOrder);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(layout.columnVisibility);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(layout.columnSizing);
+  const [density, setDensity] = useState<TableDensity>(layout.density);
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [columnPinning, setColumnPinning] = useState<ColumnPinningState>({});
+  const [tableData, setTableData] = useState<TData[]>(data);
+
+  useEffect(() => {
+    setColumnOrder(layout.columnOrder);
+    setColumnVisibility(layout.columnVisibility);
+    setColumnSizing(layout.columnSizing);
+    setDensity(layout.density);
+  }, [layout.columnOrder, layout.columnSizing, layout.columnVisibility, layout.density]);
+
+  useEffect(() => {
+    setColumnOrder((previous) => {
+      const existing = new Set(previous);
+      const cleaned = previous.filter((id) => columnIds.includes(id));
+      const merged = [...cleaned, ...columnIds.filter((id) => !existing.has(id))];
+      return merged;
+    });
+  }, [columnIds]);
+
+  useEffect(() => {
+    setTableData(data);
+  }, [data]);
+
+  useEffect(() => {
+    updateLayout({ columnOrder, columnVisibility, columnSizing, density });
+  }, [columnOrder, columnVisibility, columnSizing, density, updateLayout]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const rowSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleRowDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = tableData.findIndex((row) => row.id === active.id);
+    const newIndex = tableData.findIndex((row) => row.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) {
+      return;
+    }
+
+    const nextData = arrayMove(tableData, oldIndex, newIndex);
+    setTableData(nextData);
+    onDataChange?.(nextData);
+  };
+
+  const handleColumnDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) {
+      return;
+    }
+
+    const activeId = active.id as string;
+    const overId = over.id as string;
+
+    if (activeId === overId) {
+      return;
+    }
+
+    setColumnOrder((previous) => arrayMove(previous, previous.indexOf(activeId), previous.indexOf(overId)));
+  };
+
+  const table = useReactTable({
+    data: tableData,
+    columns: tableColumns,
+    state: {
+      sorting,
+      globalFilter,
+      columnVisibility,
+      columnOrder,
+      columnSizing,
+      rowSelection,
+      columnPinning
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    onColumnOrderChange: setColumnOrder,
+    onColumnSizingChange: setColumnSizing,
+    onRowSelectionChange: setRowSelection,
+    onColumnPinningChange: setColumnPinning,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: "includesString",
+    columnResizeMode: "onChange",
+    getRowId: (originalRow) => originalRow.id,
+    meta: {
+      onUpdate: (rowId: string, columnId: string, value: unknown) => {
+        setTableData((previous) => {
+          const nextRows = previous.map((row) => (row.id === rowId ? { ...row, [columnId]: value } : row));
+          onDataChange?.(nextRows);
+          return nextRows;
+        });
+      }
+    }
+  });
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-1 items-center gap-2">
+          <Input
+            value={globalFilter}
+            onChange={(event) => table.setGlobalFilter(event.target.value)}
+            placeholder="Search records..."
+            className="max-w-xs rounded-full border-border/70 bg-card px-4"
+            aria-label="Search table"
+          />
+          <ColumnVisibilityMenu table={table} />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex rounded-full border border-border/60 bg-card p-1">
+            {(["comfortable", "compact"] as TableDensity[]).map((option) => (
+              <Button
+                key={option}
+                type="button"
+                size="sm"
+                variant={density === option ? "default" : "ghost"}
+                className={cn(
+                  "h-8 rounded-full px-3 text-xs capitalize",
+                  density === option ? "shadow-sm" : "text-muted-foreground"
+                )}
+                onClick={() => setDensity(option)}
+              >
+                {option}
+              </Button>
+            ))}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="rounded-full border border-transparent px-3 text-xs text-muted-foreground hover:border-border"
+            onClick={reset}
+          >
+            Reset layout
+          </Button>
+        </div>
+      </div>
+      <div className="overflow-x-auto rounded-2xl border border-border/60 bg-card">
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleColumnDragEnd}>
+          <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
+            <table className={cn("min-w-full text-left", densityToRowClass[density])}>
+              <thead className="bg-card-contrast/60 text-xs uppercase tracking-wide text-muted-foreground">
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <SortableColumnHeader key={header.id} header={header} />
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <DndContext sensors={rowSensors} collisionDetection={closestCenter} onDragEnd={handleRowDragEnd}>
+                <tbody>
+                  <SortableContext items={table.getRowModel().rows.map((row) => row.id)} strategy={verticalListSortingStrategy}>
+                    {table.getRowModel().rows.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={table.getAllLeafColumns().length}
+                          className="px-6 py-12 text-center text-sm text-muted-foreground"
+                        >
+                          No data found. Adjust your filters or add new records.
+                        </td>
+                      </tr>
+                    ) : (
+                      table.getRowModel().rows.map((row) => <SortableRow key={row.id} row={row} />)
+                    )}
+                  </SortableContext>
+                </tbody>
+              </DndContext>
+            </table>
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
+  );
+}
+
+interface SortableColumnHeaderProps<TData> {
+  header: ReturnType<Table<TData>["getHeaderGroups"]>[number]["headers"][number];
+}
+
+function SortableColumnHeader<TData>({ header }: SortableColumnHeaderProps<TData>) {
+  const column = header.column;
+  const meta = (column.columnDef.meta ?? {}) as { disableDrag?: boolean };
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: column.id,
+    disabled: meta.disableDrag
+  });
+
+  return (
+    <th
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "relative select-none border-b border-border/60 bg-card-contrast/40 px-4 py-3 text-xs font-semibold uppercase text-muted-foreground",
+        isDragging && "z-10 bg-card shadow-lg"
+      )}
+    >
+      {header.isPlaceholder ? null : (
+        <div className="flex items-center gap-2">
+          {column.getCanSort() ? (
+            <button
+              type="button"
+              className="flex items-center gap-1 text-left text-foreground"
+              onClick={column.getToggleSortingHandler()}
+            >
+              <span>{flexRender(column.columnDef.header, header.getContext())}</span>
+              {column.getIsSorted() ? (
+                <span className="text-[10px] uppercase text-muted-foreground">
+                  {column.getIsSorted() === "asc" ? "▲" : "▼"}
+                </span>
+              ) : null}
+            </button>
+          ) : (
+            <span className="text-foreground">{flexRender(column.columnDef.header, header.getContext())}</span>
+          )}
+          {!meta.disableDrag ? <DragHandle {...attributes} {...listeners} /> : null}
+          {column.getCanResize() ? (
+            <div
+              onMouseDown={column.getResizeHandler()}
+              onTouchStart={column.getResizeHandler()}
+              className="absolute inset-y-0 right-0 w-1 cursor-col-resize bg-transparent"
+            />
+          ) : null}
+        </div>
+      )}
+    </th>
+  );
+}
+
+interface SortableRowProps<TData> {
+  row: ReturnType<Table<TData>["getRowModel"]>["rows"][number];
+}
+
+function SortableRow<TData>({ row }: SortableRowProps<TData>) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.id
+  });
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "border-b border-border/40 text-sm text-foreground transition",
+        isDragging ? "bg-card-contrast/60 shadow" : "hover:bg-card-contrast/40"
+      )}
+    >
+      {row.getVisibleCells().map((cell) => {
+        const isSelectionCell = cell.column.id === "__select";
+        return (
+          <td
+            key={cell.id}
+            className={cn("px-4", isSelectionCell ? "w-[52px]" : "py-3")}
+          >
+            {isSelectionCell ? (
+              <div className="flex items-center gap-2">
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                <DragHandle ref={setActivatorNodeRef} {...attributes} {...listeners} className="ml-auto" />
+              </div>
+            ) : (
+              flexRender(cell.column.columnDef.cell, cell.getContext())
+            )}
+          </td>
+        );
+      })}
+    </tr>
+  );
+}

--- a/apps/frontend/components/data-table/drag-handle.tsx
+++ b/apps/frontend/components/data-table/drag-handle.tsx
@@ -1,0 +1,26 @@
+import { GripVertical } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const DragHandle = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-muted-foreground/80 transition hover:border-border hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          className
+        )}
+        aria-label="Drag to reorder"
+        {...props}
+      >
+        <GripVertical className="h-4 w-4" aria-hidden="true" />
+        <span className="sr-only">Drag to reorder</span>
+      </button>
+    );
+  }
+);
+
+DragHandle.displayName = "DragHandle";

--- a/apps/frontend/components/data-table/editable-cell.tsx
+++ b/apps/frontend/components/data-table/editable-cell.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { CellContext } from "@tanstack/react-table";
+
+import { cn } from "@/lib/utils";
+
+export type EditableCellMeta<TData> = {
+  editable?: boolean;
+  inputType?: string;
+  placeholder?: string;
+  formatValue?: (value: unknown, row: TData) => string;
+  parseValue?: (value: string, row: TData) => unknown;
+  validate?: (value: string, row: TData) => string | null;
+};
+
+export function EditableCell<TData>({
+  getValue,
+  row,
+  column,
+  table
+}: CellContext<TData, unknown>) {
+  const meta = (column.columnDef.meta ?? {}) as EditableCellMeta<TData>;
+  const isEditable = Boolean(meta.editable);
+  const formatValue = meta.formatValue ?? ((value: unknown) => (value ?? "") as string);
+  const parseValue = meta.parseValue ?? ((value: string) => value);
+  const validate = meta.validate;
+  const accessibleLabel =
+    (typeof column.columnDef.header === "string" && column.columnDef.header) ||
+    (typeof column.id === "string" ? column.id : undefined);
+
+  const initialValue = useMemo(() => formatValue(getValue(), row.original), [formatValue, getValue, row.original]);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(initialValue);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setIsEditing(false);
+    setDraft(initialValue);
+    setError(null);
+  }, [initialValue]);
+
+  const commit = useCallback(() => {
+    const nextError = validate ? validate(draft, row.original) : null;
+    if (nextError) {
+      setError(nextError);
+      return false;
+    }
+
+    table.options.meta?.onUpdate?.(row.id, column.id, parseValue(draft, row.original));
+    setError(null);
+    setIsEditing(false);
+    return true;
+  }, [column.id, draft, parseValue, row.id, row.original, table.options.meta, validate]);
+
+  if (!isEditable) {
+    return (
+      <span className="whitespace-nowrap text-sm text-foreground" role="textbox" aria-readonly>
+        {formatValue(getValue(), row.original) || "—"}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "group relative flex min-h-[2.25rem] cursor-text items-center rounded-xl border border-transparent px-2 py-1 text-sm transition",
+        isEditing ? "border-border bg-card-contrast/60" : "hover:border-border/80 hover:bg-card-contrast/40"
+      )}
+      tabIndex={0}
+      role="textbox"
+      aria-readonly={!isEditing}
+      aria-label={accessibleLabel}
+      aria-invalid={Boolean(error) || undefined}
+      onDoubleClick={() => {
+        setIsEditing(true);
+        setDraft(initialValue);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          if (isEditing) {
+            const saved = commit();
+            if (!saved) {
+              event.preventDefault();
+            }
+          } else {
+            setIsEditing(true);
+            setDraft(initialValue);
+          }
+        }
+        if (event.key === "Escape") {
+          if (isEditing) {
+            reset();
+            event.stopPropagation();
+            event.preventDefault();
+          }
+        }
+      }}
+    >
+      {isEditing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => {
+            if (!commit()) {
+              setTimeout(() => setIsEditing(true), 0);
+            }
+          }}
+          type={meta.inputType ?? "text"}
+          placeholder={meta.placeholder}
+          className={cn(
+            "w-full rounded-lg border border-border bg-card px-2 py-1 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            error ? "border-destructive focus-visible:ring-destructive" : null
+          )}
+          aria-label={accessibleLabel}
+        />
+      ) : (
+        <span className="line-clamp-1 w-full text-sm text-foreground/90">{initialValue || "—"}</span>
+      )}
+      {error ? (
+        <span className="absolute -bottom-6 left-2 rounded-md bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/components/data-table/use-table-persistence.ts
+++ b/apps/frontend/components/data-table/use-table-persistence.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type {
+  ColumnSizingState,
+  VisibilityState
+} from "@tanstack/react-table";
+
+export type TableDensity = "comfortable" | "compact";
+
+export type TableLayoutState = {
+  columnOrder: string[];
+  columnVisibility: VisibilityState;
+  columnSizing: ColumnSizingState;
+  density: TableDensity;
+};
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+function parseLayout(value: string | null): Partial<TableLayoutState> | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<TableLayoutState>;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn("Failed to parse stored table layout", error);
+    return null;
+  }
+}
+
+export function useTablePersistence(
+  storageKey: string,
+  defaults: TableLayoutState,
+  enabled: boolean
+) {
+  const [layout, setLayout] = useState<TableLayoutState>(defaults);
+
+  useEffect(() => {
+    if (!enabled || !isBrowser()) {
+      setLayout(defaults);
+      return;
+    }
+
+    const parsed = parseLayout(window.localStorage.getItem(storageKey));
+
+    if (!parsed) {
+      setLayout(defaults);
+      return;
+    }
+
+    setLayout((previous) => ({
+      ...defaults,
+      ...previous,
+      ...parsed,
+      columnOrder: parsed.columnOrder?.length ? parsed.columnOrder : defaults.columnOrder
+    }));
+  }, [defaults, enabled, storageKey]);
+
+  useEffect(() => {
+    if (!enabled || !isBrowser()) {
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(layout));
+  }, [enabled, layout, storageKey]);
+
+  const updateLayout = useCallback(
+    (value: Partial<TableLayoutState>) =>
+      setLayout((previous) => ({
+        ...previous,
+        ...value
+      })),
+    []
+  );
+
+  const reset = useCallback(() => {
+    setLayout(defaults);
+    if (enabled && isBrowser()) {
+      window.localStorage.removeItem(storageKey);
+    }
+  }, [defaults, enabled, storageKey]);
+
+  return useMemo(
+    () => ({
+      layout,
+      updateLayout,
+      reset
+    }),
+    [layout, reset, updateLayout]
+  );
+}

--- a/apps/frontend/components/providers/app-providers.tsx
+++ b/apps/frontend/components/providers/app-providers.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from "next-auth/react";
 import { useEffect, useState, type ReactNode } from "react";
 
 import { isMockMode } from "@/lib/utils";
+import { ThemeProvider } from "../theme-provider";
 
 export function AppProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() =>
@@ -28,11 +29,13 @@ export function AppProviders({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <SessionProvider>
-      <QueryClientProvider client={queryClient}>
-        {children}
-        {process.env.NODE_ENV === "development" ? <ReactQueryDevtools /> : null}
-      </QueryClientProvider>
-    </SessionProvider>
+    <ThemeProvider>
+      <SessionProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          {process.env.NODE_ENV === "development" ? <ReactQueryDevtools /> : null}
+        </QueryClientProvider>
+      </SessionProvider>
+    </ThemeProvider>
   );
 }

--- a/apps/frontend/components/theme-provider.tsx
+++ b/apps/frontend/components/theme-provider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme={process.env.NEXT_PUBLIC_THEME_DEFAULT ?? "system"}
+      enableSystem
+      disableTransitionOnChange
+      storageKey="astalla-theme"
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/apps/frontend/components/ui/checkbox.tsx
+++ b/apps/frontend/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-border/70 bg-card text-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-foreground">
+      <Check className="h-3 w-3" aria-hidden="true" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/apps/frontend/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/components/ui/dropdown-menu.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-foreground outline-none focus-visible:bg-muted focus-visible:text-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border/60 bg-card p-1 text-foreground shadow-lg",
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 8, align = "end", ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      align={align}
+      className={cn(
+        "z-50 min-w-[12rem] overflow-hidden rounded-2xl border border-border/60 bg-card p-1 text-foreground shadow-xl",
+        "animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground outline-none focus-visible:bg-muted focus-visible:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-md py-1.5 pl-8 pr-2 text-sm text-foreground outline-none focus-visible:bg-muted focus-visible:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-md py-1.5 pl-8 pr-2 text-sm text-foreground outline-none focus-visible:bg-muted focus-visible:text-foreground",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground", inset && "pl-8", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border/60", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />;
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuShortcut,
+  DropdownMenuRadioGroup
+};

--- a/apps/frontend/components/ui/input.tsx
+++ b/apps/frontend/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = "text", ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-xl border border-border/70 bg-card px-3 py-2 text-sm text-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/frontend/components/ui/separator.tsx
+++ b/apps/frontend/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+  decorative?: boolean;
+}
+
+export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, orientation = "horizontal", decorative = true, role, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role={decorative ? "presentation" : role ?? "separator"}
+        aria-orientation={orientation}
+        className={cn(
+          "bg-border/70",
+          orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Separator.displayName = "Separator";

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -58,3 +58,6 @@ export const apiBaseUrl = (() => {
 
 export const isMockMode = () =>
   process.env.NEXT_PUBLIC_MOCK_MODE === "true" || process.env.MOCK_MODE === "true";
+
+export const isPersistenceEnabled = () =>
+  process.env.NEXT_PUBLIC_DATA_PERSISTENCE !== "false";

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,22 +8,30 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"No frontend tests yet\""
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.0",
+    "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-scroll-area": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.1",
     "@shared/api": "workspace:*",
     "@tanstack/react-query": "^5.59.8",
     "@tanstack/react-query-devtools": "^5.59.8",
+    "@tanstack/react-table": "^8.20.5",
     "autoprefixer": "^10.4.19",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.452.0",
     "msw": "^2.6.0",
     "next": "14.2.15",
+    "next-themes": "^0.3.0",
     "next-auth": "^4.24.7",
     "postcss": "^8.4.49",
     "react": "18.3.1",
@@ -33,11 +41,18 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@vitejs/plugin-react": "^5.2.0",
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.2",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.15",
-    "typescript": "^5.6.3"
+    "jsdom": "^25.0.1",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.6"
   }
 }

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -15,17 +15,23 @@ const config: Config = {
       },
       colors: {
         border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
+        input: "hsl(var(--border))",
         ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
+        background: "hsl(var(--bg))",
         foreground: "hsl(var(--foreground))",
+        panel: "hsl(var(--panel))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          contrast: "hsl(var(--card-contrast))",
+          foreground: "hsl(var(--card-foreground))"
+        },
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))"
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-contrast))"
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))"
+          DEFAULT: "hsl(var(--panel))",
+          foreground: "hsl(var(--foreground))"
         },
         muted: {
           DEFAULT: "hsl(var(--muted))",
@@ -33,15 +39,11 @@ const config: Config = {
         },
         accent: {
           DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))"
+          foreground: "hsl(var(--accent-contrast))"
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))"
-        },
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))"
         }
       },
       borderRadius: {

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    css: true,
+    coverage: {
+      reporter: ["text", "json", "html"]
+    }
+  }
+});

--- a/apps/frontend/vitest.setup.ts
+++ b/apps/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- introduce Radix-inspired light/dark theme tokens with next-themes provider and header toggle for instant contrast improvements
- refactor dashboard cards and layout for higher readability, including updated quick metrics empty states and reusable card wrapper
- rebuild the data table with TanStack Table + dnd-kit for column/row drag and drop, editable cells, density controls, and persisted layout state with tests

## Testing
- `pnpm --filter apps-frontend test` *(fails: vitest binary unavailable in the offline sandbox)*

## References
- [shadcn/ui data table](https://ui.shadcn.com/docs/components/data-table)
- [TanStack column ordering guide](https://tanstack.com/table/latest/docs/guide/column-ordering)
- [TanStack column ordering example](https://tanstack.com/table/v8/docs/framework/react/examples/column-ordering)
- [dnd-kit sortable examples](https://codesandbox.io/examples/package/%40dnd-kit/sortable)
- [Tailwind dark mode + next-themes](https://tailwindcss.com/docs/dark-mode)
- [shadcn dark mode + next-themes](https://ui.shadcn.com/docs/dark-mode/next)
- [Radix color scale guidance](https://www.radix-ui.com/colors/docs/palette-composition/understanding-the-scale)
- [Radix theme color docs](https://www.radix-ui.com/themes/docs/theme/color)
- [Tailwind theme variables](https://tailwindcss.com/docs/theme)


------
https://chatgpt.com/codex/tasks/task_e_68deb1a594a48322bd91ee6cf19d1ab3