### PR TITLE
Feature add: API integration, filters, alerts, auth

### DIFF
--- a/apps/backend/src/alerts/alerts.controller.ts
+++ b/apps/backend/src/alerts/alerts.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from "@nestjs/common";
+
+import { AlertsService } from "./alerts.service";
+
+@Controller("alerts")
+export class AlertsController {
+  constructor(private readonly alertsService: AlertsService) {}
+
+  @Get()
+  getAlerts(@Query("propertyId") propertyId?: string) {
+    return this.alertsService.getAlerts(propertyId);
+  }
+}

--- a/apps/backend/src/alerts/alerts.module.ts
+++ b/apps/backend/src/alerts/alerts.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+
+import { ProvidersModule } from "../providers/providers.module";
+import { AlertsController } from "./alerts.controller";
+import { AlertsService } from "./alerts.service";
+
+@Module({
+  imports: [ProvidersModule],
+  controllers: [AlertsController],
+  providers: [AlertsService]
+})
+export class AlertsModule {}

--- a/apps/backend/src/alerts/alerts.service.ts
+++ b/apps/backend/src/alerts/alerts.service.ts
@@ -3,10 +3,10 @@ import { Injectable } from "@nestjs/common";
 import { MockIntegrationsService } from "../providers/mock-integrations.service";
 
 @Injectable()
-export class ReviewsService {
+export class AlertsService {
   constructor(private readonly integrations: MockIntegrationsService) {}
 
-  getLatest(propertyId?: string) {
-    return this.integrations.getLatestReviews(propertyId);
+  getAlerts(propertyId?: string) {
+    return this.integrations.getAlerts(propertyId);
   }
 }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,11 +1,13 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 
+import { AlertsModule } from "./alerts/alerts.module";
 import { AuthModule } from "./auth/auth.module";
 import { JobsModule } from "./jobs/jobs.module";
 import { MetricsModule } from "./metrics/metrics.module";
 import { PrismaModule } from "./prisma/prisma.module";
 import { ProvidersModule } from "./providers/providers.module";
+import { PropertiesModule } from "./properties/properties.module";
 import { ReportsModule } from "./reports/reports.module";
 import { ReviewsModule } from "./reviews/reviews.module";
 
@@ -36,10 +38,12 @@ import { ReviewsModule } from "./reviews/reviews.module";
     }),
     PrismaModule,
     ProvidersModule,
+    PropertiesModule,
     AuthModule,
     MetricsModule,
     ReviewsModule,
     ReportsModule,
+    AlertsModule,
     JobsModule
   ]
 })

--- a/apps/backend/src/metrics/metrics.controller.ts
+++ b/apps/backend/src/metrics/metrics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
 
 import { MetricsService } from "./metrics.service";
 
@@ -7,17 +7,26 @@ export class MetricsController {
   constructor(private readonly metricsService: MetricsService) {}
 
   @Get("occupancy")
-  getOccupancy() {
-    return this.metricsService.getOccupancy();
+  getOccupancy(
+    @Query("propertyId") propertyId?: string,
+    @Query("window") windowParam?: string
+  ) {
+    return this.metricsService.getOccupancy(propertyId, windowParam);
   }
 
   @Get("pipeline")
-  getPipeline() {
-    return this.metricsService.getPipeline();
+  getPipeline(
+    @Query("propertyId") propertyId?: string,
+    @Query("window") windowParam?: string
+  ) {
+    return this.metricsService.getPipeline(propertyId, windowParam);
   }
 
   @Get("cost")
-  getCost() {
-    return this.metricsService.getCost();
+  getCost(
+    @Query("propertyId") propertyId?: string,
+    @Query("window") windowParam?: string
+  ) {
+    return this.metricsService.getCost(propertyId, windowParam);
   }
 }

--- a/apps/backend/src/metrics/metrics.service.ts
+++ b/apps/backend/src/metrics/metrics.service.ts
@@ -6,15 +6,15 @@ import { MockIntegrationsService } from "../providers/mock-integrations.service"
 export class MetricsService {
   constructor(private readonly integrations: MockIntegrationsService) {}
 
-  getOccupancy() {
-    return this.integrations.getOccupancyMetrics();
+  getOccupancy(propertyId?: string, windowParam?: string) {
+    return this.integrations.getOccupancyMetrics(propertyId, windowParam);
   }
 
-  getPipeline() {
-    return this.integrations.getPipelineMetrics();
+  getPipeline(propertyId?: string, windowParam?: string) {
+    return this.integrations.getPipelineMetrics(propertyId, windowParam);
   }
 
-  getCost() {
-    return this.integrations.getCostMetrics();
+  getCost(propertyId?: string, windowParam?: string) {
+    return this.integrations.getCostMetrics(propertyId, windowParam);
   }
 }

--- a/apps/backend/src/properties/properties.controller.ts
+++ b/apps/backend/src/properties/properties.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from "@nestjs/common";
+
+import { PropertiesService } from "./properties.service";
+
+@Controller("properties")
+export class PropertiesController {
+  constructor(private readonly propertiesService: PropertiesService) {}
+
+  @Get()
+  list() {
+    return this.propertiesService.list();
+  }
+}

--- a/apps/backend/src/properties/properties.module.ts
+++ b/apps/backend/src/properties/properties.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+
+import { ProvidersModule } from "../providers/providers.module";
+import { PropertiesController } from "./properties.controller";
+import { PropertiesService } from "./properties.service";
+
+@Module({
+  imports: [ProvidersModule],
+  controllers: [PropertiesController],
+  providers: [PropertiesService]
+})
+export class PropertiesModule {}

--- a/apps/backend/src/properties/properties.service.ts
+++ b/apps/backend/src/properties/properties.service.ts
@@ -3,10 +3,10 @@ import { Injectable } from "@nestjs/common";
 import { MockIntegrationsService } from "../providers/mock-integrations.service";
 
 @Injectable()
-export class ReviewsService {
+export class PropertiesService {
   constructor(private readonly integrations: MockIntegrationsService) {}
 
-  getLatest(propertyId?: string) {
-    return this.integrations.getLatestReviews(propertyId);
+  list() {
+    return this.integrations.getProperties();
   }
 }

--- a/apps/backend/src/providers/mock-integrations.service.ts
+++ b/apps/backend/src/providers/mock-integrations.service.ts
@@ -2,10 +2,12 @@ import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import {
-  sampleCost,
-  sampleOccupancy,
-  samplePipeline,
-  sampleReviews,
+  getAlerts,
+  getCost,
+  getOccupancy,
+  getPipeline,
+  getProperties,
+  getReviews,
   sampleUser,
   sampleWeeklyReport
 } from "./sample-data";
@@ -27,28 +29,38 @@ export class MockIntegrationsService {
     return sampleUser;
   }
 
-  getOccupancyMetrics() {
+  getProperties() {
     this.ensureMockMode();
-    return sampleOccupancy;
+    return getProperties();
   }
 
-  getPipelineMetrics() {
+  getOccupancyMetrics(propertyId?: string, windowParam?: string) {
     this.ensureMockMode();
-    return samplePipeline;
+    return getOccupancy(propertyId, windowParam);
   }
 
-  getCostMetrics() {
+  getPipelineMetrics(propertyId?: string, windowParam?: string) {
     this.ensureMockMode();
-    return sampleCost;
+    return getPipeline(propertyId, windowParam);
   }
 
-  getLatestReviews() {
+  getCostMetrics(propertyId?: string, windowParam?: string) {
     this.ensureMockMode();
-    return sampleReviews;
+    return getCost(propertyId, windowParam);
+  }
+
+  getLatestReviews(propertyId?: string) {
+    this.ensureMockMode();
+    return getReviews(propertyId);
   }
 
   getWeeklyReport() {
     this.ensureMockMode();
     return sampleWeeklyReport;
+  }
+
+  getAlerts(propertyId?: string) {
+    this.ensureMockMode();
+    return getAlerts(propertyId);
   }
 }

--- a/apps/backend/src/providers/sample-data.ts
+++ b/apps/backend/src/providers/sample-data.ts
@@ -1,69 +1,315 @@
-export const sampleOccupancy = {
-  occupancyRate: 0.93,
-  change: 0.01,
-  unitsOccupied: 325,
-  totalUnits: 350
+import type {
+  Alert,
+  CostMetricsResponse,
+  LatestReviewsResponse,
+  OccupancyMetricsResponse,
+  PipelineMetricsResponse,
+  PropertiesResponse
+} from "@shared/api";
+
+const now = Date.now();
+
+function generateTrend(base: number, windowDays: number, variance = 0.04) {
+  const points: OccupancyMetricsResponse["trend"] = [];
+  for (let index = windowDays - 1; index >= 0; index -= 1) {
+    const timestamp = new Date(now - index * 24 * 60 * 60 * 1000);
+    const offset = Math.sin((index / windowDays) * Math.PI * 2) * variance;
+    points.push({
+      timestamp: timestamp.toISOString(),
+      value: Number((base + base * offset).toFixed(4))
+    });
+  }
+  return points;
+}
+
+function generateNumericTrend(base: number, windowDays: number, variance = 0.12) {
+  const points: PipelineMetricsResponse["trend"] = [];
+  for (let index = windowDays - 1; index >= 0; index -= 1) {
+    const timestamp = new Date(now - index * 24 * 60 * 60 * 1000);
+    const offset = Math.cos((index / windowDays) * Math.PI) * variance;
+    points.push({
+      timestamp: timestamp.toISOString(),
+      value: Math.max(0, Math.round(base + base * offset))
+    });
+  }
+  return points;
+}
+
+type PropertyConfig = {
+  id: string;
+  name: string;
+  city: string;
+  state: string;
+  totalUnits: number;
+  occupancy: Record<7 | 30 | 90, { rate: number; change: number }>;
+  pipeline: Record<7 | 30 | 90, { leads: number; tours: number; started: number; approved: number }>;
+  cost: Record<7 | 30 | 90, { cpl: number; spend: number; change: number }>;
+  reviews: LatestReviewsResponse;
+  alerts: Alert[];
 };
 
-export const samplePipeline = {
-  newLeads: 78,
-  toursScheduled: 35,
-  applicationsStarted: 22,
-  applicationsApproved: 15
-};
-
-export const sampleCost = {
-  costPerLead: 128.5,
-  marketingSpend: 15400,
-  spendChange: -0.08
-};
-
-export const sampleReviews = {
-  summary: {
-    averageRating: 4.3,
-    reviewCount: 124,
-    responseRate: 0.82
+const properties: PropertyConfig[] = [
+  {
+    id: "prop-atrium",
+    name: "Atrium Center",
+    city: "Austin",
+    state: "TX",
+    totalUnits: 360,
+    occupancy: {
+      7: { rate: 0.94, change: 0.012 },
+      30: { rate: 0.932, change: 0.018 },
+      90: { rate: 0.918, change: 0.024 }
+    },
+    pipeline: {
+      7: { leads: 68, tours: 28, started: 18, approved: 12 },
+      30: { leads: 240, tours: 98, started: 72, approved: 44 },
+      90: { leads: 670, tours: 268, started: 202, approved: 134 }
+    },
+    cost: {
+      7: { cpl: 122.5, spend: 8400, change: -0.05 },
+      30: { cpl: 128.4, spend: 27800, change: -0.08 },
+      90: { cpl: 131.2, spend: 78250, change: -0.11 }
+    },
+    reviews: {
+      summary: {
+        averageRating: 4.4,
+        reviewCount: 128,
+        responseRate: 0.86
+      },
+      recent: [
+        {
+          id: "rev-atrium-1",
+          author: "Alex Johnson",
+          rating: 5,
+          body: "Maintenance requests were resolved in less than 24 hours. Appreciate the quick turnaround!",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 6).toISOString()
+        },
+        {
+          id: "rev-atrium-2",
+          author: "Taylor Smith",
+          rating: 4,
+          body: "Love the co-working lounge update. Parking could still be better organized though.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 24).toISOString()
+        }
+      ]
+    },
+    alerts: [
+      {
+        id: "alert-atrium-lease",
+        label: "Lease renewals",
+        detail: "14 leases expiring within 45 days. Prep incentive options for high-value tenants.",
+        severity: "medium",
+        occurredAt: new Date(now - 1000 * 60 * 30).toISOString()
+      },
+      {
+        id: "alert-atrium-review",
+        label: "Resident feedback spike",
+        detail: "Three new reviews mention elevator wait times during peak hours.",
+        severity: "low",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 4).toISOString()
+      }
+    ]
   },
-  recent: [
-    {
-      id: "rev-1",
-      author: "Alex Johnson",
-      rating: 5,
-      body: "Maintenance turnaround has been excellent—keep it up!",
-      submittedAt: new Date().toISOString()
+  {
+    id: "prop-harbor",
+    name: "Harbor Tower",
+    city: "Seattle",
+    state: "WA",
+    totalUnits: 420,
+    occupancy: {
+      7: { rate: 0.888, change: -0.006 },
+      30: { rate: 0.901, change: -0.012 },
+      90: { rate: 0.914, change: -0.02 }
     },
-    {
-      id: "rev-2",
-      author: "Taylor Smith",
-      rating: 3,
-      body: "Amenities are great, but parking is still limited.",
-      submittedAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString()
-    }
-  ]
-};
+    pipeline: {
+      7: { leads: 52, tours: 26, started: 16, approved: 9 },
+      30: { leads: 182, tours: 88, started: 60, approved: 34 },
+      90: { leads: 520, tours: 245, started: 178, approved: 110 }
+    },
+    cost: {
+      7: { cpl: 146.2, spend: 9200, change: 0.06 },
+      30: { cpl: 152.8, spend: 31400, change: 0.08 },
+      90: { cpl: 158.4, spend: 90500, change: 0.1 }
+    },
+    reviews: {
+      summary: {
+        averageRating: 4.1,
+        reviewCount: 96,
+        responseRate: 0.74
+      },
+      recent: [
+        {
+          id: "rev-harbor-1",
+          author: "Morgan Lee",
+          rating: 3,
+          body: "Great view but lobby renovation noise is rough. Team has been responsive though.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 8).toISOString()
+        },
+        {
+          id: "rev-harbor-2",
+          author: "Jordan Reyes",
+          rating: 5,
+          body: "Leasing team made the application process seamless. Excited to move in!",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 30).toISOString()
+        }
+      ]
+    },
+    alerts: [
+      {
+        id: "alert-harbor-maint",
+        label: "Maintenance backlog",
+        detail: "Eight open maintenance tickets exceed SLA. Coordinate contractor availability for HVAC units.",
+        severity: "high",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 2).toISOString()
+      },
+      {
+        id: "alert-harbor-marketing",
+        label: "Marketing spend spike",
+        detail: "Paid social spend is up 18% WoW with flat lead growth. Review campaign optimizations.",
+        severity: "medium",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 14).toISOString()
+      }
+    ]
+  },
+  {
+    id: "prop-quartz",
+    name: "Quartz Labs",
+    city: "Chicago",
+    state: "IL",
+    totalUnits: 310,
+    occupancy: {
+      7: { rate: 0.864, change: 0.02 },
+      30: { rate: 0.842, change: 0.014 },
+      90: { rate: 0.826, change: 0.008 }
+    },
+    pipeline: {
+      7: { leads: 46, tours: 19, started: 12, approved: 7 },
+      30: { leads: 158, tours: 64, started: 44, approved: 26 },
+      90: { leads: 420, tours: 170, started: 118, approved: 70 }
+    },
+    cost: {
+      7: { cpl: 118.1, spend: 6800, change: -0.12 },
+      30: { cpl: 121.6, spend: 22900, change: -0.16 },
+      90: { cpl: 126.2, spend: 66000, change: -0.2 }
+    },
+    reviews: {
+      summary: {
+        averageRating: 4.6,
+        reviewCount: 142,
+        responseRate: 0.9
+      },
+      recent: [
+        {
+          id: "rev-quartz-1",
+          author: "Priya Patel",
+          rating: 5,
+          body: "Community events have been a huge hit—resident retention seems to be improving!",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 5).toISOString()
+        },
+        {
+          id: "rev-quartz-2",
+          author: "Jamie Fox",
+          rating: 4,
+          body: "Appreciate the new security measures. Would love more EV charging spots though.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 18).toISOString()
+        }
+      ]
+    },
+    alerts: [
+      {
+        id: "alert-quartz-tour",
+        label: "Tour-to-lease velocity",
+        detail: "Tours converting to leases in 5.4 days (target 7). Highlight this win in weekly ops update.",
+        severity: "low",
+        occurredAt: new Date(now - 1000 * 60 * 45).toISOString()
+      },
+      {
+        id: "alert-quartz-utility",
+        label: "Utility variance",
+        detail: "Energy spend trending 9% below forecast due to LED retrofit. Confirm savings allocation.",
+        severity: "medium",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 10).toISOString()
+      }
+    ]
+  }
+];
 
-export const sampleWeeklyReport = {
-  generatedAt: new Date().toISOString(),
-  highlights: [
-    "Occupancy climbed 1% WoW with 9 net new leases",
-    "Lead-to-lease velocity improved by 14%",
-    "CPL dipped below $130 driven by organic traffic"
-  ],
-  watchlist: [
-    {
-      propertyId: "prop-red-001",
-      propertyName: "Elmwood Flats",
-      tag: "red" as const,
-      issue: "Spike in negative reviews around maintenance"
-    },
-    {
-      propertyId: "prop-watch-002",
-      propertyName: "Harbor View Lofts",
-      tag: "watch" as const,
-      issue: "Pipeline slowing week-over-week"
-    }
-  ]
-};
+function resolveWindow(value?: string) {
+  const parsed = Number(value);
+  if (parsed === 7 || parsed === 30 || parsed === 90) {
+    return parsed;
+  }
+  return 30;
+}
+
+function resolveProperty(propertyId?: string) {
+  return properties.find((property) => property.id === propertyId) ?? properties[0];
+}
+
+export function getProperties(): PropertiesResponse {
+  return {
+    properties: properties.map(({ id, name, city, state }) => ({
+      id,
+      name,
+      city,
+      state
+    }))
+  };
+}
+
+export function getOccupancy(propertyId?: string, windowParam?: string): OccupancyMetricsResponse {
+  const property = resolveProperty(propertyId);
+  const windowDays = resolveWindow(windowParam);
+  const data = property.occupancy[windowDays];
+  const unitsOccupied = Math.round(property.totalUnits * data.rate);
+
+  return {
+    occupancyRate: Number(data.rate.toFixed(3)),
+    change: Number(data.change.toFixed(3)),
+    unitsOccupied,
+    totalUnits: property.totalUnits,
+    trend: generateTrend(data.rate, windowDays)
+  };
+}
+
+export function getPipeline(propertyId?: string, windowParam?: string): PipelineMetricsResponse {
+  const property = resolveProperty(propertyId);
+  const windowDays = resolveWindow(windowParam);
+  const data = property.pipeline[windowDays];
+
+  return {
+    newLeads: data.leads,
+    toursScheduled: data.tours,
+    applicationsStarted: data.started,
+    applicationsApproved: data.approved,
+    trend: generateNumericTrend(Math.max(8, Math.round(data.leads / Math.max(1, windowDays / 7))), windowDays)
+  };
+}
+
+export function getCost(propertyId?: string, windowParam?: string): CostMetricsResponse {
+  const property = resolveProperty(propertyId);
+  const windowDays = resolveWindow(windowParam);
+  const data = property.cost[windowDays];
+
+  return {
+    costPerLead: Number(data.cpl.toFixed(2)),
+    marketingSpend: data.spend,
+    spendChange: Number(data.change.toFixed(3)),
+    trend: generateNumericTrend(Math.round(data.cpl), windowDays, 0.08)
+  };
+}
+
+export function getReviews(propertyId?: string): LatestReviewsResponse {
+  const property = resolveProperty(propertyId);
+  return property.reviews;
+}
+
+export function getAlerts(propertyId?: string): { alerts: Alert[] } {
+  const property = resolveProperty(propertyId);
+  return {
+    alerts: property.alerts
+  };
+}
 
 export const sampleUser = {
   id: "user_mock",

--- a/apps/backend/src/reviews/reviews.controller.ts
+++ b/apps/backend/src/reviews/reviews.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
 
 import { ReviewsService } from "./reviews.service";
 
@@ -7,7 +7,7 @@ export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}
 
   @Get("latest")
-  getLatest() {
-    return this.reviewsService.getLatest();
+  getLatest(@Query("propertyId") propertyId?: string) {
+    return this.reviewsService.getLatest(propertyId);
   }
 }

--- a/apps/frontend/app/api/portfolio/[id]/route.ts
+++ b/apps/frontend/app/api/portfolio/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+
+import {
+  deletePortfolioRecord,
+  listPortfolioRecords,
+  updatePortfolioRecord,
+  type PortfolioRecord
+} from "@/lib/portfolio-store";
+
+interface RouteParams {
+  params: {
+    id: string;
+  };
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const id = params.id;
+  let payload: Partial<PortfolioRecord> | undefined;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.warn("Failed to parse portfolio patch", error);
+  }
+
+  const updated = updatePortfolioRecord(id, payload ?? {});
+  if (!updated) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  deletePortfolioRecord(params.id);
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  const record = listPortfolioRecords().find((entry) => entry.id === params.id);
+  if (!record) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(record);
+}

--- a/apps/frontend/app/api/portfolio/route.ts
+++ b/apps/frontend/app/api/portfolio/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import {
+  createPortfolioRecord,
+  listPortfolioRecords,
+  type PortfolioRecord
+} from "@/lib/portfolio-store";
+
+export async function GET() {
+  const rows = listPortfolioRecords();
+  return NextResponse.json({ rows });
+}
+
+export async function POST(request: Request) {
+  let payload: Partial<PortfolioRecord> | undefined;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.warn("Failed to parse portfolio payload", error);
+  }
+  const record = createPortfolioRecord(payload);
+  return NextResponse.json(record, { status: 201 });
+}

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,5 +1,17 @@
-import { DashboardView } from "@/components/dashboard/dashboard-view";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 
-export default function DashboardPage() {
-  return <DashboardView />;
+import { DashboardView } from "@/components/dashboard/dashboard-view";
+import { authOptions } from "@/lib/auth-options";
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const role = session.user?.role === "viewer" ? "viewer" : "admin";
+
+  return <DashboardView role={role} />;
 }

--- a/apps/frontend/components/dashboard/__tests__/alerts-panel.test.tsx
+++ b/apps/frontend/components/dashboard/__tests__/alerts-panel.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react";
+
+import { AlertsPanel } from "../alerts-panel";
+
+describe("AlertsPanel", () => {
+  it("matches snapshot", () => {
+    const { container } = render(
+      <AlertsPanel
+        alerts={[
+          {
+            id: "alert-1",
+            label: "Maintenance backlog",
+            detail: "Three tickets have exceeded SLA for more than 24 hours.",
+            severity: "high",
+            occurredAt: new Date().toISOString()
+          },
+          {
+            id: "alert-2",
+            label: "Review spike",
+            detail: "Two new reviews mention HVAC noise during evenings.",
+            severity: "medium",
+            occurredAt: new Date(Date.now() - 1000 * 60 * 60).toISOString()
+          }
+        ]}
+        isLoading={false}
+        isError={false}
+        onRetry={() => {}}
+      />
+    );
+
+    const alertTitles = Array.from(
+      container.querySelectorAll("button p.text-sm.font-semibold.text-foreground"),
+      (node) => node.textContent
+    );
+
+    expect(alertTitles).toMatchInlineSnapshot(`
+      [
+        "Maintenance backlog",
+        "Review spike"
+      ]
+    `);
+  });
+});

--- a/apps/frontend/components/dashboard/__tests__/property-selector.test.tsx
+++ b/apps/frontend/components/dashboard/__tests__/property-selector.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+
+import { PropertySelector } from "../property-selector";
+
+describe("PropertySelector", () => {
+  it("matches snapshot", () => {
+    const { container } = render(
+      <PropertySelector
+        properties={[
+          { id: "prop-1", name: "Atrium Center", city: "Austin", state: "TX" },
+          { id: "prop-2", name: "Harbor Tower", city: "Seattle", state: "WA" }
+        ]}
+        selectedPropertyId="prop-1"
+        onPropertyChange={() => {}}
+        timeRange={30}
+        onTimeRangeChange={() => {}}
+      />
+    );
+
+    const select = container.querySelector("select");
+    const optionTexts = select
+      ? Array.from(select.querySelectorAll("option"), (option) => option.textContent)
+      : [];
+    expect(optionTexts).toMatchInlineSnapshot(`
+      [
+        "Atrium Center · Austin, TX",
+        "Harbor Tower · Seattle, WA"
+      ]
+    `);
+  });
+});

--- a/apps/frontend/components/dashboard/alerts-panel.tsx
+++ b/apps/frontend/components/dashboard/alerts-panel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Bell, CheckCircle2, Circle, RefreshCcw } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Alert } from "@shared/api";
+
+interface AlertsPanelProps {
+  alerts: Alert[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}
+
+type Severity = Alert["severity"];
+
+const severityStyles: Record<Severity, string> = {
+  high: "bg-red-500/10 text-red-500 border-red-500/30",
+  medium: "bg-amber-500/10 text-amber-500 border-amber-500/30",
+  low: "bg-emerald-500/10 text-emerald-500 border-emerald-500/30"
+};
+
+function formatRelativeTime(timestamp: string) {
+  const delta = Date.now() - new Date(timestamp).getTime();
+  const minutes = Math.round(delta / (1000 * 60));
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `${hours}h ago`;
+  }
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+export function AlertsPanel({ alerts, isLoading, isError, onRetry }: AlertsPanelProps) {
+  const [activeAlertId, setActiveAlertId] = useState<string | null>(null);
+  const alertCount = alerts?.length ?? 0;
+
+  useEffect(() => {
+    if (!activeAlertId && alerts && alerts.length > 0) {
+      setActiveAlertId(alerts[0].id);
+    }
+  }, [activeAlertId, alerts]);
+
+  return (
+    <div className="flex h-full flex-col rounded-3xl border border-border/80 bg-card shadow-sm">
+      <header className="flex items-center justify-between gap-4 border-b border-border/60 px-6 py-4">
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <Bell className="h-5 w-5" aria-hidden="true" />
+            </span>
+            {alertCount > 0 ? (
+              <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-[10px] font-semibold text-destructive-foreground">
+                {alertCount}
+              </span>
+            ) : null}
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Signals</p>
+            <h3 className="text-lg font-semibold text-foreground">Alerts & notifications</h3>
+          </div>
+        </div>
+        <Button type="button" variant="ghost" size="icon" onClick={onRetry} disabled={isLoading} aria-label="Refresh alerts">
+          <RefreshCcw className={cn("h-4 w-4", isLoading && "animate-spin")}
+          />
+        </Button>
+      </header>
+      <div className="flex-1 overflow-hidden">
+        {isLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-border/60 border-t-primary" />
+          </div>
+        ) : null}
+        {isError ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground">
+            <Circle className="h-8 w-8 text-destructive" />
+            <p>We couldn&apos;t load alerts. Try again in a moment.</p>
+            <Button type="button" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          </div>
+        ) : null}
+        {!isLoading && !isError ? (
+          alerts && alerts.length > 0 ? (
+            <div className="grid h-full grid-rows-[minmax(0,1fr),auto]">
+              <div className="divide-y divide-border/60 overflow-y-auto">
+                {alerts.map((alert) => {
+                  const isActive = activeAlertId === alert.id;
+                  return (
+                    <button
+                      key={alert.id}
+                      type="button"
+                      className={cn(
+                        "group flex w-full flex-col gap-2 px-6 py-4 text-left transition",
+                        isActive ? "bg-primary/5" : "hover:bg-card-contrast/40"
+                      )}
+                      onClick={() => setActiveAlertId(alert.id)}
+                      aria-pressed={isActive}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span
+                          className={cn(
+                            "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+                            severityStyles[alert.severity]
+                          )}
+                        >
+                          <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                          {alert.severity}
+                        </span>
+                        <span className="text-xs text-muted-foreground">{formatRelativeTime(alert.occurredAt)}</span>
+                      </div>
+                      <p className="text-sm font-semibold text-foreground">{alert.label}</p>
+                      <p className="text-sm text-muted-foreground line-clamp-2">{alert.detail}</p>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="border-t border-border/60 px-6 py-4">
+                {alerts.find((alert) => alert.id === activeAlertId) ? (
+                  (() => {
+                    const activeAlert = alerts.find((alert) => alert.id === activeAlertId)!;
+                    return (
+                      <div className="space-y-2">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Details</p>
+                        <p className="text-sm font-semibold text-foreground">{activeAlert.label}</p>
+                        <p className="text-sm leading-6 text-muted-foreground">{activeAlert.detail}</p>
+                      </div>
+                    );
+                  })()
+                ) : (
+                  <p className="text-sm text-muted-foreground">Select an alert to view the full context.</p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+              <p className="text-sm font-medium text-foreground">No alerts right now.</p>
+              <p className="text-sm text-muted-foreground">We&apos;ll notify you as soon as we detect something noteworthy.</p>
+            </div>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/dashboard-shell.tsx
+++ b/apps/frontend/components/dashboard/dashboard-shell.tsx
@@ -11,9 +11,11 @@ import { ThemeToggle } from "./theme-toggle";
 
 export default function DashboardShell({
   user,
+  role,
   children
 }: {
   user: MeResponse;
+  role?: "admin" | "viewer";
   children: ReactNode;
 }) {
   const displayName = user.name?.trim() || "Set your name";
@@ -48,6 +50,11 @@ export default function DashboardShell({
                   </AvatarFallback>
                 </Avatar>
               </div>
+              {role ? (
+                <span className="inline-flex items-center rounded-full border border-border/70 bg-card px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {role}
+                </span>
+              ) : null}
             </div>
           </div>
         </div>

--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -1,335 +1,278 @@
 "use client";
 
-import { type FormEvent, useEffect, useMemo, useState } from "react";
-import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, ShieldOff, Sparkles } from "lucide-react";
 
+import { AlertsPanel } from "@/components/dashboard/alerts-panel";
+import DashboardShell from "@/components/dashboard/dashboard-shell";
+import { DashboardCard } from "@/components/dashboard/dashboard-card";
+import { MetricCard } from "@/components/dashboard/metric-card";
+import { PropertySelector, type PropertyOption, type TimeRangeValue } from "@/components/dashboard/property-selector";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { api } from "@/lib/api-client";
+import { formatCurrency, formatPercent } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
-import { useDashboardState } from "@/lib/dashboard-state";
 
-import DashboardShell from "./dashboard-shell";
-import { DashboardCard } from "./dashboard-card";
 import { OperationsTable } from "./operations-table";
 
-const inputClassName =
-  "w-full rounded-xl border border-border/70 bg-card px-4 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+function resolveTrend(change?: number) {
+  if (typeof change !== "number") {
+    return "flat";
+  }
+  if (change > 0.001) {
+    return "up";
+  }
+  if (change < -0.001) {
+    return "down";
+  }
+  return "flat";
+}
 
-const textareaClassName = cn(inputClassName, "min-h-[120px] resize-none align-top");
+interface DashboardViewProps {
+  role: "admin" | "viewer";
+}
 
-const dashedPlaceholderClass =
-  "rounded-2xl border border-dashed border-border/70 bg-card/60 p-6 text-sm text-muted-foreground";
+export function DashboardView({ role }: DashboardViewProps) {
+  const [selectedProperty, setSelectedProperty] = useState<string | null>(null);
+  const [timeRange, setTimeRange] = useState<TimeRangeValue>(30);
 
-export function DashboardView() {
-  const { state, updateUser, updateWelcome, addQuickStat, removeQuickStat, clearAll } = useDashboardState();
-
-  const [isEditingWelcome, setIsEditingWelcome] = useState(false);
-  const [welcomeDraft, setWelcomeDraft] = useState(state.welcome);
-
-  const [profileDraft, setProfileDraft] = useState({
-    name: state.user.name ?? "",
-    email: state.user.email ?? "",
-    orgId: state.user.orgId ?? ""
-  });
-
-  const [showQuickStatForm, setShowQuickStatForm] = useState(false);
-  const [quickStatDraft, setQuickStatDraft] = useState({ label: "", value: "", helper: "" });
-  const [quickStatError, setQuickStatError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setWelcomeDraft(state.welcome);
-  }, [state.welcome]);
+  const meQuery = useQuery({ queryKey: ["me"], queryFn: api.me });
+  const propertiesQuery = useQuery({ queryKey: ["properties"], queryFn: api.properties });
 
   useEffect(() => {
-    setProfileDraft({
-      name: state.user.name ?? "",
-      email: state.user.email ?? "",
-      orgId: state.user.orgId ?? ""
-    });
-  }, [state.user.email, state.user.name, state.user.orgId]);
+    if (!selectedProperty && propertiesQuery.data?.properties?.length) {
+      setSelectedProperty(propertiesQuery.data.properties[0].id);
+    }
+  }, [propertiesQuery.data?.properties, selectedProperty]);
 
-  const overviewIsEmpty = useMemo(
-    () => !state.welcome.headline && !state.welcome.message && !state.welcome.note,
-    [state.welcome.headline, state.welcome.message, state.welcome.note]
+  const propertyOptions: PropertyOption[] = useMemo(() => {
+    return propertiesQuery.data?.properties ?? [];
+  }, [propertiesQuery.data?.properties]);
+
+  const metricsParams = useMemo(
+    () => ({ propertyId: selectedProperty ?? undefined, window: timeRange }),
+    [selectedProperty, timeRange]
   );
 
-  const handleWelcomeSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    updateWelcome({
-      headline: welcomeDraft.headline.trim(),
-      message: welcomeDraft.message.trim(),
-      note: welcomeDraft.note.trim()
-    });
-    setIsEditingWelcome(false);
-  };
+  const occupancyQuery = useQuery({
+    queryKey: ["occupancy", metricsParams.propertyId, metricsParams.window],
+    queryFn: () => api.occupancy(metricsParams),
+    enabled: Boolean(metricsParams.propertyId)
+  });
 
-  const handleProfileSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    updateUser({
-      name: profileDraft.name.trim(),
-      email: profileDraft.email.trim(),
-      orgId: profileDraft.orgId.trim() || "internal"
-    });
-  };
+  const pipelineQuery = useQuery({
+    queryKey: ["pipeline", metricsParams.propertyId, metricsParams.window],
+    queryFn: () => api.pipeline(metricsParams),
+    enabled: Boolean(metricsParams.propertyId)
+  });
 
-  const handleAddQuickStat = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const costQuery = useQuery({
+    queryKey: ["cost", metricsParams.propertyId, metricsParams.window],
+    queryFn: () => api.cost(metricsParams),
+    enabled: Boolean(metricsParams.propertyId)
+  });
 
-    const label = quickStatDraft.label.trim();
-    const value = quickStatDraft.value.trim();
+  const reviewsQuery = useQuery({
+    queryKey: ["reviews", selectedProperty],
+    queryFn: () => api.reviews(selectedProperty ?? undefined),
+    enabled: Boolean(selectedProperty)
+  });
 
-    if (!label || !value) {
-      setQuickStatError("Provide both a label and a value to save this metric.");
-      return;
-    }
+  const alertsQuery = useQuery({
+    queryKey: ["alerts", selectedProperty],
+    queryFn: () => api.alerts(selectedProperty ?? undefined),
+    enabled: Boolean(selectedProperty)
+  });
 
-    addQuickStat({
-      label,
-      value,
-      helper: quickStatDraft.helper.trim()
-    });
+  const isAnyLoading =
+    propertiesQuery.isLoading ||
+    occupancyQuery.isLoading ||
+    pipelineQuery.isLoading ||
+    costQuery.isLoading ||
+    reviewsQuery.isLoading;
 
-    setQuickStatDraft({ label: "", value: "", helper: "" });
-    setQuickStatError(null);
-    setShowQuickStatForm(false);
-  };
+  const fallbackUser = {
+    id: "dashboard-user",
+    name: "",
+    email: "",
+    orgId: "internal"
+  } as const;
 
-  const handleClearAll = () => {
-    clearAll();
-    setIsEditingWelcome(false);
-    setQuickStatDraft({ label: "", value: "", helper: "" });
-    setWelcomeDraft({ headline: "", message: "", note: "" });
-    setQuickStatError(null);
-  };
+  const selectedPropertyName = propertyOptions.find((option) => option.id === selectedProperty)?.name;
 
   return (
-    <DashboardShell user={state.user}>
-      <section className="grid gap-6 xl:grid-cols-[2fr,1.1fr]">
-        <DashboardCard
-          title="Overview"
-          description="Craft the copy that anchors your workspace."
-          action={
-            <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={() => setIsEditingWelcome((value) => !value)}>
-              <Pencil className="h-3.5 w-3.5" />
-              {isEditingWelcome ? "Close editor" : "Edit overview"}
-            </Button>
-          }
-        >
-          {overviewIsEmpty ? (
-            <div className={cn(dashedPlaceholderClass, "text-center")}>Use this space to greet collaborators and share context.</div>
-          ) : (
-            <div className="space-y-3">
-              {state.welcome.headline ? (
-                <h2 className="text-3xl font-semibold tracking-tight text-foreground lg:text-[2rem]">
-                  {state.welcome.headline}
-                </h2>
-              ) : null}
-              {state.welcome.message ? (
-                <p className="text-base leading-7 text-muted-foreground">{state.welcome.message}</p>
-              ) : null}
-              {state.welcome.note ? (
-                <div className="rounded-2xl border border-border/70 bg-card px-4 py-3 text-sm text-muted-foreground">
-                  {state.welcome.note}
-                </div>
-              ) : null}
-            </div>
-          )}
-
-          {isEditingWelcome ? (
-            <form className="space-y-4" onSubmit={handleWelcomeSubmit}>
-              <div className="space-y-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Headline</label>
-                <Input
-                  value={welcomeDraft.headline}
-                  onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, headline: event.target.value }))}
-                  placeholder="Give your workspace a title"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Message</label>
-                <textarea
-                  className={textareaClassName}
-                  value={welcomeDraft.message}
-                  onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, message: event.target.value }))}
-                  placeholder="Share the context for this dashboard"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Note</label>
-                <textarea
-                  className={cn(textareaClassName, "min-h-[80px] text-sm")}
-                  value={welcomeDraft.note}
-                  onChange={(event) => setWelcomeDraft((previous) => ({ ...previous, note: event.target.value }))}
-                  placeholder="Optional: add a callout or reminder"
-                />
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button type="submit" size="sm" className="gap-2">
-                  Save overview
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground"
-                  onClick={() => {
-                    setIsEditingWelcome(false);
-                    setWelcomeDraft(state.welcome);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          ) : null}
-        </DashboardCard>
-
-        <DashboardCard
-          title="Workspace identity"
-          description="This information powers the shell header for collaborators."
-          dense
-        >
-          <form className="space-y-4" onSubmit={handleProfileSubmit}>
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Name</label>
-              <Input
-                value={profileDraft.name}
-                onChange={(event) => setProfileDraft((previous) => ({ ...previous, name: event.target.value }))}
-                placeholder="Who is signed in?"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Email</label>
-              <Input
-                type="email"
-                value={profileDraft.email}
-                onChange={(event) => setProfileDraft((previous) => ({ ...previous, email: event.target.value }))}
-                placeholder="user@company.com"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Org ID</label>
-              <Input
-                value={profileDraft.orgId}
-                onChange={(event) => setProfileDraft((previous) => ({ ...previous, orgId: event.target.value }))}
-                placeholder="internal"
-              />
-            </div>
-            <Button type="submit" size="sm" className="gap-2">
-              Update identity
-            </Button>
-          </form>
-        </DashboardCard>
+    <DashboardShell user={meQuery.data ?? fallbackUser} role={role}>
+      <section>
+        <PropertySelector
+          properties={propertyOptions}
+          selectedPropertyId={selectedProperty}
+          onPropertyChange={setSelectedProperty}
+          timeRange={timeRange}
+          onTimeRangeChange={setTimeRange}
+          disabled={propertiesQuery.isLoading}
+        />
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-[1.8fr,1fr]">
+      <section className="grid gap-6 lg:grid-cols-3">
+        <MetricCard
+          title="Average occupancy"
+          value={occupancyQuery.data ? formatPercent(occupancyQuery.data.occupancyRate) : "--"}
+          helperText={
+            occupancyQuery.data
+              ? `${occupancyQuery.data.unitsOccupied} of ${occupancyQuery.data.totalUnits} units`
+              : undefined
+          }
+          change={occupancyQuery.data?.change}
+          trend={resolveTrend(occupancyQuery.data?.change)}
+          trendPoints={occupancyQuery.data?.trend}
+          trendFormatter={(value) => `${formatPercent(value)} occupancy`}
+          testId="metric-occupancy"
+          isLoading={occupancyQuery.isPending && !occupancyQuery.data}
+          isError={occupancyQuery.isError}
+          onRetry={() => occupancyQuery.refetch()}
+        />
+        <MetricCard
+          title="Pipeline conversions"
+          value={pipelineQuery.data ? `${pipelineQuery.data.applicationsApproved}` : "--"}
+          helperText={
+            pipelineQuery.data
+              ? `${pipelineQuery.data.newLeads} leads • ${pipelineQuery.data.toursScheduled} tours`
+              : undefined
+          }
+          change={pipelineQuery.data ? pipelineQuery.data.applicationsApproved / Math.max(1, pipelineQuery.data.newLeads) - 0.3 : undefined}
+          trend={resolveTrend(
+            pipelineQuery.data
+              ? pipelineQuery.data.applicationsApproved / Math.max(1, pipelineQuery.data.newLeads) - 0.3
+              : undefined
+          )}
+          trendPoints={pipelineQuery.data?.trend}
+          trendFormatter={(value) => `${value} conversions/day`}
+          testId="metric-pipeline"
+          isLoading={pipelineQuery.isPending && !pipelineQuery.data}
+          isError={pipelineQuery.isError}
+          onRetry={() => pipelineQuery.refetch()}
+        />
+        <MetricCard
+          title="Cost per lead"
+          value={costQuery.data ? formatCurrency(costQuery.data.costPerLead) : "--"}
+          helperText={costQuery.data ? `Spend ${formatCurrency(costQuery.data.marketingSpend)}` : ""}
+          change={costQuery.data?.spendChange}
+          trend={resolveTrend(costQuery.data?.spendChange)}
+          trendPoints={costQuery.data?.trend}
+          trendFormatter={(value) => `${formatCurrency(value)} CPL`}
+          testId="metric-cost"
+          isLoading={costQuery.isPending && !costQuery.data}
+          isError={costQuery.isError}
+          onRetry={() => costQuery.refetch()}
+        />
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.6fr,1fr]">
         <DashboardCard
-          title="Quick metrics"
-          description="Create callouts for the numbers you reference often."
+          title={selectedPropertyName ? `${selectedPropertyName} reviews` : "Resident feedback"}
+          description="Latest resident sentiment and response coverage"
           action={
-            <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={() => setShowQuickStatForm((value) => !value)}>
-              <Plus className="h-3.5 w-3.5" />
-              {showQuickStatForm ? "Close" : "Add metric"}
+            <Button type="button" size="sm" variant="ghost" className="gap-2" onClick={() => reviewsQuery.refetch()}>
+              <Loader2 className={cn("h-4 w-4", reviewsQuery.isFetching && "animate-spin")}
+              />
+              Refresh
             </Button>
           }
         >
-          {state.quickStats.length === 0 ? (
-            <div className={dashedPlaceholderClass}>No quick metrics yet. Add your first one to see it here.</div>
-          ) : (
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {state.quickStats.map((stat) => (
-                <div
-                  key={stat.id}
-                  className="rounded-2xl border border-border/70 bg-card px-5 py-4 shadow-sm transition hover:border-border"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{stat.label}</p>
-                      <p className="text-2xl font-semibold text-foreground">{stat.value}</p>
-                      {stat.helper ? (
-                        <p className="text-xs text-muted-foreground">{stat.helper}</p>
-                      ) : null}
+          {reviewsQuery.isLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : null}
+          {reviewsQuery.isError ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+              <ShieldOff className="h-10 w-10 text-destructive" />
+              <p className="text-sm text-muted-foreground">Unable to load reviews. Please retry in a moment.</p>
+              <Button type="button" size="sm" onClick={() => reviewsQuery.refetch()}>
+                Retry
+              </Button>
+            </div>
+          ) : null}
+          {!reviewsQuery.isLoading && !reviewsQuery.isError && reviewsQuery.data ? (
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between gap-4 rounded-2xl border border-border/70 bg-card-contrast/40 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Average rating</p>
+                  <p className="text-3xl font-semibold text-foreground">
+                    {reviewsQuery.data.summary.averageRating.toFixed(1)}
+                  </p>
+                </div>
+                <Separator orientation="vertical" className="h-12" />
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Response rate</p>
+                  <p className="text-xl font-semibold text-foreground">{formatPercent(reviewsQuery.data.summary.responseRate)}</p>
+                </div>
+                <Separator orientation="vertical" className="h-12" />
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Reviews</p>
+                  <p className="text-xl font-semibold text-foreground">{reviewsQuery.data.summary.reviewCount}</p>
+                </div>
+              </div>
+              <div className="grid gap-3">
+                {reviewsQuery.data.recent.map((review) => (
+                  <article
+                    key={review.id}
+                    className="rounded-2xl border border-border/70 bg-card px-4 py-3 shadow-sm transition hover:border-border"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-foreground">{review.author}</p>
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(review.submittedAt).toLocaleString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                          hour: "numeric",
+                          minute: "2-digit"
+                        })}
+                      </span>
                     </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-muted-foreground"
-                      onClick={() => removeQuickStat(stat.id)}
-                      aria-label={`Remove ${stat.label}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
+                    <p className="mt-2 text-sm text-muted-foreground">{review.body}</p>
+                  </article>
+                ))}
+              </div>
             </div>
-          )}
-
-          {showQuickStatForm ? (
-            <form className="space-y-4" onSubmit={handleAddQuickStat}>
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Label</label>
-                  <Input
-                    value={quickStatDraft.label}
-                    onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, label: event.target.value }))}
-                    placeholder="Metric label"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Value</label>
-                  <Input
-                    value={quickStatDraft.value}
-                    onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, value: event.target.value }))}
-                    placeholder="42, 93%, etc."
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Helper text</label>
-                <Input
-                  value={quickStatDraft.helper}
-                  onChange={(event) => setQuickStatDraft((previous) => ({ ...previous, helper: event.target.value }))}
-                  placeholder="Optional context"
-                />
-              </div>
-              {quickStatError ? <p className="text-xs text-destructive">{quickStatError}</p> : null}
-              <div className="flex flex-wrap items-center gap-2">
-                <Button type="submit" size="sm" className="gap-2">
-                  Save metric
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground"
-                  onClick={() => {
-                    setShowQuickStatForm(false);
-                    setQuickStatDraft({ label: "", value: "", helper: "" });
-                    setQuickStatError(null);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </form>
           ) : null}
         </DashboardCard>
 
+        <AlertsPanel
+          alerts={alertsQuery.data?.alerts}
+          isLoading={alertsQuery.isLoading}
+          isError={alertsQuery.isError}
+          onRetry={() => alertsQuery.refetch()}
+        />
+      </section>
+
+      <section>
         <DashboardCard
-          title="Reset dashboard"
-          description="Clear all saved content and start from a blank canvas. This removes locally stored data only."
-          dense
+          title="Portfolio performance"
+          description="Track contracts, SLAs and incident load across properties"
+          action={
+            role === "admin" ? (
+              <p className="text-xs text-muted-foreground">Admins can add, edit or delete records directly in this table.</p>
+            ) : (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Sparkles className="h-4 w-4" />
+                Viewer mode: editing disabled
+              </div>
+            )
+          }
+          contentClassName="-mt-2"
         >
-          <Button type="button" variant="ghost" className="gap-2" onClick={handleClearAll}>
-            <RefreshCw className="h-3.5 w-3.5" />
-            Clear saved data
-          </Button>
+          <OperationsTable canEdit={role === "admin"} />
         </DashboardCard>
       </section>
 
-      <OperationsTable />
+      {isAnyLoading && !selectedProperty ? (
+        <div className="flex flex-col items-center gap-2 py-8 text-sm text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" /> Preparing your dashboard...
+        </div>
+      ) : null}
     </DashboardShell>
   );
 }

--- a/apps/frontend/components/dashboard/metric-card.tsx
+++ b/apps/frontend/components/dashboard/metric-card.tsx
@@ -1,9 +1,15 @@
-import { TrendingDown, TrendingUp } from "lucide-react";
+import { Loader2, TrendingDown, TrendingUp } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export type TrendDirection = "up" | "down" | "flat";
+
+export type MetricTrendPoint = {
+  timestamp: string;
+  value: number;
+};
 
 export interface MetricCardProps {
   title: string;
@@ -11,31 +17,117 @@ export interface MetricCardProps {
   helperText?: string;
   change?: number;
   trend?: TrendDirection;
+  trendPoints?: MetricTrendPoint[];
+  trendFormatter?: (value: number) => string;
   className?: string;
+  testId?: string;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
 }
 
-export function MetricCard({ title, value, helperText, change, trend = "flat", className }: MetricCardProps) {
+export function MetricCard({
+  title,
+  value,
+  helperText,
+  change,
+  trend = "flat",
+  trendPoints,
+  trendFormatter,
+  className,
+  testId,
+  isLoading,
+  isError,
+  onRetry
+}: MetricCardProps) {
   const TrendIcon = trend === "up" ? TrendingUp : trend === "down" ? TrendingDown : null;
   const trendColor = trend === "down" ? "text-red-500" : trend === "up" ? "text-emerald-500" : "text-muted-foreground";
 
   return (
-    <Card className={cn("h-full", className)}>
+    <Card className={cn("h-full", className)} data-testid={testId}>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex flex-col">
           <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
-          <span className="mt-2 text-3xl font-semibold tracking-tight text-foreground">{value}</span>
+          <span className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+            {isLoading || isError ? "--" : value}
+          </span>
         </div>
-        {TrendIcon ? <TrendIcon className={cn("h-5 w-5", trendColor)} /> : null}
+        {!isLoading && !isError && TrendIcon ? <TrendIcon className={cn("h-5 w-5", trendColor)} /> : null}
       </CardHeader>
       <CardContent>
-        {helperText ? <p className="text-sm text-muted-foreground">{helperText}</p> : null}
-        {typeof change === "number" ? (
-          <p className="mt-2 text-sm text-muted-foreground">
-            {change > 0 ? "+" : ""}
-            {(change * 100).toFixed(1)}% vs. last period
-          </p>
+        {isLoading ? (
+          <div className="flex h-24 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            Loading metric…
+          </div>
+        ) : null}
+        {isError ? (
+          <div className="flex h-24 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+            <p>We couldn&apos;t load this metric.</p>
+            {onRetry ? (
+              <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+                Retry
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+        {!isLoading && !isError ? (
+          <div className="space-y-3">
+            {helperText ? <p className="text-sm text-muted-foreground">{helperText}</p> : null}
+            {typeof change === "number" ? (
+              <p className="text-sm text-muted-foreground">
+                {change > 0 ? "+" : ""}
+                {(change * 100).toFixed(1)}% vs. last period
+              </p>
+            ) : null}
+            {trendPoints && trendPoints.length > 1 ? (
+              <div className="rounded-2xl border border-border/70 bg-card-contrast/60 p-3">
+                <Sparkline points={trendPoints} formatter={trendFormatter} />
+              </div>
+            ) : null}
+          </div>
         ) : null}
       </CardContent>
     </Card>
+  );
+}
+
+interface SparklineProps {
+  points: MetricTrendPoint[];
+  formatter?: (value: number) => string;
+}
+
+function Sparkline({ points, formatter }: SparklineProps) {
+  const width = 220;
+  const height = 80;
+  const values = points.map((point) => point.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const path = points
+    .map((point, index) => {
+      const x = (index / (points.length - 1)) * width;
+      const y = height - ((point.value - min) / range) * height;
+      return `${index === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+
+  const latest = points[points.length - 1];
+
+  return (
+    <figure className="flex flex-col gap-2">
+      <svg
+        role="img"
+        aria-label={formatter ? formatter(latest.value) : `Latest value ${latest.value}`}
+        viewBox={`0 0 ${width} ${height}`}
+        className="h-20 w-full"
+      >
+        <path d={path} fill="none" stroke="var(--primary)" strokeWidth={2.5} strokeLinecap="round" />
+      </svg>
+      <figcaption className="text-xs text-muted-foreground">
+        {formatter ? formatter(latest.value) : `Latest: ${latest.value}`}
+      </figcaption>
+    </figure>
   );
 }

--- a/apps/frontend/components/dashboard/operations-table.tsx
+++ b/apps/frontend/components/dashboard/operations-table.tsx
@@ -1,94 +1,19 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { format } from "date-fns";
+import { Loader2, Plus, Trash2 } from "lucide-react";
 
 import { DataTable } from "@/components/data-table/data-table";
 import type { EditableCellMeta } from "@/components/data-table/editable-cell";
-import { DashboardCard } from "@/components/dashboard/dashboard-card";
-import { isPersistenceEnabled } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { cn, isPersistenceEnabled } from "@/lib/utils";
 
-export type PortfolioRow = {
-  id: string;
-  name: string;
-  status: "Green" | "At risk" | "Delayed" | "Planning";
-  owner: string;
-  updatedAt: string;
-  slaHours: number;
-  monthlyCost: number;
-  occupancy: number;
-  incidents: number;
-};
+import type { PortfolioRecord } from "@/lib/portfolio-store";
 
-const initialRows: PortfolioRow[] = [
-  {
-    id: "prop-1",
-    name: "Atrium Center",
-    status: "Green",
-    owner: "Casey Wynn",
-    updatedAt: "2024-11-04T15:05:00.000Z",
-    slaHours: 12,
-    monthlyCost: 48000,
-    occupancy: 92,
-    incidents: 1
-  },
-  {
-    id: "prop-2",
-    name: "Harbor Tower",
-    status: "At risk",
-    owner: "Jules Moreno",
-    updatedAt: "2024-11-03T09:20:00.000Z",
-    slaHours: 4,
-    monthlyCost: 72000,
-    occupancy: 87,
-    incidents: 4
-  },
-  {
-    id: "prop-3",
-    name: "North Loop Campus",
-    status: "Delayed",
-    owner: "Sydney Patel",
-    updatedAt: "2024-11-01T12:10:00.000Z",
-    slaHours: 30,
-    monthlyCost: 56000,
-    occupancy: 81,
-    incidents: 3
-  },
-  {
-    id: "prop-4",
-    name: "Quartz Labs",
-    status: "Planning",
-    owner: "Amelia Chen",
-    updatedAt: "2024-10-28T08:12:00.000Z",
-    slaHours: 48,
-    monthlyCost: 39500,
-    occupancy: 68,
-    incidents: 6
-  },
-  {
-    id: "prop-5",
-    name: "Riverside Commons",
-    status: "Green",
-    owner: "Jonah Walker",
-    updatedAt: "2024-11-05T18:30:00.000Z",
-    slaHours: 16,
-    monthlyCost: 61000,
-    occupancy: 95,
-    incidents: 0
-  },
-  {
-    id: "prop-6",
-    name: "Summit Hub",
-    status: "At risk",
-    owner: "Bryn Lee",
-    updatedAt: "2024-11-02T16:02:00.000Z",
-    slaHours: 10,
-    monthlyCost: 45200,
-    occupancy: 78,
-    incidents: 5
-  }
-];
+export type PortfolioRow = PortfolioRecord;
 
 const statusOptions: PortfolioRow["status"][] = ["Green", "At risk", "Delayed", "Planning"];
 
@@ -104,8 +29,98 @@ function validateDate(value: string) {
   return Number.isNaN(Date.parse(value)) ? "Invalid date" : null;
 }
 
-export function OperationsTable() {
-  const [rows, setRows] = useState(initialRows);
+async function fetchPortfolio() {
+  const response = await fetch("/api/portfolio", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error("Failed to load portfolio rows");
+  }
+  const payload: { rows: PortfolioRow[] } = await response.json();
+  return payload.rows;
+}
+
+export function OperationsTable({ canEdit }: { canEdit: boolean }) {
+  const queryClient = useQueryClient();
+  const rowsQuery = useQuery({ queryKey: ["portfolio"], queryFn: fetchPortfolio });
+  const [rows, setRows] = useState<PortfolioRow[]>([]);
+
+  useEffect(() => {
+    if (rowsQuery.data) {
+      setRows(rowsQuery.data);
+    }
+  }, [rowsQuery.data]);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch("/api/portfolio", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({})
+      });
+      if (!response.ok) {
+        throw new Error("Failed to create row");
+      }
+      return (await response.json()) as PortfolioRow;
+    },
+    onSuccess: (record) => {
+      setRows((previous) => [...previous, record]);
+      queryClient.invalidateQueries({ queryKey: ["portfolio"] });
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, patch }: { id: string; patch: Partial<PortfolioRow> }) => {
+      const response = await fetch(`/api/portfolio/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch)
+      });
+      if (!response.ok) {
+        throw new Error("Failed to update row");
+      }
+      return (await response.json()) as PortfolioRow;
+    },
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: ["portfolio"] });
+      const previousRows = rows;
+      setRows((current) => current.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+      return { previousRows };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousRows) {
+        setRows(context.previousRows);
+      }
+    },
+    onSuccess: (updated) => {
+      setRows((previous) => previous.map((row) => (row.id === updated.id ? updated : row)));
+      queryClient.invalidateQueries({ queryKey: ["portfolio"] });
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const response = await fetch(`/api/portfolio/${id}`, {
+        method: "DELETE"
+      });
+      if (!response.ok) {
+        throw new Error("Failed to delete row");
+      }
+      return id;
+    },
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ["portfolio"] });
+      const previousRows = rows;
+      setRows((current) => current.filter((row) => row.id !== id));
+      return { previousRows };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousRows) {
+        setRows(context.previousRows);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["portfolio"] });
+    }
+  });
 
   const columns = useMemo<ColumnDef<PortfolioRow, unknown>[]>(() => {
     return [
@@ -114,7 +129,7 @@ export function OperationsTable() {
         id: "name",
         header: "Property",
         meta: {
-          editable: true,
+          editable: canEdit,
           validate: validateNonEmpty,
           placeholder: "Property name"
         } satisfies EditableCellMeta<PortfolioRow>
@@ -124,7 +139,7 @@ export function OperationsTable() {
         id: "status",
         header: "Status",
         meta: {
-          editable: true,
+          editable: canEdit,
           validate: (value: string) =>
             statusOptions.includes(value as PortfolioRow["status"]) ? null : "Use a listed status",
           placeholder: "Green"
@@ -135,7 +150,7 @@ export function OperationsTable() {
         id: "owner",
         header: "Owner",
         meta: {
-          editable: true,
+          editable: canEdit,
           validate: validateNonEmpty,
           placeholder: "Owner"
         } satisfies EditableCellMeta<PortfolioRow>
@@ -145,7 +160,7 @@ export function OperationsTable() {
         id: "updatedAt",
         header: "Last updated",
         meta: {
-          editable: true,
+          editable: canEdit,
           formatValue: (value: unknown) => {
             const parsed = value ? new Date(value as string) : null;
             return parsed ? format(parsed, "MMM d, yyyy HH:mm") : "";
@@ -160,7 +175,7 @@ export function OperationsTable() {
         id: "slaHours",
         header: "SLA (hrs)",
         meta: {
-          editable: true,
+          editable: canEdit,
           inputType: "number",
           formatValue: (value) => String(value ?? ""),
           parseValue: (value: string) => Number(value),
@@ -172,7 +187,7 @@ export function OperationsTable() {
         id: "monthlyCost",
         header: "Monthly cost",
         meta: {
-          editable: true,
+          editable: canEdit,
           inputType: "number",
           formatValue: (value) =>
             typeof value === "number" ? `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}` : "",
@@ -185,10 +200,9 @@ export function OperationsTable() {
         id: "occupancy",
         header: "Occupancy %",
         meta: {
-          editable: true,
+          editable: canEdit,
           inputType: "number",
-          formatValue: (value) =>
-            typeof value === "number" ? `${value.toFixed(0)}%` : "",
+          formatValue: (value) => (typeof value === "number" ? `${value.toFixed(0)}%` : ""),
           parseValue: (value: string) => Number(value.replace(/%/g, "")),
           validate: (value: string) => {
             const numeric = Number(value.replace(/%/g, ""));
@@ -207,29 +221,77 @@ export function OperationsTable() {
         id: "incidents",
         header: "Open incidents",
         meta: {
-          editable: true,
+          editable: canEdit,
           inputType: "number",
           parseValue: (value: string) => Number(value),
           validate: validatePositiveNumber,
           formatValue: (value) => String(value ?? "")
         } satisfies EditableCellMeta<PortfolioRow>
+      },
+      {
+        id: "actions",
+        header: "",
+        enableHiding: false,
+        cell: ({ row }) => (
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground"
+              onClick={() => deleteMutation.mutate(row.original.id)}
+              disabled={!canEdit || deleteMutation.isPending}
+              aria-label={`Delete ${row.original.name}`}
+            >
+              {deleteMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        )
       }
     ];
-  }, []);
+  }, [canEdit, deleteMutation.isPending]);
 
   return (
-    <DashboardCard
-      title="Portfolio performance"
-      description="Track contracts, SLAs and incident load for high-value properties."
-      action={<p className="text-xs text-muted-foreground">Drag columns or rows to personalize the view.</p>}
-    >
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Button
+          type="button"
+          size="sm"
+          className="gap-2"
+          onClick={() => createMutation.mutate()}
+          disabled={!canEdit || createMutation.isPending}
+        >
+          {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+          Add row
+        </Button>
+        {rowsQuery.isFetching ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Syncing
+          </div>
+        ) : null}
+      </div>
+      {rowsQuery.isError ? (
+        <div className="rounded-2xl border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          Unable to load saved portfolio rows. Working with the latest cached data.
+        </div>
+      ) : null}
       <DataTable
         columns={columns}
         data={rows}
-        storageKey="astalla:portfolio-table:v2"
+        storageKey="astalla:portfolio-table:v3"
         persistenceEnabled={isPersistenceEnabled()}
-        onDataChange={setRows}
+        onDataChange={(nextRows) => setRows(nextRows)}
+        className={cn(!canEdit && "opacity-90")}
+        meta={{
+          onUpdate: (rowId: string, columnId: string, value: unknown) => {
+            updateMutation.mutate({ id: rowId, patch: { [columnId]: value } as Partial<PortfolioRow> });
+          }
+        }}
       />
-    </DashboardCard>
+    </div>
   );
 }

--- a/apps/frontend/components/dashboard/property-selector.tsx
+++ b/apps/frontend/components/dashboard/property-selector.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { ChevronDown, MapPin } from "lucide-react";
+import type { ChangeEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type PropertyOption = {
+  id: string;
+  name: string;
+  city: string;
+  state: string;
+};
+
+const TIME_RANGES = [
+  { label: "Last 7 days", value: 7 },
+  { label: "Last 30 days", value: 30 },
+  { label: "Last 90 days", value: 90 }
+] as const;
+
+type TimeRangeValue = (typeof TIME_RANGES)[number]["value"];
+
+interface PropertySelectorProps {
+  properties: PropertyOption[];
+  selectedPropertyId: string | null;
+  onPropertyChange: (propertyId: string) => void;
+  timeRange: TimeRangeValue;
+  onTimeRangeChange: (range: TimeRangeValue) => void;
+  disabled?: boolean;
+}
+
+export function PropertySelector({
+  properties,
+  selectedPropertyId,
+  onPropertyChange,
+  timeRange,
+  onTimeRangeChange,
+  disabled
+}: PropertySelectorProps) {
+  return (
+    <div className="flex flex-col gap-4 rounded-3xl border border-border/80 bg-panel/90 p-6 shadow-sm supports-[backdrop-filter]:backdrop-blur">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <MapPin className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Portfolio</p>
+            <h2 className="text-xl font-semibold text-foreground">Property insights</h2>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor="property-select">
+            Property
+          </label>
+          <div className="relative">
+            <select
+              id="property-select"
+              className={cn(
+                "appearance-none rounded-full border border-border/80 bg-card px-4 py-2 pr-10 text-sm font-medium text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                disabled && "cursor-not-allowed opacity-60"
+              )}
+              value={selectedPropertyId ?? ""}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => onPropertyChange(event.target.value)}
+              disabled={disabled || properties.length === 0}
+            >
+              {properties.length === 0 ? <option value="">No properties</option> : null}
+              {properties.map((property) => (
+                <option key={property.id} value={property.id}>
+                  {property.name} · {property.city}, {property.state}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Time range</span>
+        <div className="flex rounded-full border border-border/70 bg-card p-1 shadow-sm">
+          {TIME_RANGES.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              size="sm"
+              variant={timeRange === option.value ? "default" : "ghost"}
+              className={cn(
+                "h-8 rounded-full px-4 text-xs font-semibold",
+                timeRange === option.value ? "shadow-sm" : "text-muted-foreground"
+              )}
+              onClick={() => onTimeRangeChange(option.value)}
+              disabled={disabled}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type { TimeRangeValue };

--- a/apps/frontend/components/data-table/data-table.tsx
+++ b/apps/frontend/components/data-table/data-table.tsx
@@ -29,7 +29,8 @@ import {
   type ColumnPinningState,
   type ColumnSizingState,
   type SortingState,
-  type Table
+  type Table,
+  type TableMeta
 } from "@tanstack/react-table";
 import {
   type RowSelectionState,
@@ -59,6 +60,7 @@ interface DataTableProps<TData extends { id: string }> {
   className?: string;
   persistenceEnabled?: boolean;
   onDataChange?: (rows: TData[]) => void;
+  meta?: TableMeta<TData>;
 }
 
 function defaultColumnId<TData>(column: ColumnDef<TData, unknown>, index: number) {
@@ -97,7 +99,8 @@ export function DataTable<TData extends { id: string }>({
   storageKey,
   className,
   persistenceEnabled = true,
-  onDataChange
+  onDataChange,
+  meta
 }: DataTableProps<TData>) {
   const selectionColumn = useMemo<ColumnDef<TData, unknown>>(
     () => ({
@@ -251,7 +254,8 @@ export function DataTable<TData extends { id: string }>({
           onDataChange?.(nextRows);
           return nextRows;
         });
-      }
+      },
+      ...meta
     }
   });
 

--- a/apps/frontend/e2e/dashboard.spec.ts
+++ b/apps/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test("user can log in and view property metrics", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.fill('input[name="identifier"]', "demo@example.com");
+  await page.fill('input[name="password"]', "password");
+  await page.getByRole("button", { name: /sign in/i }).click();
+
+  await page.waitForURL("**/dashboard");
+  await expect(page.getByText(/property insights/i)).toBeVisible();
+
+  await expect(page.getByTestId("metric-occupancy")).toContainText("%");
+
+  await page.selectOption("#property-select", "prop-harbor");
+  await expect(page.getByText(/Harbor Tower reviews/)).toBeVisible();
+  await expect(page.getByTestId("metric-occupancy")).toContainText("%");
+  await expect(page.getByTestId("metric-pipeline")).not.toContainText("--");
+});

--- a/apps/frontend/lib/api-client.ts
+++ b/apps/frontend/lib/api-client.ts
@@ -1,18 +1,22 @@
 import { isMockMode, apiBaseUrl } from "@/lib/utils";
 import {
+  alertsResponseSchema,
   costMetricsSchema,
   latestReviewsSchema,
   meResponseSchema,
   occupancyMetricsSchema,
   pipelineMetricsSchema,
+  propertiesResponseSchema,
   weeklyReportSchema
 } from "@shared/api";
 import type {
+  AlertsResponse,
   CostMetricsResponse,
   LatestReviewsResponse,
   MeResponse,
   OccupancyMetricsResponse,
   PipelineMetricsResponse,
+  PropertiesResponse,
   WeeklyReportResponse
 } from "@shared/api";
 
@@ -34,11 +38,46 @@ async function fetchJson<T>(path: string, schema: { parse: (data: unknown) => T 
   return schema.parse(json);
 }
 
+type MetricParams = {
+  propertyId?: string;
+  window?: string | number;
+};
+
+function createQuery(params: Record<string, string | number | undefined>) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== "") {
+      search.append(key, String(value));
+    }
+  });
+  const queryString = search.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
 export const api = {
   me: () => fetchJson<MeResponse>("/auth/me", meResponseSchema),
-  occupancy: () => fetchJson<OccupancyMetricsResponse>("/metrics/occupancy", occupancyMetricsSchema),
-  pipeline: () => fetchJson<PipelineMetricsResponse>("/metrics/pipeline", pipelineMetricsSchema),
-  cost: () => fetchJson<CostMetricsResponse>("/metrics/cost", costMetricsSchema),
-  reviews: () => fetchJson<LatestReviewsResponse>("/reviews/latest", latestReviewsSchema),
+  occupancy: (params: MetricParams) =>
+    fetchJson<OccupancyMetricsResponse>(
+      `/metrics/occupancy${createQuery({ propertyId: params.propertyId, window: params.window })}`,
+      occupancyMetricsSchema
+    ),
+  pipeline: (params: MetricParams) =>
+    fetchJson<PipelineMetricsResponse>(
+      `/metrics/pipeline${createQuery({ propertyId: params.propertyId, window: params.window })}`,
+      pipelineMetricsSchema
+    ),
+  cost: (params: MetricParams) =>
+    fetchJson<CostMetricsResponse>(
+      `/metrics/cost${createQuery({ propertyId: params.propertyId, window: params.window })}`,
+      costMetricsSchema
+    ),
+  reviews: (propertyId?: string) =>
+    fetchJson<LatestReviewsResponse>(
+      `/reviews/latest${createQuery({ propertyId })}`,
+      latestReviewsSchema
+    ),
+  alerts: (propertyId?: string) =>
+    fetchJson<AlertsResponse>(`/alerts${createQuery({ propertyId })}`, alertsResponseSchema),
+  properties: () => fetchJson<PropertiesResponse>("/properties", propertiesResponseSchema),
   report: () => fetchJson<WeeklyReportResponse>("/reports/weekly", weeklyReportSchema)
 };

--- a/apps/frontend/lib/auth-options.ts
+++ b/apps/frontend/lib/auth-options.ts
@@ -197,6 +197,8 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         session.user.name = session.user.name ?? fallbackUser.name;
         session.user.email = session.user.email ?? fallbackUser.email;
+        const identifier = session.user.email?.toLowerCase() ?? "";
+        session.user.role = identifier.includes("viewer") ? "viewer" : "admin";
       }
       return session;
     }

--- a/apps/frontend/lib/formatters.ts
+++ b/apps/frontend/lib/formatters.ts
@@ -1,0 +1,14 @@
+export function formatCurrency(value: number, locale: string = "en-US") {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value < 100 ? 2 : 0
+  }).format(value);
+}
+
+export function formatPercent(value: number, locale: string = "en-US") {
+  return new Intl.NumberFormat(locale, {
+    style: "percent",
+    maximumFractionDigits: 1
+  }).format(value);
+}

--- a/apps/frontend/lib/portfolio-store.ts
+++ b/apps/frontend/lib/portfolio-store.ts
@@ -1,0 +1,143 @@
+export type PortfolioRecord = {
+  id: string;
+  name: string;
+  status: "Green" | "At risk" | "Delayed" | "Planning";
+  owner: string;
+  updatedAt: string;
+  slaHours: number;
+  monthlyCost: number;
+  occupancy: number;
+  incidents: number;
+};
+
+const initialRecords: PortfolioRecord[] = [
+  {
+    id: "prop-1",
+    name: "Atrium Center",
+    status: "Green",
+    owner: "Casey Wynn",
+    updatedAt: "2024-11-04T15:05:00.000Z",
+    slaHours: 12,
+    monthlyCost: 48000,
+    occupancy: 92,
+    incidents: 1
+  },
+  {
+    id: "prop-2",
+    name: "Harbor Tower",
+    status: "At risk",
+    owner: "Jules Moreno",
+    updatedAt: "2024-11-03T09:20:00.000Z",
+    slaHours: 4,
+    monthlyCost: 72000,
+    occupancy: 87,
+    incidents: 4
+  },
+  {
+    id: "prop-3",
+    name: "North Loop Campus",
+    status: "Delayed",
+    owner: "Sydney Patel",
+    updatedAt: "2024-11-01T12:10:00.000Z",
+    slaHours: 30,
+    monthlyCost: 56000,
+    occupancy: 81,
+    incidents: 3
+  },
+  {
+    id: "prop-4",
+    name: "Quartz Labs",
+    status: "Planning",
+    owner: "Amelia Chen",
+    updatedAt: "2024-10-28T08:12:00.000Z",
+    slaHours: 48,
+    monthlyCost: 39500,
+    occupancy: 68,
+    incidents: 6
+  },
+  {
+    id: "prop-5",
+    name: "Riverside Commons",
+    status: "Green",
+    owner: "Jonah Walker",
+    updatedAt: "2024-11-05T18:30:00.000Z",
+    slaHours: 16,
+    monthlyCost: 61000,
+    occupancy: 95,
+    incidents: 0
+  },
+  {
+    id: "prop-6",
+    name: "Summit Hub",
+    status: "At risk",
+    owner: "Bryn Lee",
+    updatedAt: "2024-11-02T16:02:00.000Z",
+    slaHours: 10,
+    monthlyCost: 45200,
+    occupancy: 78,
+    incidents: 5
+  }
+];
+
+const store = new Map<string, PortfolioRecord>();
+let seeded = false;
+
+function ensureSeeded() {
+  if (!seeded) {
+    initialRecords.forEach((record) => {
+      store.set(record.id, { ...record });
+    });
+    seeded = true;
+  }
+}
+
+function createId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `row_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function listPortfolioRecords(): PortfolioRecord[] {
+  ensureSeeded();
+  return Array.from(store.values());
+}
+
+export function createPortfolioRecord(partial?: Partial<PortfolioRecord>): PortfolioRecord {
+  ensureSeeded();
+  const id = createId();
+  const now = new Date().toISOString();
+  const record: PortfolioRecord = {
+    id,
+    name: partial?.name ?? "New property",
+    status: partial?.status ?? "Planning",
+    owner: partial?.owner ?? "Unassigned",
+    updatedAt: now,
+    slaHours: partial?.slaHours ?? 12,
+    monthlyCost: partial?.monthlyCost ?? 25000,
+    occupancy: partial?.occupancy ?? 80,
+    incidents: partial?.incidents ?? 0
+  };
+  store.set(id, record);
+  return record;
+}
+
+export function updatePortfolioRecord(id: string, patch: Partial<PortfolioRecord>): PortfolioRecord | null {
+  ensureSeeded();
+  const existing = store.get(id);
+  if (!existing) {
+    return null;
+  }
+  const updated = {
+    ...existing,
+    ...patch,
+    updatedAt: patch.updatedAt ?? new Date().toISOString()
+  } satisfies PortfolioRecord;
+  store.set(id, updated);
+  return updated;
+}
+
+export function deletePortfolioRecord(id: string) {
+  ensureSeeded();
+  store.delete(id);
+}

--- a/apps/frontend/mocks/handlers.ts
+++ b/apps/frontend/mocks/handlers.ts
@@ -1,84 +1,307 @@
 import { HttpResponse, http } from "msw";
 
-const mockOccupancy = {
-  occupancyRate: 0.93,
-  change: 0.01,
-  unitsOccupied: 325,
-  totalUnits: 350
+type TrendPoint = { timestamp: string; value: number };
+
+type PropertyData = {
+  id: string;
+  name: string;
+  city: string;
+  state: string;
+  totalUnits: number;
+  occupancy: Record<7 | 30 | 90, { rate: number; change: number; trend: TrendPoint[] }>;
+  pipeline: Record<7 | 30 | 90, { leads: number; tours: number; started: number; approved: number; trend: TrendPoint[] }>;
+  cost: Record<7 | 30 | 90, { cpl: number; spend: number; change: number; trend: TrendPoint[] }>;
+  reviews: {
+    summary: { averageRating: number; reviewCount: number; responseRate: number };
+    recent: Array<{ id: string; author: string; rating: number; body: string; submittedAt: string }>;
+  };
+  alerts: Array<{ id: string; label: string; detail: string; severity: "high" | "medium" | "low"; occurredAt: string }>;
 };
 
-const mockPipeline = {
-  newLeads: 78,
-  toursScheduled: 35,
-  applicationsStarted: 22,
-  applicationsApproved: 15
-};
+const now = Date.now();
 
-const mockCost = {
-  costPerLead: 128.5,
-  marketingSpend: 15400,
-  spendChange: -0.08
-};
+function buildTrend(base: number, windowDays: number, factor = 0.05): TrendPoint[] {
+  return Array.from({ length: windowDays }).map((_, index, array) => {
+    const reverseIndex = array.length - index - 1;
+    const timestamp = new Date(now - reverseIndex * 24 * 60 * 60 * 1000).toISOString();
+    const offset = Math.sin((reverseIndex / windowDays) * Math.PI * 1.8) * factor;
+    const value = Number((base + base * offset).toFixed(3));
+    return { timestamp, value };
+  });
+}
 
-const mockReviews = {
-  summary: {
-    averageRating: 4.3,
-    reviewCount: 124,
-    responseRate: 0.82
+const properties: PropertyData[] = [
+  {
+    id: "prop-atrium",
+    name: "Atrium Center",
+    city: "Austin",
+    state: "TX",
+    totalUnits: 360,
+    occupancy: {
+      7: { rate: 0.94, change: 0.012, trend: buildTrend(0.94, 7) },
+      30: { rate: 0.932, change: 0.018, trend: buildTrend(0.932, 30) },
+      90: { rate: 0.918, change: 0.024, trend: buildTrend(0.918, 90) }
+    },
+    pipeline: {
+      7: { leads: 68, tours: 28, started: 18, approved: 12, trend: buildTrend(12, 7, 0.18) },
+      30: { leads: 240, tours: 98, started: 72, approved: 44, trend: buildTrend(38, 30, 0.12) },
+      90: { leads: 670, tours: 268, started: 202, approved: 134, trend: buildTrend(80, 90, 0.1) }
+    },
+    cost: {
+      7: { cpl: 122.5, spend: 8400, change: -0.05, trend: buildTrend(122.5, 7, 0.07) },
+      30: { cpl: 128.4, spend: 27800, change: -0.08, trend: buildTrend(128.4, 30, 0.05) },
+      90: { cpl: 131.2, spend: 78250, change: -0.11, trend: buildTrend(131.2, 90, 0.04) }
+    },
+    reviews: {
+      summary: { averageRating: 4.4, reviewCount: 128, responseRate: 0.86 },
+      recent: [
+        {
+          id: "rev-atrium-1",
+          author: "Alex Johnson",
+          rating: 5,
+          body: "Maintenance requests were resolved in less than a day.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 6).toISOString()
+        },
+        {
+          id: "rev-atrium-2",
+          author: "Taylor Smith",
+          rating: 4,
+          body: "Loving the coworking space refresh—parking still tight though.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 24).toISOString()
+        }
+      ]
+    },
+    alerts: [
+      {
+        id: "alert-atrium-lease",
+        label: "Lease renewals",
+        detail: "14 leases expiring within 45 days. Prep retention offers.",
+        severity: "medium",
+        occurredAt: new Date(now - 1000 * 60 * 45).toISOString()
+      },
+      {
+        id: "alert-atrium-review",
+        label: "Feedback spike",
+        detail: "Elevator wait times mentioned in recent resident reviews.",
+        severity: "low",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 5).toISOString()
+      }
+    ]
   },
-  recent: [
-    {
-      id: "rev-1",
-      author: "Alex Johnson",
-      rating: 5,
-      body: "Maintenance turnaround has been excellent—keep it up!",
-      submittedAt: new Date().toISOString()
+  {
+    id: "prop-harbor",
+    name: "Harbor Tower",
+    city: "Seattle",
+    state: "WA",
+    totalUnits: 420,
+    occupancy: {
+      7: { rate: 0.888, change: -0.006, trend: buildTrend(0.888, 7) },
+      30: { rate: 0.901, change: -0.012, trend: buildTrend(0.901, 30) },
+      90: { rate: 0.914, change: -0.02, trend: buildTrend(0.914, 90) }
     },
-    {
-      id: "rev-2",
-      author: "Taylor Smith",
-      rating: 3,
-      body: "Amenities are great, but parking is still limited.",
-      submittedAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString()
-    }
-  ]
-};
-
-const mockReport = {
-  generatedAt: new Date().toISOString(),
-  highlights: [
-    "Occupancy climbed 1% WoW with 9 net new leases",
-    "Lead-to-lease velocity improved by 14%",
-    "CPL dipped below $130 driven by organic traffic"
-  ],
-  watchlist: [
-    {
-      propertyId: "prop-red-001",
-      propertyName: "Elmwood Flats",
-      tag: "red" as const,
-      issue: "Spike in negative reviews around maintenance"
+    pipeline: {
+      7: { leads: 52, tours: 26, started: 16, approved: 9, trend: buildTrend(10, 7, 0.16) },
+      30: { leads: 182, tours: 88, started: 60, approved: 34, trend: buildTrend(30, 30, 0.11) },
+      90: { leads: 520, tours: 245, started: 178, approved: 110, trend: buildTrend(58, 90, 0.09) }
     },
-    {
-      propertyId: "prop-watch-002",
-      propertyName: "Harbor View Lofts",
-      tag: "watch" as const,
-      issue: "Pipeline slowing week-over-week"
-    }
-  ]
-};
+    cost: {
+      7: { cpl: 146.2, spend: 9200, change: 0.06, trend: buildTrend(146.2, 7, 0.08) },
+      30: { cpl: 152.8, spend: 31400, change: 0.08, trend: buildTrend(152.8, 30, 0.06) },
+      90: { cpl: 158.4, spend: 90500, change: 0.1, trend: buildTrend(158.4, 90, 0.05) }
+    },
+    reviews: {
+      summary: { averageRating: 4.1, reviewCount: 96, responseRate: 0.74 },
+      recent: [
+        {
+          id: "rev-harbor-1",
+          author: "Morgan Lee",
+          rating: 3,
+          body: "Lobby renovation noise has been rough, team remains responsive though.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 8).toISOString()
+        },
+        {
+          id: "rev-harbor-2",
+          author: "Jordan Reyes",
+          rating: 5,
+          body: "Seamless move-in experience. Leasing team is top-notch!",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 32).toISOString()
+        }
+      ]
+    },
+    alerts: [
+      {
+        id: "alert-harbor-maint",
+        label: "Maintenance backlog",
+        detail: "Eight open tickets exceed SLA. Coordinate contractor availability.",
+        severity: "high",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 2).toISOString()
+      },
+      {
+        id: "alert-harbor-marketing",
+        label: "Marketing spend spike",
+        detail: "Paid social spend up 18% WoW with flat lead growth.",
+        severity: "medium",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 14).toISOString()
+      }
+    ]
+  },
+  {
+    id: "prop-quartz",
+    name: "Quartz Labs",
+    city: "Chicago",
+    state: "IL",
+    totalUnits: 310,
+    occupancy: {
+      7: { rate: 0.864, change: 0.02, trend: buildTrend(0.864, 7) },
+      30: { rate: 0.842, change: 0.014, trend: buildTrend(0.842, 30) },
+      90: { rate: 0.826, change: 0.008, trend: buildTrend(0.826, 90) }
+    },
+    pipeline: {
+      7: { leads: 46, tours: 19, started: 12, approved: 7, trend: buildTrend(9, 7, 0.15) },
+      30: { leads: 158, tours: 64, started: 44, approved: 26, trend: buildTrend(24, 30, 0.1) },
+      90: { leads: 420, tours: 170, started: 118, approved: 70, trend: buildTrend(46, 90, 0.08) }
+    },
+    cost: {
+      7: { cpl: 118.1, spend: 6800, change: -0.12, trend: buildTrend(118.1, 7, 0.07) },
+      30: { cpl: 121.6, spend: 22900, change: -0.16, trend: buildTrend(121.6, 30, 0.05) },
+      90: { cpl: 126.2, spend: 66000, change: -0.2, trend: buildTrend(126.2, 90, 0.04) }
+    },
+    reviews: {
+      summary: { averageRating: 4.6, reviewCount: 142, responseRate: 0.9 },
+      recent: [
+        {
+          id: "rev-quartz-1",
+          author: "Priya Patel",
+          rating: 5,
+          body: "Community events have boosted resident retention already!",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 5).toISOString()
+        },
+        {
+          id: "rev-quartz-2",
+          author: "Jamie Fox",
+          rating: 4,
+          body: "Security upgrades feel great—could use more EV charging spots.",
+          submittedAt: new Date(now - 1000 * 60 * 60 * 18).toISOString()
+        }
+      ]
+    },
+    alerts: [
+      {
+        id: "alert-quartz-tour",
+        label: "Tour velocity",
+        detail: "Tours converting to leases in 5.4 days (target 7). Celebrate with ops team.",
+        severity: "low",
+        occurredAt: new Date(now - 1000 * 60 * 55).toISOString()
+      },
+      {
+        id: "alert-quartz-utility",
+        label: "Utility variance",
+        detail: "Energy spend trending 9% below forecast thanks to LED retrofit.",
+        severity: "medium",
+        occurredAt: new Date(now - 1000 * 60 * 60 * 11).toISOString()
+      }
+    ]
+  }
+];
 
-const mockUser = {
-  id: "user_mock",
-  name: "Mock User",
-  email: "mock.user@example.com",
-  orgId: "org_123"
-};
+function resolveWindow(value?: string) {
+  const parsed = Number(value);
+  if (parsed === 7 || parsed === 30 || parsed === 90) {
+    return parsed;
+  }
+  return 30;
+}
+
+function resolveProperty(propertyId?: string) {
+  return properties.find((property) => property.id === propertyId) ?? properties[0];
+}
 
 export const handlers = [
-  http.get("*/auth/me", () => HttpResponse.json(mockUser)),
-  http.get("*/metrics/occupancy", () => HttpResponse.json(mockOccupancy)),
-  http.get("*/metrics/pipeline", () => HttpResponse.json(mockPipeline)),
-  http.get("*/metrics/cost", () => HttpResponse.json(mockCost)),
-  http.get("*/reviews/latest", () => HttpResponse.json(mockReviews)),
-  http.get("*/reports/weekly", () => HttpResponse.json(mockReport))
+  http.get("*/auth/me", () =>
+    HttpResponse.json({
+      id: "user_mock",
+      name: "Mock User",
+      email: "mock.user@example.com",
+      orgId: "org_123"
+    })
+  ),
+  http.get("*/properties", () =>
+    HttpResponse.json({
+      properties: properties.map(({ id, name, city, state }) => ({ id, name, city, state }))
+    })
+  ),
+  http.get("*/metrics/occupancy", ({ request }) => {
+    const url = new URL(request.url);
+    const propertyId = url.searchParams.get("propertyId") ?? undefined;
+    const windowParam = resolveWindow(url.searchParams.get("window") ?? undefined);
+    const property = resolveProperty(propertyId);
+    const data = property.occupancy[windowParam];
+
+    return HttpResponse.json({
+      occupancyRate: data.rate,
+      change: data.change,
+      unitsOccupied: Math.round(property.totalUnits * data.rate),
+      totalUnits: property.totalUnits,
+      trend: data.trend
+    });
+  }),
+  http.get("*/metrics/pipeline", ({ request }) => {
+    const url = new URL(request.url);
+    const propertyId = url.searchParams.get("propertyId") ?? undefined;
+    const windowParam = resolveWindow(url.searchParams.get("window") ?? undefined);
+    const property = resolveProperty(propertyId);
+    const data = property.pipeline[windowParam];
+
+    return HttpResponse.json({
+      newLeads: data.leads,
+      toursScheduled: data.tours,
+      applicationsStarted: data.started,
+      applicationsApproved: data.approved,
+      trend: data.trend
+    });
+  }),
+  http.get("*/metrics/cost", ({ request }) => {
+    const url = new URL(request.url);
+    const propertyId = url.searchParams.get("propertyId") ?? undefined;
+    const windowParam = resolveWindow(url.searchParams.get("window") ?? undefined);
+    const property = resolveProperty(propertyId);
+    const data = property.cost[windowParam];
+
+    return HttpResponse.json({
+      costPerLead: data.cpl,
+      marketingSpend: data.spend,
+      spendChange: data.change,
+      trend: data.trend
+    });
+  }),
+  http.get("*/reviews/latest", ({ request }) => {
+    const url = new URL(request.url);
+    const propertyId = url.searchParams.get("propertyId") ?? undefined;
+    const property = resolveProperty(propertyId);
+    return HttpResponse.json(property.reviews);
+  }),
+  http.get("*/alerts", ({ request }) => {
+    const url = new URL(request.url);
+    const propertyId = url.searchParams.get("propertyId") ?? undefined;
+    const property = resolveProperty(propertyId);
+    return HttpResponse.json({ alerts: property.alerts });
+  }),
+  http.get("*/reports/weekly", () =>
+    HttpResponse.json({
+      generatedAt: new Date(now - 1000 * 60 * 60 * 12).toISOString(),
+      highlights: [
+        "Occupancy climbed 1% WoW with 9 net new leases",
+        "Lead-to-lease velocity improved by 14%",
+        "CPL dipped below $130 driven by organic traffic"
+      ],
+      watchlist: [
+        {
+          propertyId: "prop-harbor",
+          propertyName: "Harbor Tower",
+          tag: "red",
+          issue: "Maintenance backlog is increasing week-over-week"
+        }
+      ]
+    })
+  )
 ];

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.0",
@@ -41,6 +42,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.41.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  retries: 0,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
+    trace: "on-first-retry"
+  }
+});

--- a/apps/frontend/types/next-auth.d.ts
+++ b/apps/frontend/types/next-auth.d.ts
@@ -1,0 +1,9 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultSession["user"] & {
+      role?: "admin" | "viewer";
+    };
+  }
+}

--- a/packages/shared/dist/schemas.d.ts
+++ b/packages/shared/dist/schemas.d.ts
@@ -321,28 +321,64 @@ export declare const occupancyMetricsSchema: z.ZodObject<{
     change: z.ZodNumber;
     unitsOccupied: z.ZodNumber;
     totalUnits: z.ZodNumber;
+    trend: z.ZodArray<z.ZodObject<{
+        timestamp: z.ZodString;
+        value: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        value: number;
+        timestamp: string;
+    }, {
+        value: number;
+        timestamp: string;
+    }>, "many">;
 }, "strip", z.ZodTypeAny, {
     occupancyRate: number;
     change: number;
     unitsOccupied: number;
     totalUnits: number;
+    trend: {
+        value: number;
+        timestamp: string;
+    }[];
 }, {
     occupancyRate: number;
     change: number;
     unitsOccupied: number;
     totalUnits: number;
+    trend: {
+        value: number;
+        timestamp: string;
+    }[];
 }>;
 export declare const pipelineMetricsSchema: z.ZodObject<{
     newLeads: z.ZodNumber;
     toursScheduled: z.ZodNumber;
     applicationsStarted: z.ZodNumber;
     applicationsApproved: z.ZodNumber;
+    trend: z.ZodArray<z.ZodObject<{
+        timestamp: z.ZodString;
+        value: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        value: number;
+        timestamp: string;
+    }, {
+        value: number;
+        timestamp: string;
+    }>, "many">;
 }, "strip", z.ZodTypeAny, {
+    trend: {
+        value: number;
+        timestamp: string;
+    }[];
     newLeads: number;
     toursScheduled: number;
     applicationsStarted: number;
     applicationsApproved: number;
 }, {
+    trend: {
+        value: number;
+        timestamp: string;
+    }[];
     newLeads: number;
     toursScheduled: number;
     applicationsStarted: number;
@@ -352,11 +388,29 @@ export declare const costMetricsSchema: z.ZodObject<{
     costPerLead: z.ZodNumber;
     marketingSpend: z.ZodNumber;
     spendChange: z.ZodNumber;
+    trend: z.ZodArray<z.ZodObject<{
+        timestamp: z.ZodString;
+        value: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        value: number;
+        timestamp: string;
+    }, {
+        value: number;
+        timestamp: string;
+    }>, "many">;
 }, "strip", z.ZodTypeAny, {
+    trend: {
+        value: number;
+        timestamp: string;
+    }[];
     costPerLead: number;
     marketingSpend: number;
     spendChange: number;
 }, {
+    trend: {
+        value: number;
+        timestamp: string;
+    }[];
     costPerLead: number;
     marketingSpend: number;
     spendChange: number;
@@ -462,9 +516,105 @@ export declare const weeklyReportSchema: z.ZodObject<Pick<{
         issue: string;
     }[];
 }>;
+export declare const alertSchema: z.ZodObject<{
+    id: z.ZodString;
+    label: z.ZodString;
+    detail: z.ZodString;
+    severity: z.ZodEnum<["high", "medium", "low"]>;
+    occurredAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    occurredAt: string;
+    label: string;
+    detail: string;
+    severity: "high" | "medium" | "low";
+}, {
+    id: string;
+    occurredAt: string;
+    label: string;
+    detail: string;
+    severity: "high" | "medium" | "low";
+}>;
+export declare const alertsResponseSchema: z.ZodObject<{
+    alerts: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        label: z.ZodString;
+        detail: z.ZodString;
+        severity: z.ZodEnum<["high", "medium", "low"]>;
+        occurredAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        occurredAt: string;
+        label: string;
+        detail: string;
+        severity: "high" | "medium" | "low";
+    }, {
+        id: string;
+        occurredAt: string;
+        label: string;
+        detail: string;
+        severity: "high" | "medium" | "low";
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    alerts: {
+        id: string;
+        occurredAt: string;
+        label: string;
+        detail: string;
+        severity: "high" | "medium" | "low";
+    }[];
+}, {
+    alerts: {
+        id: string;
+        occurredAt: string;
+        label: string;
+        detail: string;
+        severity: "high" | "medium" | "low";
+    }[];
+}>;
+export declare const propertiesResponseSchema: z.ZodObject<{
+    properties: z.ZodArray<z.ZodObject<Pick<{
+        id: z.ZodString;
+        name: z.ZodString;
+        address: z.ZodString;
+        city: z.ZodString;
+        state: z.ZodString;
+        zip: z.ZodString;
+        orgId: z.ZodString;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "id" | "name" | "city" | "state">, "strip", z.ZodTypeAny, {
+        id: string;
+        name: string;
+        city: string;
+        state: string;
+    }, {
+        id: string;
+        name: string;
+        city: string;
+        state: string;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    properties: {
+        id: string;
+        name: string;
+        city: string;
+        state: string;
+    }[];
+}, {
+    properties: {
+        id: string;
+        name: string;
+        city: string;
+        state: string;
+    }[];
+}>;
 export type Org = z.infer<typeof orgSchema>;
 export type Property = z.infer<typeof propertySchema>;
 export type User = z.infer<typeof userSchema>;
+export type Alert = z.infer<typeof alertSchema>;
+export type AlertsResponse = z.infer<typeof alertsResponseSchema>;
+export type PropertiesResponse = z.infer<typeof propertiesResponseSchema>;
 export type BasicAuthAccount = z.infer<typeof basicAuthAccountSchema>;
 export type RegisterBasicAuthRequest = z.infer<typeof registerBasicAuthRequestSchema>;
 export type RegisterBasicAuthResponse = z.infer<typeof registerBasicAuthResponseSchema>;

--- a/packages/shared/dist/schemas.js
+++ b/packages/shared/dist/schemas.js
@@ -102,22 +102,29 @@ export const reportSnapshotSchema = z.object({
 export const meResponseSchema = userSchema.extend({
     orgId: z.string()
 });
+const metricPointSchema = z.object({
+    timestamp: z.string().datetime({ offset: true }),
+    value: z.number()
+});
 export const occupancyMetricsSchema = z.object({
     occupancyRate: z.number(),
     change: z.number(),
     unitsOccupied: z.number(),
-    totalUnits: z.number()
+    totalUnits: z.number(),
+    trend: z.array(metricPointSchema)
 });
 export const pipelineMetricsSchema = z.object({
     newLeads: z.number(),
     toursScheduled: z.number(),
     applicationsStarted: z.number(),
-    applicationsApproved: z.number()
+    applicationsApproved: z.number(),
+    trend: z.array(metricPointSchema)
 });
 export const costMetricsSchema = z.object({
     costPerLead: z.number(),
     marketingSpend: z.number(),
-    spendChange: z.number()
+    spendChange: z.number(),
+    trend: z.array(metricPointSchema)
 });
 export const latestReviewsSchema = z.object({
     summary: z.object({
@@ -137,4 +144,22 @@ export const weeklyReportSchema = reportSnapshotSchema.pick({
     generatedAt: true,
     highlights: true,
     watchlist: true
+});
+export const alertSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    detail: z.string(),
+    severity: z.enum(["high", "medium", "low"]),
+    occurredAt: z.string().datetime({ offset: true })
+});
+export const alertsResponseSchema = z.object({
+    alerts: z.array(alertSchema)
+});
+export const propertiesResponseSchema = z.object({
+    properties: z.array(propertySchema.pick({
+        id: true,
+        name: true,
+        city: true,
+        state: true
+    }))
 });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -121,24 +121,32 @@ export const meResponseSchema = userSchema.extend({
   orgId: z.string()
 });
 
+const metricPointSchema = z.object({
+  timestamp: z.string().datetime({ offset: true }),
+  value: z.number()
+});
+
 export const occupancyMetricsSchema = z.object({
   occupancyRate: z.number(),
   change: z.number(),
   unitsOccupied: z.number(),
-  totalUnits: z.number()
+  totalUnits: z.number(),
+  trend: z.array(metricPointSchema)
 });
 
 export const pipelineMetricsSchema = z.object({
   newLeads: z.number(),
   toursScheduled: z.number(),
   applicationsStarted: z.number(),
-  applicationsApproved: z.number()
+  applicationsApproved: z.number(),
+  trend: z.array(metricPointSchema)
 });
 
 export const costMetricsSchema = z.object({
   costPerLead: z.number(),
   marketingSpend: z.number(),
-  spendChange: z.number()
+  spendChange: z.number(),
+  trend: z.array(metricPointSchema)
 });
 
 export const latestReviewsSchema = z.object({
@@ -164,9 +172,35 @@ export const weeklyReportSchema = reportSnapshotSchema.pick({
   watchlist: true
 });
 
+export const alertSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  detail: z.string(),
+  severity: z.enum(["high", "medium", "low"]),
+  occurredAt: z.string().datetime({ offset: true })
+});
+
+export const alertsResponseSchema = z.object({
+  alerts: z.array(alertSchema)
+});
+
+export const propertiesResponseSchema = z.object({
+  properties: z.array(
+    propertySchema.pick({
+      id: true,
+      name: true,
+      city: true,
+      state: true
+    })
+  )
+});
+
 export type Org = z.infer<typeof orgSchema>;
 export type Property = z.infer<typeof propertySchema>;
 export type User = z.infer<typeof userSchema>;
+export type Alert = z.infer<typeof alertSchema>;
+export type AlertsResponse = z.infer<typeof alertsResponseSchema>;
+export type PropertiesResponse = z.infer<typeof propertiesResponseSchema>;
 export type BasicAuthAccount = z.infer<typeof basicAuthAccountSchema>;
 export type RegisterBasicAuthRequest = z.infer<typeof registerBasicAuthRequestSchema>;
 export type RegisterBasicAuthResponse = z.infer<typeof registerBasicAuthResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.18.8)(typescript@5.9.3)))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.41.2
+        version: 1.41.2
       '@types/node':
         specifier: ^22.10.1
         version: 22.18.8


### PR DESCRIPTION
## Summary
- add explicit loading, error, and retry affordances to dashboard metric cards
- wire occupancy, pipeline, and cost queries to surface pending/error state in the card UI
- export alert and property response schemas and types from the shared API package so the dashboard build can resolve them

## Testing
- pnpm --filter @shared/api build

------
https://chatgpt.com/codex/tasks/task_e_68dee3c319008322b31acdfe9f5c44c0