### PR TITLE
Tables v2 — multi-table system with real-time collab, permissions, forms, and dashboard glue

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,6 +17,7 @@
     "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^10.4.7",
     "@nestjs/platform-express": "^10.4.7",
+    "@nestjs/platform-socket.io": "^10.4.7",
     "@shared/api": "workspace:*",
     "@prisma/client": "^5.22.0",
     "express": "^4.19.2",
@@ -25,8 +26,10 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "ioredis": "^5.4.1",
+    "@nestjs/websockets": "^10.4.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "yjs": "^13.6.15",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -43,6 +43,8 @@ model User {
   org       Org      @relation(fields: [orgId], references: [id])
   orgId     String
   tableViews TableView[]
+  audits    TableAudit[]
+  role      TableRole @default(viewer)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -136,13 +138,17 @@ model Table {
   columns     TableColumn[]
   rows        TableRow[]
   views       TableView[]
+  audits      TableAudit[]
+  forms       Form[]
+  permissions TablePermission[]
+  snapshots   TableCrdtSnapshot?
   refColumns  TableColumn[] @relation("RefTable")
   createdAt   DateTime     @default(now())
 }
 
 model TableColumn {
   id          String        @id @default(cuid())
-  table       Table         @relation(fields: [tableId], references: [id])
+  table       Table         @relation(fields: [tableId], references: [id], onDelete: Cascade)
   tableId     String
   name        String
   type        TableColumnType
@@ -151,34 +157,38 @@ model TableColumn {
   formulaExpr String?
   order       Int
   cells       TableCell[]
+  permissions TablePermission[]
 }
 
 model TableRow {
   id        String      @id @default(cuid())
-  table     Table       @relation(fields: [tableId], references: [id])
+  table     Table       @relation(fields: [tableId], references: [id], onDelete: Cascade)
   tableId   String
   createdAt DateTime    @default(now())
   order     Int
   cells     TableCell[]
+  permissions TablePermission[]
 }
 
 model TableCell {
   id        String     @id @default(cuid())
-  row       TableRow   @relation(fields: [rowId], references: [id])
+  row       TableRow   @relation(fields: [rowId], references: [id], onDelete: Cascade)
   rowId     String
-  column    TableColumn @relation(fields: [columnId], references: [id])
+  column    TableColumn @relation(fields: [columnId], references: [id], onDelete: Cascade)
   columnId  String
   valueJson Json
 }
 
 model TableView {
   id         String   @id @default(cuid())
-  table      Table    @relation(fields: [tableId], references: [id])
+  table      Table    @relation(fields: [tableId], references: [id], onDelete: Cascade)
   tableId    String
-  user       User     @relation(fields: [userId], references: [id])
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId     String
   name       String
   configJson Json
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 }
 
 enum TableColumnType {
@@ -188,4 +198,72 @@ enum TableColumnType {
   bool
   ref
   formula
+}
+
+model TableAudit {
+  id        String            @id @default(cuid())
+  table     Table             @relation(fields: [tableId], references: [id], onDelete: Cascade)
+  tableId   String
+  row       TableRow?         @relation(fields: [rowId], references: [id], onDelete: SetNull)
+  rowId     String?
+  column    TableColumn?      @relation(fields: [columnId], references: [id], onDelete: SetNull)
+  columnId  String?
+  user      User?             @relation(fields: [userId], references: [id], onDelete: SetNull)
+  userId    String?
+  action    TableAuditAction
+  oldValue  Json?
+  newValue  Json?
+  createdAt DateTime          @default(now())
+}
+
+model Form {
+  id         String   @id @default(cuid())
+  table      Table    @relation(fields: [tableId], references: [id], onDelete: Cascade)
+  tableId    String
+  name       String
+  configJson Json
+  isPublic   Boolean  @default(false)
+  createdAt  DateTime @default(now())
+}
+
+model TablePermission {
+  id        String     @id @default(cuid())
+  table     Table      @relation(fields: [tableId], references: [id], onDelete: Cascade)
+  tableId   String
+  role      TableRole
+  row       TableRow?  @relation(fields: [rowId], references: [id], onDelete: Cascade)
+  rowId     String?
+  column    TableColumn? @relation(fields: [columnId], references: [id], onDelete: Cascade)
+  columnId  String?
+  canRead   Boolean   @default(true)
+  canWrite  Boolean   @default(false)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model TableCrdtSnapshot {
+  id        String   @id @default(cuid())
+  table     Table    @relation(fields: [tableId], references: [id], onDelete: Cascade)
+  tableId   String   @unique
+  state     Bytes
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+enum TableAuditAction {
+  row_created
+  row_updated
+  row_deleted
+  column_created
+  column_updated
+  column_deleted
+  cell_updated
+  form_submitted
+  table_updated
+}
+
+enum TableRole {
+  admin
+  editor
+  viewer
 }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ProvidersModule } from "./providers/providers.module";
 import { PropertiesModule } from "./properties/properties.module";
 import { ReportsModule } from "./reports/reports.module";
 import { ReviewsModule } from "./reviews/reviews.module";
+import { TablesModule } from "./tables/tables.module";
 
 @Module({
   imports: [
@@ -44,7 +45,8 @@ import { ReviewsModule } from "./reviews/reviews.module";
     ReviewsModule,
     ReportsModule,
     AlertsModule,
-    JobsModule
+    JobsModule,
+    TablesModule
   ]
 })
 export class AppModule {}

--- a/apps/backend/src/tables/table-collaboration.gateway.ts
+++ b/apps/backend/src/tables/table-collaboration.gateway.ts
@@ -1,0 +1,64 @@
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer
+} from "@nestjs/websockets";
+import { Logger } from "@nestjs/common";
+import type { Server, Socket } from "socket.io";
+
+import { TableCollaborationService } from "./table-collaboration.service";
+
+@WebSocketGateway({ namespace: "table-collab", cors: { origin: "*" } })
+export class TableCollaborationGateway implements OnGatewayConnection {
+  @WebSocketServer()
+  server!: Server;
+
+  private readonly logger = new Logger(TableCollaborationGateway.name);
+
+  constructor(private readonly collab: TableCollaborationService) {}
+
+  async handleConnection(client: Socket) {
+    this.logger.debug(`Client connected: ${client.id}`);
+  }
+
+  @SubscribeMessage("join")
+  async handleJoin(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: {
+      tableId: string;
+    }
+  ) {
+    if (!payload?.tableId) {
+      client.emit("error", { message: "tableId is required" });
+      return;
+    }
+
+    client.join(payload.tableId);
+    const state = await this.collab.encodeState(payload.tableId);
+    client.emit("sync", { update: Buffer.from(state).toString("base64") });
+  }
+
+  @SubscribeMessage("update")
+  async handleUpdate(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: {
+      tableId: string;
+      update: string;
+      actorId?: string | null;
+    }
+  ) {
+    if (!payload?.tableId || !payload.update) {
+      client.emit("error", { message: "tableId and update are required" });
+      return;
+    }
+
+    const binary = Buffer.from(payload.update, "base64");
+    await this.collab.applyUpdate(payload.tableId, new Uint8Array(binary));
+    client.to(payload.tableId).emit("update", payload);
+  }
+}

--- a/apps/backend/src/tables/table-collaboration.service.ts
+++ b/apps/backend/src/tables/table-collaboration.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import * as Y from "yjs";
+
+import { PrismaService } from "../prisma/prisma.service";
+
+@Injectable()
+export class TableCollaborationService {
+  private readonly logger = new Logger(TableCollaborationService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async loadDocument(tableId: string) {
+    const tableExists = await this.prisma.table.findUnique({ where: { id: tableId }, select: { id: true } });
+    if (!tableExists) {
+      throw new NotFoundException("Table not found");
+    }
+
+    const snapshot = await this.prisma.tableCrdtSnapshot.findUnique({ where: { tableId } });
+    const doc = new Y.Doc();
+
+    if (snapshot?.state) {
+      try {
+        Y.applyUpdate(doc, new Uint8Array(snapshot.state));
+      } catch (error) {
+        this.logger.warn(`Failed to hydrate CRDT snapshot for table ${tableId}: ${error}`);
+      }
+    }
+
+    return doc;
+  }
+
+  async encodeState(tableId: string) {
+    const doc = await this.loadDocument(tableId);
+    return Y.encodeStateAsUpdate(doc);
+  }
+
+  async applyUpdate(tableId: string, update: Uint8Array) {
+    const doc = await this.loadDocument(tableId);
+    Y.applyUpdate(doc, update);
+    await this.persistDocument(tableId, doc);
+    return update;
+  }
+
+  private async persistDocument(tableId: string, doc: Y.Doc) {
+    const encoded = Y.encodeStateAsUpdate(doc);
+    await this.prisma.tableCrdtSnapshot.upsert({
+      where: { tableId },
+      create: {
+        tableId,
+        state: Buffer.from(encoded)
+      },
+      update: {
+        state: Buffer.from(encoded)
+      }
+    });
+  }
+}

--- a/apps/backend/src/tables/table-forms.controller.ts
+++ b/apps/backend/src/tables/table-forms.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+
+import { TablesService } from "./tables.service";
+
+@Controller("forms")
+export class TableFormsController {
+  constructor(private readonly tablesService: TablesService) {}
+
+  @Get(":id")
+  getForm(@Param("id") id: string) {
+    return this.tablesService.getForm(id);
+  }
+
+  @Post(":id/submit")
+  submitForm(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      values: Record<string, unknown>;
+      actorId?: string | null;
+    }
+  ) {
+    return this.tablesService.submitForm(id, {
+      values: body.values,
+      actorId: body.actorId
+    });
+  }
+}

--- a/apps/backend/src/tables/tables.controller.ts
+++ b/apps/backend/src/tables/tables.controller.ts
@@ -1,0 +1,260 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query
+} from "@nestjs/common";
+import { Prisma, TableColumnType, TableRole } from "@prisma/client";
+
+import { TablesService } from "./tables.service";
+
+@Controller("tables")
+export class TablesController {
+  constructor(private readonly tablesService: TablesService) {}
+
+  @Get()
+  list(@Query("orgId") orgId?: string) {
+    if (!orgId) {
+      throw new BadRequestException("orgId query parameter is required");
+    }
+
+    return this.tablesService.list(orgId);
+  }
+
+  @Get(":id")
+  get(@Param("id") id: string) {
+    return this.tablesService.get(id);
+  }
+
+  @Post()
+  create(
+    @Body()
+    body: {
+      orgId: string;
+      name: string;
+      columns?: Array<{
+        name: string;
+        type: TableColumnType;
+        refTableId?: string | null;
+        formulaExpr?: string | null;
+      }>;
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.createTable(body);
+  }
+
+  @Patch(":id")
+  update(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      name?: string;
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.updateTable(id, body);
+  }
+
+  @Delete(":id")
+  delete(@Param("id") id: string) {
+    return this.tablesService.deleteTable(id);
+  }
+
+  @Post(":id/columns")
+  createColumn(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      name: string;
+      type: TableColumnType;
+      refTableId?: string | null;
+      formulaExpr?: string | null;
+      order?: number;
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.createColumn(id, body);
+  }
+
+  @Patch("columns/:columnId")
+  updateColumn(
+    @Param("columnId") columnId: string,
+    @Body()
+    body: {
+      name?: string;
+      type?: TableColumnType;
+      refTableId?: string | null;
+      formulaExpr?: string | null;
+      order?: number;
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.updateColumn(columnId, body);
+  }
+
+  @Delete("columns/:columnId")
+  deleteColumn(@Param("columnId") columnId: string, @Query("userId") userId?: string) {
+    return this.tablesService.deleteColumn(columnId, userId);
+  }
+
+  @Post(":id/columns/reorder")
+  reorderColumns(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      columnIds: string[];
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.reorderColumns(id, body);
+  }
+
+  @Post(":id/rows")
+  createRow(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      values: Record<string, unknown>;
+      userId?: string | null;
+      order?: number;
+    }
+  ) {
+    return this.tablesService.createRow(id, body);
+  }
+
+  @Patch("rows/:rowId")
+  updateRow(
+    @Param("rowId") rowId: string,
+    @Body()
+    body: {
+      values: Record<string, unknown>;
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.updateRow(rowId, body);
+  }
+
+  @Delete("rows/:rowId")
+  deleteRow(@Param("rowId") rowId: string, @Query("userId") userId?: string) {
+    return this.tablesService.deleteRow(rowId, userId);
+  }
+
+  @Post(":id/rows/reorder")
+  reorderRows(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      rowIds: string[];
+      userId?: string | null;
+    }
+  ) {
+    return this.tablesService.reorderRows(id, body);
+  }
+
+  @Get(":id/views")
+  listViews(@Param("id") id: string) {
+    return this.tablesService.listViews(id);
+  }
+
+  @Post(":id/views")
+  createView(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      userId: string;
+      name: string;
+      configJson: unknown;
+    }
+  ) {
+    return this.tablesService.createView(id, {
+      userId: body.userId,
+      name: body.name,
+      configJson: body.configJson as Prisma.JsonValue
+    });
+  }
+
+  @Patch("views/:viewId")
+  updateView(
+    @Param("viewId") viewId: string,
+    @Body()
+    body: {
+      name?: string;
+      configJson?: unknown;
+    }
+  ) {
+    return this.tablesService.updateView(viewId, {
+      name: body.name,
+      configJson: body.configJson as Prisma.JsonValue | undefined
+    });
+  }
+
+  @Delete("views/:viewId")
+  deleteView(@Param("viewId") viewId: string) {
+    return this.tablesService.deleteView(viewId);
+  }
+
+  @Get(":id/permissions")
+  listPermissions(@Param("id") id: string) {
+    return this.tablesService.listPermissions(id);
+  }
+
+  @Put(":id/permissions")
+  setPermissions(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      permissions: Array<{
+        role: TableRole;
+        rowId?: string | null;
+        columnId?: string | null;
+        canRead: boolean;
+        canWrite: boolean;
+      }>;
+    }
+  ) {
+    return this.tablesService.setPermissions(id, body.permissions ?? []);
+  }
+
+  @Get(":id/history")
+  getHistory(
+    @Param("id") id: string,
+    @Query("rowId") rowId?: string,
+    @Query("columnId") columnId?: string,
+    @Query("limit") limit?: string
+  ) {
+    return this.tablesService.getHistory(id, {
+      rowId,
+      columnId,
+      limit: limit ? Number(limit) : undefined
+    });
+  }
+
+  @Get(":id/forms")
+  listForms(@Param("id") id: string) {
+    return this.tablesService.listForms(id);
+  }
+
+  @Post(":id/forms")
+  createForm(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      name: string;
+      configJson: unknown;
+      isPublic?: boolean;
+    }
+  ) {
+    return this.tablesService.createForm(id, {
+      name: body.name,
+      configJson: body.configJson as Prisma.JsonValue,
+      isPublic: body.isPublic
+    });
+  }
+}

--- a/apps/backend/src/tables/tables.module.ts
+++ b/apps/backend/src/tables/tables.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { PrismaModule } from "../prisma/prisma.module";
+
+import { TableCollaborationGateway } from "./table-collaboration.gateway";
+import { TableCollaborationService } from "./table-collaboration.service";
+import { TableFormsController } from "./table-forms.controller";
+import { TablesController } from "./tables.controller";
+import { TablesService } from "./tables.service";
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TablesController, TableFormsController],
+  providers: [TablesService, TableCollaborationService, TableCollaborationGateway],
+  exports: [TablesService]
+})
+export class TablesModule {}

--- a/apps/backend/src/tables/tables.service.ts
+++ b/apps/backend/src/tables/tables.service.ts
@@ -1,0 +1,811 @@
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import {
+  Prisma,
+  TableAuditAction,
+  TableColumnType,
+  TableRole
+} from "@prisma/client";
+
+import { PrismaService } from "../prisma/prisma.service";
+
+type PrismaClientLike = Prisma.TransactionClient;
+
+type TableWithRelations = Prisma.TableGetPayload<{
+  include: {
+    columns: true;
+    rows: { include: { cells: true } };
+    views: true;
+    permissions: true;
+    forms: true;
+  };
+}>;
+
+type RowWithCells = Prisma.TableRowGetPayload<{
+  include: { cells: true };
+}>;
+
+interface CreateTableInput {
+  orgId: string;
+  name: string;
+  columns?: Array<{
+    name: string;
+    type: TableColumnType;
+    refTableId?: string | null;
+    formulaExpr?: string | null;
+  }>;
+  userId?: string | null;
+}
+
+interface UpdateTableInput {
+  name?: string;
+  userId?: string | null;
+}
+
+interface CreateColumnInput {
+  name: string;
+  type: TableColumnType;
+  refTableId?: string | null;
+  formulaExpr?: string | null;
+  order?: number;
+  userId?: string | null;
+}
+
+interface UpdateColumnInput {
+  name?: string;
+  type?: TableColumnType;
+  refTableId?: string | null;
+  formulaExpr?: string | null;
+  order?: number;
+  userId?: string | null;
+}
+
+interface CreateRowInput {
+  values: Record<string, unknown>;
+  userId?: string | null;
+  order?: number;
+}
+
+interface UpdateRowInput {
+  values: Record<string, unknown>;
+  userId?: string | null;
+}
+
+interface ReorderRowsInput {
+  rowIds: string[];
+  userId?: string | null;
+}
+
+interface ReorderColumnsInput {
+  columnIds: string[];
+  userId?: string | null;
+}
+
+interface CreateViewInput {
+  userId: string;
+  name: string;
+  configJson: Prisma.JsonValue;
+}
+
+interface UpdateViewInput {
+  name?: string;
+  configJson?: Prisma.JsonValue;
+}
+
+interface UpsertPermissionInput {
+  role: TableRole;
+  rowId?: string | null;
+  columnId?: string | null;
+  canRead: boolean;
+  canWrite: boolean;
+}
+
+interface CreateFormInput {
+  name: string;
+  configJson: Prisma.JsonValue;
+  isPublic?: boolean;
+}
+
+interface SubmitFormInput {
+  values: Record<string, unknown>;
+  actorId?: string | null;
+}
+
+@Injectable()
+export class TablesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(orgId: string) {
+    const tables = await this.prisma.table.findMany({
+      where: { orgId },
+      include: {
+        columns: { orderBy: { order: "asc" } },
+        rows: { orderBy: { order: "asc" }, include: { cells: true } },
+        views: true,
+        permissions: true,
+        forms: true
+      },
+      orderBy: { createdAt: "asc" }
+    });
+
+    return tables.map((table) => this.serializeTable(table));
+  }
+
+  async get(tableId: string) {
+    const table = await this.prisma.table.findUnique({
+      where: { id: tableId },
+      include: {
+        columns: { orderBy: { order: "asc" } },
+        rows: { orderBy: { order: "asc" }, include: { cells: true } },
+        views: true,
+        permissions: true,
+        forms: true
+      }
+    });
+
+    if (!table) {
+      throw new NotFoundException("Table not found");
+    }
+
+    return this.serializeTable(table);
+  }
+
+  async createTable(input: CreateTableInput) {
+    if (!input.orgId) {
+      throw new BadRequestException("orgId is required");
+    }
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      const table = await tx.table.create({
+        data: {
+          orgId: input.orgId,
+          name: input.name
+        }
+      });
+
+      if (input.columns?.length) {
+        for (const [index, column] of input.columns.entries()) {
+          const created = await tx.tableColumn.create({
+            data: {
+              tableId: table.id,
+              name: column.name,
+              type: column.type,
+              refTableId: column.refTableId ?? null,
+              formulaExpr: column.formulaExpr ?? null,
+              order: index
+            }
+          });
+
+          await this.logAudit(tx, {
+            action: TableAuditAction.column_created,
+            tableId: table.id,
+            columnId: created.id,
+            userId: input.userId ?? undefined,
+            newValue: {
+              name: column.name,
+              type: column.type,
+              refTableId: column.refTableId ?? null,
+              formulaExpr: column.formulaExpr ?? null,
+              order: created.order
+            }
+          });
+        }
+      }
+
+      return table.id;
+    });
+
+    return this.get(result);
+  }
+
+  async updateTable(tableId: string, input: UpdateTableInput) {
+    await this.ensureTableExists(tableId);
+
+    if (typeof input.name === "string") {
+      await this.prisma.table.update({
+        where: { id: tableId },
+        data: { name: input.name }
+      });
+
+      await this.logAudit(this.prisma, {
+        tableId,
+        action: TableAuditAction.table_updated,
+        userId: input.userId ?? undefined,
+        newValue: { name: input.name }
+      });
+    }
+
+    return this.get(tableId);
+  }
+
+  async deleteTable(tableId: string) {
+    await this.ensureTableExists(tableId);
+    await this.prisma.table.delete({ where: { id: tableId } });
+  }
+
+  async createColumn(tableId: string, input: CreateColumnInput) {
+    await this.ensureTableExists(tableId);
+
+    const column = await this.prisma.$transaction(async (tx) => {
+      const order =
+        typeof input.order === "number"
+          ? input.order
+          : await tx.tableColumn.count({ where: { tableId } });
+
+      const created = await tx.tableColumn.create({
+        data: {
+          tableId,
+          name: input.name,
+          type: input.type,
+          refTableId: input.refTableId ?? null,
+          formulaExpr: input.formulaExpr ?? null,
+          order
+        }
+      });
+
+      const existingRows = await tx.tableRow.findMany({ where: { tableId }, select: { id: true } });
+      for (const row of existingRows) {
+        await tx.tableCell.create({
+          data: {
+            rowId: row.id,
+            columnId: created.id,
+            valueJson: Prisma.JsonNull
+          }
+        });
+      }
+
+      await this.logAudit(tx, {
+        tableId,
+        columnId: created.id,
+        action: TableAuditAction.column_created,
+        userId: input.userId ?? undefined,
+        newValue: {
+          name: input.name,
+          type: input.type,
+          refTableId: input.refTableId ?? null,
+          formulaExpr: input.formulaExpr ?? null,
+          order: created.order
+        }
+      });
+
+      return created;
+    });
+
+    return column;
+  }
+
+  async updateColumn(columnId: string, input: UpdateColumnInput) {
+    const column = await this.prisma.tableColumn.findUnique({ where: { id: columnId } });
+    if (!column) {
+      throw new NotFoundException("Column not found");
+    }
+
+    await this.prisma.tableColumn.update({
+      where: { id: columnId },
+      data: {
+        name: input.name,
+        type: input.type,
+        refTableId: input.refTableId ?? null,
+        formulaExpr: input.formulaExpr ?? null,
+        order: input.order ?? column.order
+      }
+    });
+
+    await this.logAudit(this.prisma, {
+      tableId: column.tableId,
+      columnId,
+      action: TableAuditAction.column_updated,
+      userId: input.userId ?? undefined,
+      oldValue: column,
+      newValue: {
+        name: input.name ?? column.name,
+        type: input.type ?? column.type,
+        refTableId: input.refTableId ?? column.refTableId,
+        formulaExpr: input.formulaExpr ?? column.formulaExpr,
+        order: input.order ?? column.order
+      }
+    });
+  }
+
+  async deleteColumn(columnId: string, userId?: string | null) {
+    const column = await this.prisma.tableColumn.findUnique({ where: { id: columnId } });
+    if (!column) {
+      throw new NotFoundException("Column not found");
+    }
+
+    await this.prisma.tableColumn.delete({ where: { id: columnId } });
+
+    await this.logAudit(this.prisma, {
+      tableId: column.tableId,
+      columnId,
+      action: TableAuditAction.column_deleted,
+      userId: userId ?? undefined,
+      oldValue: column
+    });
+  }
+
+  async reorderColumns(tableId: string, input: ReorderColumnsInput) {
+    const existing = await this.prisma.tableColumn.findMany({ where: { tableId } });
+    const existingIds = new Set(existing.map((column) => column.id));
+
+    for (const id of input.columnIds) {
+      if (!existingIds.has(id)) {
+        throw new BadRequestException(`Column ${id} does not belong to table ${tableId}`);
+      }
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const [order, id] of input.columnIds.entries()) {
+        await tx.tableColumn.update({ where: { id }, data: { order } });
+      }
+
+      await this.logAudit(tx, {
+        tableId,
+        action: TableAuditAction.column_updated,
+        userId: input.userId ?? undefined,
+        newValue: { order: input.columnIds }
+      });
+    });
+  }
+
+  async createRow(tableId: string, input: CreateRowInput) {
+    await this.ensureTableExists(tableId);
+
+    const rowValues = input.values ?? {};
+    const columns = await this.prisma.tableColumn.findMany({ where: { tableId }, select: { id: true } });
+    const columnIds = new Set(columns.map((column) => column.id));
+    const invalidKeys = Object.keys(rowValues).filter((key) => !columnIds.has(key));
+    if (invalidKeys.length) {
+      throw new BadRequestException(`Invalid column ids: ${invalidKeys.join(", ")}`);
+    }
+
+    const rowId = await this.prisma.$transaction(async (tx) => {
+      const order =
+        typeof input.order === "number"
+          ? input.order
+          : await tx.tableRow.count({ where: { tableId } });
+
+      const row = await tx.tableRow.create({ data: { tableId, order } });
+      await this.upsertRowCells(tx, tableId, row.id, rowValues);
+
+      await this.logAudit(tx, {
+        tableId,
+        rowId: row.id,
+        action: TableAuditAction.row_created,
+        userId: input.userId ?? undefined,
+        newValue: input.values
+      });
+
+      return row.id;
+    });
+
+    return this.getRow(rowId);
+  }
+
+  async updateRow(rowId: string, input: UpdateRowInput) {
+    const row = await this.prisma.tableRow.findUnique({ where: { id: rowId }, include: { table: true } });
+    if (!row) {
+      throw new NotFoundException("Row not found");
+    }
+
+    const rowValues = input.values ?? {};
+    const columns = await this.prisma.tableColumn.findMany({ where: { tableId: row.tableId }, select: { id: true } });
+    const columnIds = new Set(columns.map((column) => column.id));
+    const invalidKeys = Object.keys(rowValues).filter((key) => !columnIds.has(key));
+    if (invalidKeys.length) {
+      throw new BadRequestException(`Invalid column ids: ${invalidKeys.join(", ")}`);
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      const before = await tx.tableCell.findMany({ where: { rowId } });
+      await this.upsertRowCells(tx, row.tableId, rowId, rowValues);
+      const after = await tx.tableCell.findMany({ where: { rowId } });
+
+      const changedCells: Array<{ columnId: string; oldValue: Prisma.JsonValue | null; newValue: Prisma.JsonValue | null }> = [];
+
+      const afterMap = new Map(after.map((cell) => [cell.columnId, cell.valueJson]));
+      for (const cell of before) {
+        const nextValue = afterMap.get(cell.columnId);
+        if (!this.areJsonValuesEqual(cell.valueJson, nextValue)) {
+          changedCells.push({ columnId: cell.columnId, oldValue: cell.valueJson, newValue: nextValue ?? Prisma.JsonNull });
+        }
+      }
+
+      for (const change of changedCells) {
+        await this.logAudit(tx, {
+          tableId: row.tableId,
+          rowId,
+          columnId: change.columnId,
+          action: TableAuditAction.cell_updated,
+          userId: input.userId ?? undefined,
+          oldValue: change.oldValue ?? Prisma.JsonNull,
+          newValue: change.newValue ?? Prisma.JsonNull
+        });
+      }
+
+      await this.logAudit(tx, {
+        tableId: row.tableId,
+        rowId,
+        action: TableAuditAction.row_updated,
+        userId: input.userId ?? undefined,
+        newValue: rowValues
+      });
+    });
+
+    return this.getRow(rowId);
+  }
+
+  async deleteRow(rowId: string, userId?: string | null) {
+    const row = await this.prisma.tableRow.findUnique({ where: { id: rowId } });
+    if (!row) {
+      throw new NotFoundException("Row not found");
+    }
+
+    await this.prisma.tableRow.delete({ where: { id: rowId } });
+
+    await this.logAudit(this.prisma, {
+      tableId: row.tableId,
+      rowId,
+      action: TableAuditAction.row_deleted,
+      userId: userId ?? undefined
+    });
+  }
+
+  async reorderRows(tableId: string, input: ReorderRowsInput) {
+    const existing = await this.prisma.tableRow.findMany({ where: { tableId } });
+    const existingIds = new Set(existing.map((row) => row.id));
+
+    for (const rowId of input.rowIds) {
+      if (!existingIds.has(rowId)) {
+        throw new BadRequestException(`Row ${rowId} does not belong to table ${tableId}`);
+      }
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const [order, id] of input.rowIds.entries()) {
+        await tx.tableRow.update({ where: { id }, data: { order } });
+      }
+
+      await this.logAudit(tx, {
+        tableId,
+        action: TableAuditAction.row_updated,
+        userId: input.userId ?? undefined,
+        newValue: { order: input.rowIds }
+      });
+    });
+  }
+
+  async listViews(tableId: string) {
+    await this.ensureTableExists(tableId);
+    return this.prisma.tableView.findMany({ where: { tableId }, orderBy: { createdAt: "asc" } });
+  }
+
+  async createView(tableId: string, input: CreateViewInput) {
+    await this.ensureTableExists(tableId);
+    return this.prisma.tableView.create({
+      data: {
+        tableId,
+        userId: input.userId,
+        name: input.name,
+        configJson: input.configJson
+      }
+    });
+  }
+
+  async updateView(viewId: string, input: UpdateViewInput) {
+    const view = await this.prisma.tableView.findUnique({ where: { id: viewId } });
+    if (!view) {
+      throw new NotFoundException("View not found");
+    }
+
+    return this.prisma.tableView.update({
+      where: { id: viewId },
+      data: {
+        name: input.name ?? view.name,
+        configJson: input.configJson ?? view.configJson
+      }
+    });
+  }
+
+  async deleteView(viewId: string) {
+    const view = await this.prisma.tableView.findUnique({ where: { id: viewId } });
+    if (!view) {
+      throw new NotFoundException("View not found");
+    }
+
+    await this.prisma.tableView.delete({ where: { id: viewId } });
+  }
+
+  async listPermissions(tableId: string) {
+    await this.ensureTableExists(tableId);
+    return this.prisma.tablePermission.findMany({ where: { tableId } });
+  }
+
+  async setPermissions(tableId: string, permissions: UpsertPermissionInput[]) {
+    await this.ensureTableExists(tableId);
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.tablePermission.deleteMany({ where: { tableId } });
+
+      if (!permissions.length) {
+        return;
+      }
+
+      const rowIds = permissions.filter((item) => item.rowId).map((item) => item.rowId as string);
+      const columnIds = permissions.filter((item) => item.columnId).map((item) => item.columnId as string);
+
+      if (rowIds.length) {
+        const rows = await tx.tableRow.findMany({ where: { id: { in: rowIds } } });
+        const missing = rowIds.filter((id) => !rows.some((row) => row.id === id));
+        if (missing.length) {
+          throw new BadRequestException(`Rows not found: ${missing.join(", ")}`);
+        }
+
+        const mismatched = rows.filter((row) => row.tableId !== tableId);
+        if (mismatched.length) {
+          throw new BadRequestException(
+            `Rows do not belong to table: ${mismatched.map((row) => row.id).join(", ")}`
+          );
+        }
+      }
+
+      if (columnIds.length) {
+        const columns = await tx.tableColumn.findMany({ where: { id: { in: columnIds } } });
+        const missing = columnIds.filter((id) => !columns.some((column) => column.id === id));
+        if (missing.length) {
+          throw new BadRequestException(`Columns not found: ${missing.join(", ")}`);
+        }
+
+        const mismatched = columns.filter((column) => column.tableId !== tableId);
+        if (mismatched.length) {
+          throw new BadRequestException(
+            `Columns do not belong to table: ${mismatched.map((column) => column.id).join(", ")}`
+          );
+        }
+      }
+
+      await tx.tablePermission.createMany({
+        data: permissions.map((permission) => ({
+          tableId,
+          role: permission.role,
+          rowId: permission.rowId ?? null,
+          columnId: permission.columnId ?? null,
+          canRead: permission.canRead,
+          canWrite: permission.canWrite
+        }))
+      });
+    });
+
+    return this.listPermissions(tableId);
+  }
+
+  async getHistory(tableId: string, filters: { rowId?: string; columnId?: string; limit?: number }) {
+    await this.ensureTableExists(tableId);
+
+    const history = await this.prisma.tableAudit.findMany({
+      where: {
+        tableId,
+        rowId: filters.rowId,
+        columnId: filters.columnId
+      },
+      orderBy: { createdAt: "desc" },
+      take: filters.limit ?? 200
+    });
+
+    return history;
+  }
+
+  async listForms(tableId: string) {
+    await this.ensureTableExists(tableId);
+    return this.prisma.form.findMany({ where: { tableId }, orderBy: { createdAt: "desc" } });
+  }
+
+  async createForm(tableId: string, input: CreateFormInput) {
+    await this.ensureTableExists(tableId);
+
+    return this.prisma.form.create({
+      data: {
+        tableId,
+        name: input.name,
+        configJson: input.configJson,
+        isPublic: Boolean(input.isPublic)
+      }
+    });
+  }
+
+  async getForm(formId: string) {
+    const form = await this.prisma.form.findUnique({ where: { id: formId } });
+    if (!form) {
+      throw new NotFoundException("Form not found");
+    }
+
+    return form;
+  }
+
+  async submitForm(formId: string, input: SubmitFormInput) {
+    const form = await this.prisma.form.findUnique({
+      where: { id: formId },
+      include: {
+        table: {
+          include: {
+            columns: { orderBy: { order: "asc" } }
+          }
+        }
+      }
+    });
+
+    if (!form) {
+      throw new NotFoundException("Form not found");
+    }
+
+    if (!form.isPublic && !input.actorId) {
+      throw new ForbiddenException("Authentication required to submit this form");
+    }
+
+    const rowValues: Record<string, unknown> = {};
+    for (const column of form.table.columns) {
+      if (Object.prototype.hasOwnProperty.call(input.values, column.id)) {
+        rowValues[column.id] = input.values[column.id];
+      }
+    }
+
+    const row = await this.createRow(form.tableId, {
+      values: rowValues,
+      userId: input.actorId
+    });
+
+    await this.logAudit(this.prisma, {
+      tableId: form.tableId,
+      rowId: row.id,
+      action: TableAuditAction.form_submitted,
+      userId: input.actorId ?? undefined,
+      newValue: { formId }
+    });
+
+    return row;
+  }
+
+  private async ensureTableExists(tableId: string) {
+    const exists = await this.prisma.table.findUnique({ where: { id: tableId }, select: { id: true } });
+    if (!exists) {
+      throw new NotFoundException("Table not found");
+    }
+  }
+
+  private serializeTable(table: TableWithRelations) {
+    return {
+      id: table.id,
+      orgId: table.orgId,
+      name: table.name,
+      createdAt: table.createdAt,
+      columns: table.columns
+        .sort((a, b) => a.order - b.order)
+        .map((column) => ({
+          id: column.id,
+          tableId: column.tableId,
+          name: column.name,
+          type: column.type,
+          refTableId: column.refTableId,
+          formulaExpr: column.formulaExpr,
+          order: column.order
+        })),
+      rows: table.rows
+        .sort((a, b) => a.order - b.order)
+        .map((row) => this.serializeRow(row, table.columns)),
+      views: table.views,
+      permissions: table.permissions,
+      forms: table.forms
+    };
+  }
+
+  private serializeRow(row: RowWithCells, columns: TableWithRelations["columns"]) {
+    const cellMap: Record<string, unknown> = {};
+    for (const cell of row.cells) {
+      cellMap[cell.columnId] = cell.valueJson;
+    }
+
+    for (const column of columns) {
+      if (!(column.id in cellMap)) {
+        cellMap[column.id] = Prisma.JsonNull;
+      }
+    }
+
+    return {
+      id: row.id,
+      tableId: row.tableId,
+      order: row.order,
+      createdAt: row.createdAt,
+      values: cellMap
+    };
+  }
+
+  private async getRow(rowId: string) {
+    const row = await this.prisma.tableRow.findUnique({
+      where: { id: rowId },
+      include: { cells: true, table: { include: { columns: true } } }
+    });
+
+    if (!row) {
+      throw new NotFoundException("Row not found");
+    }
+
+    return {
+      id: row.id,
+      tableId: row.tableId,
+      order: row.order,
+      createdAt: row.createdAt,
+      values: row.cells.reduce<Record<string, unknown>>((acc, cell) => {
+        acc[cell.columnId] = cell.valueJson;
+        return acc;
+      }, {})
+    };
+  }
+
+  private async upsertRowCells(
+    client: PrismaClientLike,
+    tableId: string,
+    rowId: string,
+    values: Record<string, unknown>
+  ) {
+    const columns = await client.tableColumn.findMany({
+      where: { tableId },
+      orderBy: { order: "asc" }
+    });
+
+    for (const column of columns) {
+      const value = Object.prototype.hasOwnProperty.call(values, column.id)
+        ? (values[column.id] as Prisma.JsonValue)
+        : Prisma.JsonNull;
+
+      const existing = await client.tableCell.findFirst({
+        where: {
+          rowId,
+          columnId: column.id
+        }
+      });
+
+      if (existing) {
+        await client.tableCell.update({
+          where: { id: existing.id },
+          data: { valueJson: value }
+        });
+      } else {
+        await client.tableCell.create({
+          data: {
+            rowId,
+            columnId: column.id,
+            valueJson: value
+          }
+        });
+      }
+    }
+  }
+
+  private async logAudit(
+    client: PrismaClientLike | PrismaService,
+    entry: {
+      tableId: string;
+      action: TableAuditAction;
+      rowId?: string;
+      columnId?: string;
+      userId?: string;
+      oldValue?: Prisma.JsonValue | null;
+      newValue?: Prisma.JsonValue | null;
+    }
+  ) {
+    await client.tableAudit.create({
+      data: {
+        tableId: entry.tableId,
+        rowId: entry.rowId ?? null,
+        columnId: entry.columnId ?? null,
+        userId: entry.userId ?? null,
+        action: entry.action,
+        oldValue: entry.oldValue ?? Prisma.JsonNull,
+        newValue: entry.newValue ?? Prisma.JsonNull
+      }
+    });
+  }
+
+  private areJsonValuesEqual(a: Prisma.JsonValue | null | undefined, b: Prisma.JsonValue | null | undefined) {
+    return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+  }
+}

--- a/apps/frontend/app/tables/[id]/page.tsx
+++ b/apps/frontend/app/tables/[id]/page.tsx
@@ -1,0 +1,21 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { TableWorkspace } from "@/components/tables/table-workspace";
+import { authOptions } from "@/lib/auth-options";
+
+interface TablePageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default async function TablePage({ params }: TablePageProps) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  return <TableWorkspace tableId={params.id} />;
+}

--- a/apps/frontend/app/tables/page.tsx
+++ b/apps/frontend/app/tables/page.tsx
@@ -1,0 +1,15 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { TableWorkspace } from "@/components/tables/table-workspace";
+import { authOptions } from "@/lib/auth-options";
+
+export default async function TablesIndexPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  return <TableWorkspace tableId="" />;
+}

--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Loader2, ShieldOff, Sparkles } from "lucide-react";
@@ -254,7 +255,17 @@ export function DashboardView({ role }: DashboardViewProps) {
           description="Track contracts, SLAs and incident load across properties"
           action={
             role === "admin" ? (
-              <p className="text-xs text-muted-foreground">Admins can add, edit or delete records directly in this table.</p>
+              <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                <span>Admins can add, edit or delete records directly in this table.</span>
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="h-8 rounded-full border-border/70 px-3"
+                >
+                  <Link href="/tables">Open as table</Link>
+                </Button>
+              </div>
             ) : (
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Sparkles className="h-4 w-4" />

--- a/apps/frontend/components/data-table/data-table.tsx
+++ b/apps/frontend/components/data-table/data-table.tsx
@@ -37,7 +37,8 @@ import {
   type VisibilityState,
   useReactTable
 } from "@tanstack/react-table";
-import { useEffect, useMemo, useState } from "react";
+import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -61,6 +62,10 @@ interface DataTableProps<TData extends { id: string }> {
   persistenceEnabled?: boolean;
   onDataChange?: (rows: TData[]) => void;
   meta?: TableMeta<TData>;
+  enableVirtualizedRows?: boolean;
+  virtualizationThreshold?: number;
+  virtualizedContainerHeight?: number;
+  virtualizationOverscan?: number;
 }
 
 function defaultColumnId<TData>(column: ColumnDef<TData, unknown>, index: number) {
@@ -100,7 +105,11 @@ export function DataTable<TData extends { id: string }>({
   className,
   persistenceEnabled = true,
   onDataChange,
-  meta
+  meta,
+  enableVirtualizedRows = false,
+  virtualizationThreshold = 200,
+  virtualizedContainerHeight = 560,
+  virtualizationOverscan = 12
 }: DataTableProps<TData>) {
   const selectionColumn = useMemo<ColumnDef<TData, unknown>>(
     () => ({
@@ -154,6 +163,7 @@ export function DataTable<TData extends { id: string }>({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnPinning, setColumnPinning] = useState<ColumnPinningState>({});
   const [tableData, setTableData] = useState<TData[]>(data);
+  const tableScrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setColumnOrder(layout.columnOrder);
@@ -259,6 +269,31 @@ export function DataTable<TData extends { id: string }>({
     }
   });
 
+  const tableRows = table.getRowModel().rows;
+  const shouldVirtualize =
+    enableVirtualizedRows && tableRows.length > 0 && tableRows.length >= virtualizationThreshold;
+  const rowVirtualizer = useVirtualizer({
+    count: tableRows.length,
+    getScrollElement: () => tableScrollRef.current,
+    estimateSize: () => (density === "compact" ? 40 : 56),
+    overscan: virtualizationOverscan,
+    enabled: shouldVirtualize
+  });
+  const tableClassName = useMemo(
+    () => cn("min-w-full text-left", densityToRowClass[density]),
+    [density]
+  );
+  const noDataRow = (
+    <tr>
+      <td
+        colSpan={table.getAllLeafColumns().length}
+        className="px-6 py-12 text-center text-sm text-muted-foreground"
+      >
+        No data found. Adjust your filters or add new records.
+      </td>
+    </tr>
+  );
+
   return (
     <div className={cn("space-y-4", className)}>
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -301,40 +336,51 @@ export function DataTable<TData extends { id: string }>({
           </Button>
         </div>
       </div>
-      <div className="overflow-x-auto rounded-2xl border border-border/60 bg-card">
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleColumnDragEnd}>
-          <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
-            <table className={cn("min-w-full text-left", densityToRowClass[density])}>
-              <thead className="bg-card-contrast/60 text-xs uppercase tracking-wide text-muted-foreground">
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <SortableColumnHeader key={header.id} header={header} />
-                    ))}
-                  </tr>
-                ))}
-              </thead>
-              <DndContext sensors={rowSensors} collisionDetection={closestCenter} onDragEnd={handleRowDragEnd}>
-                <tbody>
-                  <SortableContext items={table.getRowModel().rows.map((row) => row.id)} strategy={verticalListSortingStrategy}>
-                    {table.getRowModel().rows.length === 0 ? (
-                      <tr>
-                        <td
-                          colSpan={table.getAllLeafColumns().length}
-                          className="px-6 py-12 text-center text-sm text-muted-foreground"
-                        >
-                          No data found. Adjust your filters or add new records.
-                        </td>
-                      </tr>
-                    ) : (
-                      table.getRowModel().rows.map((row) => <SortableRow key={row.id} row={row} />)
-                    )}
-                  </SortableContext>
-                </tbody>
-              </DndContext>
-            </table>
-          </SortableContext>
-        </DndContext>
+      <div className="overflow-hidden rounded-2xl border border-border/60 bg-card">
+        <div
+          ref={tableScrollRef}
+          className="w-full overflow-auto"
+          style={shouldVirtualize ? { maxHeight: virtualizedContainerHeight } : undefined}
+        >
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleColumnDragEnd}>
+            <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
+              <table className={tableClassName}>
+                <thead className="bg-card-contrast/60 text-xs uppercase tracking-wide text-muted-foreground">
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <SortableColumnHeader key={header.id} header={header} />
+                      ))}
+                    </tr>
+                  ))}
+                </thead>
+                {shouldVirtualize ? (
+                  <tbody
+                    style={{
+                      height: rowVirtualizer.getTotalSize(),
+                      position: "relative"
+                    }}
+                  >
+                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                      const row = tableRows[virtualRow.index];
+                      return <VirtualizedRow key={row.id} row={row} virtualRow={virtualRow} />;
+                    })}
+                  </tbody>
+                ) : (
+                  <DndContext sensors={rowSensors} collisionDetection={closestCenter} onDragEnd={handleRowDragEnd}>
+                    <tbody>
+                      <SortableContext items={tableRows.map((row) => row.id)} strategy={verticalListSortingStrategy}>
+                        {tableRows.length === 0
+                          ? noDataRow
+                          : tableRows.map((row) => <SortableRow key={row.id} row={row} />)}
+                      </SortableContext>
+                    </tbody>
+                  </DndContext>
+                )}
+              </table>
+            </SortableContext>
+          </DndContext>
+        </div>
       </div>
     </div>
   );
@@ -427,6 +473,41 @@ function SortableRow<TData>({ row }: SortableRowProps<TData>) {
             ) : (
               flexRender(cell.column.columnDef.cell, cell.getContext())
             )}
+          </td>
+        );
+      })}
+    </tr>
+  );
+}
+
+interface VirtualizedRowProps<TData> {
+  row: ReturnType<Table<TData>["getRowModel"]>["rows"][number];
+  virtualRow: VirtualItem;
+}
+
+function VirtualizedRow<TData>({ row, virtualRow }: VirtualizedRowProps<TData>) {
+  return (
+    <tr
+      data-index={virtualRow.index}
+      ref={(node) => {
+        if (node) {
+          virtualRow.measureElement?.(node);
+        }
+      }}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        transform: `translateY(${virtualRow.start}px)`
+      }}
+      className="border-b border-border/40 text-sm text-foreground transition hover:bg-card-contrast/40"
+    >
+      {row.getVisibleCells().map((cell) => {
+        const isSelectionCell = cell.column.id === "__select";
+        return (
+          <td key={cell.id} className={cn("px-4", isSelectionCell ? "w-[52px]" : "py-3")}>
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </td>
         );
       })}

--- a/apps/frontend/components/tables/table-workspace.tsx
+++ b/apps/frontend/components/tables/table-workspace.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { DataTable } from "@/components/data-table/data-table";
+import type { EditableCellMeta } from "@/components/data-table/editable-cell";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useDashboardState } from "@/lib/dashboard-state";
+import { cn } from "@/lib/utils";
+
+type WorkspaceRow = {
+  id: string;
+} & Record<string, string>;
+
+interface TableWorkspaceProps {
+  tableId: string;
+}
+
+export function TableWorkspace({ tableId }: TableWorkspaceProps) {
+  const router = useRouter();
+  const {
+    state,
+    createTable,
+    deleteTable,
+    addTableRow,
+    removeTableRow,
+    updateTableDetails,
+    addTableColumn,
+    removeTableColumn,
+    replaceTableRows
+  } = useDashboardState();
+
+  const knownTableIdsRef = useRef(new Set(state.tables.map((table) => table.id)));
+  useEffect(() => {
+    const known = knownTableIdsRef.current;
+    const newTables = state.tables.filter((entry) => !known.has(entry.id));
+    if (newTables.length > 0) {
+      knownTableIdsRef.current = new Set(state.tables.map((entry) => entry.id));
+      router.replace(`/tables/${newTables[0].id}`);
+      return;
+    }
+
+    knownTableIdsRef.current = new Set(state.tables.map((entry) => entry.id));
+  }, [router, state.tables]);
+
+  const resolvedTable = useMemo(
+    () => state.tables.find((entry) => entry.id === tableId),
+    [state.tables, tableId]
+  );
+  const table = resolvedTable ?? state.tables[0];
+
+  useEffect(() => {
+    if (!resolvedTable && state.tables.length > 0 && state.tables[0].id !== tableId) {
+      router.replace(`/tables/${state.tables[0].id}`);
+    }
+  }, [resolvedTable, router, state.tables, tableId]);
+
+  const [search, setSearch] = useState("");
+  const [newTableName, setNewTableName] = useState("");
+  const [newTableColumns, setNewTableColumns] = useState("Name, Status");
+  const [newColumnName, setNewColumnName] = useState("");
+  const [draftName, setDraftName] = useState(table?.name ?? "");
+  const [draftDescription, setDraftDescription] = useState(table?.description ?? "");
+
+  useEffect(() => {
+    setDraftName(table?.name ?? "");
+    setDraftDescription(table?.description ?? "");
+  }, [table?.description, table?.id, table?.name]);
+
+  const filteredTables = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return state.tables;
+    }
+    return state.tables.filter((entry) => entry.name.toLowerCase().includes(query));
+  }, [search, state.tables]);
+
+  const workspaceColumns = useMemo<ColumnDef<WorkspaceRow, unknown>[]>(() => {
+    if (!table) {
+      return [];
+    }
+
+    return table.columns.map((columnName, index) => ({
+      accessorKey: `column_${index}`,
+      id: `column_${index}`,
+      header: columnName || `Column ${index + 1}`,
+      meta: {
+        editable: true,
+        placeholder: columnName || `Column ${index + 1}`
+      } satisfies EditableCellMeta<WorkspaceRow>
+    }));
+  }, [table]);
+
+  const workspaceRows = useMemo<WorkspaceRow[]>(() => {
+    if (!table) {
+      return [];
+    }
+
+    return table.rows.map((row, rowIndex) => {
+      const record: WorkspaceRow = { id: `${table.id}-${rowIndex}` };
+      table.columns.forEach((_, columnIndex) => {
+        record[`column_${columnIndex}`] = row[columnIndex] ?? "";
+      });
+      return record;
+    });
+  }, [table]);
+
+  const handleCreateTable = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const name = newTableName.trim();
+    if (!name) {
+      return;
+    }
+
+    const columns = newTableColumns
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    createTable({
+      name,
+      columns: columns.length > 0 ? columns : ["Name", "Status"],
+      description: ""
+    });
+    setNewTableName("");
+    setNewTableColumns("Name, Status");
+  };
+
+  const handleDeleteTable = () => {
+    if (!table) {
+      return;
+    }
+    deleteTable(table.id);
+  };
+
+  const handleAddRow = () => {
+    if (!table) {
+      return;
+    }
+    addTableRow(table.id, new Array(table.columns.length).fill(""));
+  };
+
+  const handleRemoveRow = () => {
+    if (!table || table.rows.length === 0) {
+      return;
+    }
+    removeTableRow(table.id, table.rows.length - 1);
+  };
+
+  const handleAddColumn = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!table) {
+      return;
+    }
+
+    const name = newColumnName.trim() || `Column ${table.columns.length + 1}`;
+    addTableColumn(table.id, { name });
+    setNewColumnName("");
+  };
+
+  const handleRenameTable = () => {
+    if (!table) {
+      return;
+    }
+    updateTableDetails(table.id, { name: draftName });
+  };
+
+  const handleUpdateDescription = () => {
+    if (!table) {
+      return;
+    }
+    updateTableDetails(table.id, { description: draftDescription });
+  };
+
+  const handleRowsChange = (rows: WorkspaceRow[]) => {
+    if (!table) {
+      return;
+    }
+    const normalized = rows.map((row) =>
+      table.columns.map((_, index) => row[`column_${index}`] ?? "")
+    );
+    replaceTableRows(table.id, normalized);
+  };
+
+  if (!table) {
+    return (
+      <div className="flex flex-col items-center gap-6 rounded-2xl border border-dashed border-border/70 bg-card/40 p-10 text-center">
+        <div className="max-w-md space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Create your first table</h2>
+          <p className="text-sm text-muted-foreground">
+            Tables let you capture workflows, audit updates, and collaborate with your team in real time.
+            Start by defining the columns you need and invite others to contribute.
+          </p>
+        </div>
+        <form onSubmit={handleCreateTable} className="flex w-full max-w-md flex-col gap-3">
+          <Input
+            value={newTableName}
+            onChange={(event) => setNewTableName(event.target.value)}
+            placeholder="Table name"
+            required
+          />
+          <Input
+            value={newTableColumns}
+            onChange={(event) => setNewTableColumns(event.target.value)}
+            placeholder="Columns (comma separated)"
+          />
+          <Button type="submit">Create table</Button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 md:flex-row">
+      <aside className="w-full rounded-2xl border border-border/60 bg-card p-4 md:w-72">
+        <form onSubmit={handleCreateTable} className="space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">New table</h2>
+            <p className="text-xs text-muted-foreground/80">Name your dataset and choose starter columns.</p>
+          </div>
+          <Input
+            value={newTableName}
+            onChange={(event) => setNewTableName(event.target.value)}
+            placeholder="Portfolio tracker"
+            required
+          />
+          <Input
+            value={newTableColumns}
+            onChange={(event) => setNewTableColumns(event.target.value)}
+            placeholder="Columns (comma separated)"
+          />
+          <Button type="submit" className="w-full">
+            + Create table
+          </Button>
+        </form>
+
+        <div className="mt-6 space-y-3">
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search tables"
+          />
+          <nav className="space-y-1">
+            {filteredTables.length === 0 ? (
+              <p className="rounded-lg bg-card-contrast/40 px-3 py-2 text-xs text-muted-foreground">
+                No tables match your search.
+              </p>
+            ) : (
+              filteredTables.map((entry) => (
+                <Link
+                  key={entry.id}
+                  href={`/tables/${entry.id}`}
+                  className={cn(
+                    "flex items-center justify-between rounded-xl px-3 py-2 text-sm transition",
+                    entry.id === table.id
+                      ? "bg-primary/10 text-primary-foreground shadow"
+                      : "text-muted-foreground hover:bg-card-contrast/50 hover:text-foreground"
+                  )}
+                >
+                  <span className="truncate">{entry.name}</span>
+                  <span className="text-xs text-muted-foreground">{entry.columns.length} cols</span>
+                </Link>
+              ))
+            )}
+          </nav>
+        </div>
+      </aside>
+
+      <main className="flex-1 space-y-8">
+        <header className="space-y-4 rounded-2xl border border-border/60 bg-card p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="flex-1 space-y-3">
+              <div>
+                <label className="text-xs font-medium uppercase text-muted-foreground" htmlFor="table-name">
+                  Table name
+                </label>
+                <Input
+                  id="table-name"
+                  value={draftName}
+                  onChange={(event) => setDraftName(event.target.value)}
+                  onBlur={handleRenameTable}
+                  placeholder="Team workspace"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium uppercase text-muted-foreground" htmlFor="table-description">
+                  Description
+                </label>
+                <textarea
+                  id="table-description"
+                  value={draftDescription}
+                  onChange={(event) => setDraftDescription(event.target.value)}
+                  onBlur={handleUpdateDescription}
+                  placeholder="Summarize what this dataset tracks"
+                  className="mt-1 w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  rows={2}
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleAddRow}>
+                Add row
+              </Button>
+              <Button variant="outline" onClick={handleRemoveRow} disabled={table.rows.length === 0}>
+                Remove row
+              </Button>
+              <Button variant="destructive" onClick={handleDeleteTable}>
+                Delete table
+              </Button>
+            </div>
+          </div>
+        </header>
+
+        <section className="rounded-2xl border border-border/60 bg-card p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Columns</h3>
+              <p className="text-xs text-muted-foreground">Reorder columns inside the grid or add new fields here.</p>
+            </div>
+            <form onSubmit={handleAddColumn} className="flex w-full max-w-sm items-center gap-2 md:w-auto">
+              <Input
+                value={newColumnName}
+                onChange={(event) => setNewColumnName(event.target.value)}
+                placeholder="Column label"
+              />
+              <Button type="submit" variant="secondary">
+                + Add column
+              </Button>
+            </form>
+          </div>
+          <ul className="mt-4 grid gap-2 md:grid-cols-2">
+            {table.columns.map((columnName, index) => (
+              <li
+                key={columnName + index.toString()}
+                className="flex items-center justify-between rounded-xl border border-border/60 bg-card-contrast/40 px-3 py-2 text-sm"
+              >
+                <span className="truncate font-medium text-foreground">{columnName || `Column ${index + 1}`}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-xs text-muted-foreground hover:text-destructive"
+                  onClick={() => removeTableColumn(table.id, index)}
+                  disabled={table.columns.length <= 1}
+                >
+                  Remove
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="rounded-2xl border border-border/60 bg-card p-4 shadow-sm">
+          <DataTable
+            columns={workspaceColumns}
+            data={workspaceRows}
+            storageKey={`astalla:workspace:${table.id}`}
+            onDataChange={handleRowsChange}
+            persistenceEnabled={true}
+            enableVirtualizedRows
+            virtualizationThreshold={100}
+            virtualizedContainerHeight={600}
+          />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/frontend/lib/dashboard-state.ts
+++ b/apps/frontend/lib/dashboard-state.ts
@@ -328,6 +328,115 @@ export function useDashboardState() {
     }));
   }, []);
 
+  const updateTableDetails = useCallback((tableId: string, patch: { name?: string; description?: string }) => {
+    setState((previous) => ({
+      ...previous,
+      tables: previous.tables.map((table) => {
+        if (table.id !== tableId) {
+          return table;
+        }
+
+        const timestamp = new Date().toISOString();
+        const nextName = patch.name?.trim() ? patch.name : table.name;
+        const nextDescription =
+          patch.description !== undefined
+            ? patch.description?.trim()
+              ? patch.description
+              : undefined
+            : table.description;
+
+        return {
+          ...table,
+          name: nextName,
+          description: nextDescription,
+          updatedAt: timestamp
+        };
+      })
+    }));
+  }, []);
+
+  const addTableColumn = useCallback(
+    (tableId: string, column: { name: string; index?: number }) => {
+      setState((previous) => ({
+        ...previous,
+        tables: previous.tables.map((table) => {
+          if (table.id !== tableId) {
+            return table;
+          }
+
+          const timestamp = new Date().toISOString();
+          const insertIndex = Math.min(
+            Math.max(column.index ?? table.columns.length, 0),
+            table.columns.length
+          );
+          const nextColumns = [...table.columns];
+          nextColumns.splice(insertIndex, 0, column.name);
+          const nextRows = table.rows.map((row) => {
+            const copy = [...row];
+            copy.splice(insertIndex, 0, "");
+            return copy;
+          });
+
+          return {
+            ...table,
+            columns: nextColumns,
+            rows: nextRows,
+            updatedAt: timestamp
+          };
+        })
+      }));
+    },
+    []
+  );
+
+  const removeTableColumn = useCallback((tableId: string, columnIndex: number) => {
+    setState((previous) => ({
+      ...previous,
+      tables: previous.tables.map((table) => {
+        if (table.id !== tableId) {
+          return table;
+        }
+
+        if (columnIndex < 0 || columnIndex >= table.columns.length) {
+          return table;
+        }
+
+        const timestamp = new Date().toISOString();
+        const nextColumns = table.columns.filter((_, index) => index !== columnIndex);
+        const nextRows = table.rows.map((row) => row.filter((_, index) => index !== columnIndex));
+
+        return {
+          ...table,
+          columns: nextColumns,
+          rows: nextRows,
+          updatedAt: timestamp
+        };
+      })
+    }));
+  }, []);
+
+  const replaceTableRows = useCallback((tableId: string, rows: string[][]) => {
+    setState((previous) => ({
+      ...previous,
+      tables: previous.tables.map((table) => {
+        if (table.id !== tableId) {
+          return table;
+        }
+
+        const timestamp = new Date().toISOString();
+        const normalized = rows.map((row) =>
+          table.columns.map((_, index) => (typeof row[index] === "string" ? row[index] : ""))
+        );
+
+        return {
+          ...table,
+          rows: normalized,
+          updatedAt: timestamp
+        };
+      })
+    }));
+  }, []);
+
   const clearAll = useCallback(() => {
     setState(createDefaultState());
 
@@ -351,6 +460,10 @@ export function useDashboardState() {
       deleteTable,
       addTableRow,
       removeTableRow,
+      updateTableDetails,
+      addTableColumn,
+      removeTableColumn,
+      replaceTableRows,
       clearAll
     }),
     [
@@ -363,6 +476,10 @@ export function useDashboardState() {
       deleteTable,
       addTableRow,
       removeTableRow,
+      updateTableDetails,
+      addTableColumn,
+      removeTableColumn,
+      replaceTableRows,
       clearAll
     ]
   );

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.59.8",
     "@tanstack/react-query-devtools": "^5.59.8",
     "@tanstack/react-table": "^8.20.5",
+    "@tanstack/react-virtual": "^3.8.7",
     "autoprefixer": "^10.4.19",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- expand the Prisma data model with per-cell audit logging, role-aware permissions, public forms, and CRDT snapshots to support collaborative tables
- add a dedicated NestJS tables module exposing CRUD endpoints, history queries, Yjs websocket collaboration, and form submission APIs
- enhance the dashboard table experience with row virtualization, a multi-table workspace UI, and deep links from the portfolio widget to the new tables area

## Testing
- pnpm install *(fails: npm registry returned 403; credentials required in this environment)*
- pnpm --filter apps-backend prisma format *(fails: Prisma engine downloads blocked by 403; requires external network access)*

------
https://chatgpt.com/codex/tasks/task_e_68defa874f488322851eb5b035db9ecd