### PR TITLE
UI polish: contrast, empty states, responsive, table interactivity

### DIFF
--- a/apps/frontend/app/api/portfolio/reorder/route.ts
+++ b/apps/frontend/app/api/portfolio/reorder/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { reorderPortfolioRecords } from "@/lib/portfolio-store";
+
+export async function POST(request: Request) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.warn("Failed to parse portfolio reorder payload", error);
+  }
+
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    !("order" in payload) ||
+    !Array.isArray((payload as { order: unknown }).order)
+  ) {
+    return NextResponse.json({ message: "Invalid order payload" }, { status: 400 });
+  }
+
+  const orderUpdates = (payload as { order: Array<{ id: string; order: number }> }).order.filter(
+    (entry): entry is { id: string; order: number } =>
+      typeof entry?.id === "string" && typeof entry?.order === "number"
+  );
+
+  const rows = reorderPortfolioRecords(orderUpdates);
+  return NextResponse.json({ rows });
+}

--- a/apps/frontend/components/dashboard/dashboard-card.tsx
+++ b/apps/frontend/components/dashboard/dashboard-card.tsx
@@ -26,24 +26,24 @@ export function DashboardCard({
   return (
     <Card
       className={cn(
-        "rounded-3xl border border-border/80 bg-card text-card-foreground shadow-sm transition-all",
+        "rounded-3xl border border-border bg-card/95 text-card-foreground shadow-sm transition-all",
         "supports-[backdrop-filter]:bg-card/90 supports-[backdrop-filter]:backdrop-blur",
         "hover:shadow-md focus-within:shadow-md",
         className
       )}
     >
-      <div className={cn("flex flex-col", dense ? "p-5" : "p-6")}> 
+      <div className={cn("flex flex-col", dense ? "p-6" : "p-7")}>
         <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="space-y-1">
-            <h2 className="text-sm font-semibold tracking-tight text-foreground sm:text-base">{title}</h2>
+          <div className="space-y-1.5">
+            <h2 className="text-base font-semibold tracking-tight text-foreground sm:text-lg">{title}</h2>
             {description ? (
-              <p className="text-sm text-muted-foreground/90">{description}</p>
+              <p className="text-sm text-foreground/80">{description}</p>
             ) : null}
           </div>
           {action ? <div className="shrink-0 space-y-2 text-sm text-muted-foreground">{action}</div> : null}
         </div>
-        <Separator className="mt-4" />
-        <div className={cn("pt-4", dense ? "space-y-4" : "space-y-5", contentClassName)}>{children}</div>
+        <Separator className="mt-5 bg-border/80" />
+        <div className={cn("pt-5", dense ? "space-y-4" : "space-y-5", contentClassName)}>{children}</div>
       </div>
     </Card>
   );

--- a/apps/frontend/components/dashboard/dashboard-shell.tsx
+++ b/apps/frontend/components/dashboard/dashboard-shell.tsx
@@ -26,7 +26,7 @@ export default function DashboardShell({
     <div className="flex min-h-screen flex-col">
       <header className="px-6 pt-10">
         <div className="mx-auto w-full max-w-7xl">
-          <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-border/70 bg-panel/90 px-6 py-5 shadow-sm supports-[backdrop-filter]:backdrop-blur">
+          <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-border bg-panel/95 px-6 py-5 shadow-sm supports-[backdrop-filter]:backdrop-blur">
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/80">
                 {user.orgId ? user.orgId : "Astalla internal"}
@@ -60,8 +60,8 @@ export default function DashboardShell({
         </div>
       </header>
       <ScrollArea className="flex-1">
-        <main className="mx-auto w-full max-w-7xl px-6 pb-12 pt-10">
-          <div className="grid gap-6 pb-12">{children}</div>
+        <main className="mx-auto w-full max-w-7xl px-6 pb-16 pt-10">
+          <div className="flex flex-col gap-8 pb-12 sm:gap-9 lg:gap-10">{children}</div>
         </main>
       </ScrollArea>
     </div>

--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -1,15 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, ShieldOff, Sparkles } from "lucide-react";
 
 import { AlertsPanel } from "@/components/dashboard/alerts-panel";
 import DashboardShell from "@/components/dashboard/dashboard-shell";
 import { DashboardCard } from "@/components/dashboard/dashboard-card";
 import { MetricCard } from "@/components/dashboard/metric-card";
-import { PropertySelector, type PropertyOption, type TimeRangeValue } from "@/components/dashboard/property-selector";
+import {
+  PropertySelector,
+  type CreatePropertyPayload,
+  type PropertyOption,
+  type TimeRangeValue
+} from "@/components/dashboard/property-selector";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/lib/api-client";
@@ -17,6 +22,7 @@ import { formatCurrency, formatPercent } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
 import { OperationsTable } from "./operations-table";
+import type { PropertiesResponse } from "@shared/api";
 
 function resolveTrend(change?: number) {
   if (typeof change !== "number") {
@@ -38,19 +44,54 @@ interface DashboardViewProps {
 export function DashboardView({ role }: DashboardViewProps) {
   const [selectedProperty, setSelectedProperty] = useState<string | null>(null);
   const [timeRange, setTimeRange] = useState<TimeRangeValue>(30);
+  const queryClient = useQueryClient();
 
   const meQuery = useQuery({ queryKey: ["me"], queryFn: api.me });
   const propertiesQuery = useQuery({ queryKey: ["properties"], queryFn: api.properties });
 
-  useEffect(() => {
-    if (!selectedProperty && propertiesQuery.data?.properties?.length) {
-      setSelectedProperty(propertiesQuery.data.properties[0].id);
-    }
-  }, [propertiesQuery.data?.properties, selectedProperty]);
-
   const propertyOptions: PropertyOption[] = useMemo(() => {
     return propertiesQuery.data?.properties ?? [];
   }, [propertiesQuery.data?.properties]);
+
+  const handleCreateProperty = async (payload: CreatePropertyPayload): Promise<PropertyOption> => {
+    const normalizedCode = payload.code.trim().toUpperCase();
+    const baseId = normalizedCode.toLowerCase().replace(/[^a-z0-9]+/g, "-") || `property-${Date.now()}`;
+    const existingIds = new Set(propertyOptions.map((option) => option.id));
+    let candidate = baseId;
+    let increment = 1;
+    while (existingIds.has(candidate)) {
+      candidate = `${baseId}-${increment++}`;
+    }
+
+    const city = payload.city?.trim() || "—";
+    const state = payload.state?.trim()?.toUpperCase() || "—";
+
+    const created: PropertyOption = {
+      id: candidate,
+      name: payload.name.trim(),
+      city,
+      state
+    };
+
+    queryClient.setQueryData<PropertiesResponse | undefined>(["properties"], (previous) => {
+      const next = previous ?? { properties: [] };
+      return {
+        properties: [
+          ...next.properties,
+          {
+            id: created.id,
+            name: created.name,
+            city: created.city,
+            state: created.state,
+            propertyCode: normalizedCode,
+            region: state
+          }
+        ]
+      } satisfies PropertiesResponse;
+    });
+
+    return created;
+  };
 
   const metricsParams = useMemo(
     () => ({ propertyId: selectedProperty ?? undefined, window: timeRange }),
@@ -102,6 +143,8 @@ export function DashboardView({ role }: DashboardViewProps) {
   } as const;
 
   const selectedPropertyName = propertyOptions.find((option) => option.id === selectedProperty)?.name;
+  const hasProperties = propertyOptions.length > 0;
+  const shouldShowEmptyState = !selectedProperty || !hasProperties;
 
   return (
     <DashboardShell user={meQuery.data ?? fallbackUser} role={role}>
@@ -113,143 +156,185 @@ export function DashboardView({ role }: DashboardViewProps) {
           timeRange={timeRange}
           onTimeRangeChange={setTimeRange}
           disabled={propertiesQuery.isLoading}
+          onCreateProperty={handleCreateProperty}
         />
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-3">
-        <MetricCard
-          title="Average occupancy"
-          value={occupancyQuery.data ? formatPercent(occupancyQuery.data.occupancyRate) : "--"}
-          helperText={
-            occupancyQuery.data
-              ? `${occupancyQuery.data.unitsOccupied} of ${occupancyQuery.data.totalUnits} units`
-              : undefined
-          }
-          change={occupancyQuery.data?.change}
-          trend={resolveTrend(occupancyQuery.data?.change)}
-          trendPoints={occupancyQuery.data?.trend}
-          trendFormatter={(value) => `${formatPercent(value)} occupancy`}
-          testId="metric-occupancy"
-          isLoading={occupancyQuery.isPending && !occupancyQuery.data}
-          isError={occupancyQuery.isError}
-          onRetry={() => occupancyQuery.refetch()}
-        />
-        <MetricCard
-          title="Pipeline conversions"
-          value={pipelineQuery.data ? `${pipelineQuery.data.applicationsApproved}` : "--"}
-          helperText={
-            pipelineQuery.data
-              ? `${pipelineQuery.data.newLeads} leads • ${pipelineQuery.data.toursScheduled} tours`
-              : undefined
-          }
-          change={pipelineQuery.data ? pipelineQuery.data.applicationsApproved / Math.max(1, pipelineQuery.data.newLeads) - 0.3 : undefined}
-          trend={resolveTrend(
-            pipelineQuery.data
-              ? pipelineQuery.data.applicationsApproved / Math.max(1, pipelineQuery.data.newLeads) - 0.3
-              : undefined
-          )}
-          trendPoints={pipelineQuery.data?.trend}
-          trendFormatter={(value) => `${value} conversions/day`}
-          testId="metric-pipeline"
-          isLoading={pipelineQuery.isPending && !pipelineQuery.data}
-          isError={pipelineQuery.isError}
-          onRetry={() => pipelineQuery.refetch()}
-        />
-        <MetricCard
-          title="Cost per lead"
-          value={costQuery.data ? formatCurrency(costQuery.data.costPerLead) : "--"}
-          helperText={costQuery.data ? `Spend ${formatCurrency(costQuery.data.marketingSpend)}` : ""}
-          change={costQuery.data?.spendChange}
-          trend={resolveTrend(costQuery.data?.spendChange)}
-          trendPoints={costQuery.data?.trend}
-          trendFormatter={(value) => `${formatCurrency(value)} CPL`}
-          testId="metric-cost"
-          isLoading={costQuery.isPending && !costQuery.data}
-          isError={costQuery.isError}
-          onRetry={() => costQuery.refetch()}
-        />
-      </section>
-
-      <section className="grid gap-6 lg:grid-cols-[1.6fr,1fr]">
-        <DashboardCard
-          title={selectedPropertyName ? `${selectedPropertyName} reviews` : "Resident feedback"}
-          description="Latest resident sentiment and response coverage"
-          action={
-            <Button type="button" size="sm" variant="ghost" className="gap-2" onClick={() => reviewsQuery.refetch()}>
-              <Loader2 className={cn("h-4 w-4", reviewsQuery.isFetching && "animate-spin")}
-              />
-              Refresh
-            </Button>
-          }
-        >
-          {reviewsQuery.isLoading ? (
-            <div className="flex items-center justify-center py-16">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            </div>
-          ) : null}
-          {reviewsQuery.isError ? (
-            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
-              <ShieldOff className="h-10 w-10 text-destructive" />
-              <p className="text-sm text-muted-foreground">Unable to load reviews. Please retry in a moment.</p>
-              <Button type="button" size="sm" onClick={() => reviewsQuery.refetch()}>
-                Retry
+      {propertiesQuery.isError ? (
+        <section>
+          <div className="rounded-3xl border border-destructive/40 bg-destructive/10 p-6 text-sm text-destructive">
+            We couldn&apos;t load your property list. Please retry in a moment.
+            <div className="mt-3">
+              <Button type="button" size="sm" variant="destructive" onClick={() => propertiesQuery.refetch()}>
+                Try again
               </Button>
             </div>
-          ) : null}
-          {!reviewsQuery.isLoading && !reviewsQuery.isError && reviewsQuery.data ? (
-            <div className="flex flex-col gap-4">
-              <div className="flex items-center justify-between gap-4 rounded-2xl border border-border/70 bg-card-contrast/40 px-4 py-3">
-                <div>
-                  <p className="text-sm font-semibold text-foreground">Average rating</p>
-                  <p className="text-3xl font-semibold text-foreground">
-                    {reviewsQuery.data.summary.averageRating.toFixed(1)}
-                  </p>
-                </div>
-                <Separator orientation="vertical" className="h-12" />
-                <div>
-                  <p className="text-sm font-semibold text-foreground">Response rate</p>
-                  <p className="text-xl font-semibold text-foreground">{formatPercent(reviewsQuery.data.summary.responseRate)}</p>
-                </div>
-                <Separator orientation="vertical" className="h-12" />
-                <div>
-                  <p className="text-sm font-semibold text-foreground">Reviews</p>
-                  <p className="text-xl font-semibold text-foreground">{reviewsQuery.data.summary.reviewCount}</p>
-                </div>
-              </div>
-              <div className="grid gap-3">
-                {reviewsQuery.data.recent.map((review) => (
-                  <article
-                    key={review.id}
-                    className="rounded-2xl border border-border/70 bg-card px-4 py-3 shadow-sm transition hover:border-border"
-                  >
-                    <div className="flex items-center justify-between">
-                      <p className="text-sm font-semibold text-foreground">{review.author}</p>
-                      <span className="text-xs text-muted-foreground">
-                        {new Date(review.submittedAt).toLocaleString(undefined, {
-                          month: "short",
-                          day: "numeric",
-                          hour: "numeric",
-                          minute: "2-digit"
-                        })}
-                      </span>
-                    </div>
-                    <p className="mt-2 text-sm text-muted-foreground">{review.body}</p>
-                  </article>
-                ))}
-              </div>
+          </div>
+        </section>
+      ) : null}
+
+      {shouldShowEmptyState && !propertiesQuery.isError ? (
+        <section>
+          <div className="flex flex-col items-center gap-4 rounded-3xl border border-border bg-card/85 px-8 py-16 text-center shadow-sm">
+            <Sparkles className="h-8 w-8 text-primary" />
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-foreground">No properties yet. Add one to get started.</h3>
+              <p className="text-sm text-muted-foreground">
+                Create your first property or choose one above to see live metrics populate instantly.
+              </p>
             </div>
-          ) : null}
-        </DashboardCard>
+            <Button
+              type="button"
+              className="rounded-full px-6"
+              onClick={() => document.getElementById("property-select")?.focus()}
+            >
+              Add a property
+            </Button>
+          </div>
+        </section>
+      ) : null}
 
-        <AlertsPanel
-          alerts={alertsQuery.data?.alerts}
-          isLoading={alertsQuery.isLoading}
-          isError={alertsQuery.isError}
-          onRetry={() => alertsQuery.refetch()}
-        />
-      </section>
+      {!shouldShowEmptyState ? (
+        <section className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+          <MetricCard
+            title="Average occupancy"
+            value={occupancyQuery.data ? formatPercent(occupancyQuery.data.occupancyRate) : "--"}
+            helperText={
+              occupancyQuery.data
+                ? `${occupancyQuery.data.unitsOccupied} of ${occupancyQuery.data.totalUnits} units`
+                : undefined
+            }
+            change={occupancyQuery.data?.change}
+            trend={resolveTrend(occupancyQuery.data?.change)}
+            trendPoints={occupancyQuery.data?.trend}
+            trendFormatter={(value) => `${formatPercent(value)} occupancy`}
+            testId="metric-occupancy"
+            isLoading={occupancyQuery.isPending && !occupancyQuery.data}
+            isError={occupancyQuery.isError}
+            onRetry={() => occupancyQuery.refetch()}
+          />
+          <MetricCard
+            title="Pipeline conversions"
+            value={pipelineQuery.data ? `${pipelineQuery.data.applicationsApproved}` : "--"}
+            helperText={
+              pipelineQuery.data
+                ? `${pipelineQuery.data.newLeads} leads • ${pipelineQuery.data.toursScheduled} tours`
+                : undefined
+            }
+            change={
+              pipelineQuery.data
+                ? pipelineQuery.data.applicationsApproved / Math.max(1, pipelineQuery.data.newLeads) - 0.3
+                : undefined
+            }
+            trend={resolveTrend(
+              pipelineQuery.data
+                ? pipelineQuery.data.applicationsApproved / Math.max(1, pipelineQuery.data.newLeads) - 0.3
+                : undefined
+            )}
+            trendPoints={pipelineQuery.data?.trend}
+            trendFormatter={(value) => `${value} conversions/day`}
+            testId="metric-pipeline"
+            isLoading={pipelineQuery.isPending && !pipelineQuery.data}
+            isError={pipelineQuery.isError}
+            onRetry={() => pipelineQuery.refetch()}
+          />
+          <MetricCard
+            title="Cost per lead"
+            value={costQuery.data ? formatCurrency(costQuery.data.costPerLead) : "--"}
+            helperText={costQuery.data ? `Spend ${formatCurrency(costQuery.data.marketingSpend)}` : ""}
+            change={costQuery.data?.spendChange}
+            trend={resolveTrend(costQuery.data?.spendChange)}
+            trendPoints={costQuery.data?.trend}
+            trendFormatter={(value) => `${formatCurrency(value)} CPL`}
+            testId="metric-cost"
+            isLoading={costQuery.isPending && !costQuery.data}
+            isError={costQuery.isError}
+            onRetry={() => costQuery.refetch()}
+          />
+        </section>
+      ) : null}
 
-      <section>
+      {!shouldShowEmptyState ? (
+        <section className="grid gap-5 lg:grid-cols-[1.6fr,1fr]">
+          <DashboardCard
+            title={selectedPropertyName ? `${selectedPropertyName} reviews` : "Resident feedback"}
+            description="Latest resident sentiment and response coverage"
+            action={
+              <Button type="button" size="sm" variant="ghost" className="gap-2" onClick={() => reviewsQuery.refetch()}>
+                <Loader2 className={cn("h-4 w-4", reviewsQuery.isFetching && "animate-spin")} />
+                Refresh
+              </Button>
+            }
+          >
+            {reviewsQuery.isLoading ? (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              </div>
+            ) : null}
+            {reviewsQuery.isError ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+                <ShieldOff className="h-10 w-10 text-destructive" />
+                <p className="text-sm text-muted-foreground">Unable to load reviews. Please retry in a moment.</p>
+                <Button type="button" size="sm" onClick={() => reviewsQuery.refetch()}>
+                  Retry
+                </Button>
+              </div>
+            ) : null}
+            {!reviewsQuery.isLoading && !reviewsQuery.isError && reviewsQuery.data ? (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-border bg-card-contrast/40 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">Average rating</p>
+                    <p className="text-3xl font-semibold text-foreground">
+                      {reviewsQuery.data.summary.averageRating.toFixed(1)}
+                    </p>
+                  </div>
+                  <Separator orientation="vertical" className="hidden h-12 sm:block" />
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">Response rate</p>
+                    <p className="text-xl font-semibold text-foreground">{formatPercent(reviewsQuery.data.summary.responseRate)}</p>
+                  </div>
+                  <Separator orientation="vertical" className="hidden h-12 sm:block" />
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">Reviews</p>
+                    <p className="text-xl font-semibold text-foreground">{reviewsQuery.data.summary.reviewCount}</p>
+                  </div>
+                </div>
+                <div className="grid gap-3">
+                  {reviewsQuery.data.recent.map((review) => (
+                    <article
+                      key={review.id}
+                      className="rounded-2xl border border-border bg-card px-4 py-3 shadow-sm transition hover:border-border"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-sm font-semibold text-foreground">{review.author}</p>
+                        <span className="text-xs text-muted-foreground">
+                          {new Date(review.submittedAt).toLocaleString(undefined, {
+                            month: "short",
+                            day: "numeric",
+                            hour: "numeric",
+                            minute: "2-digit"
+                          })}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{review.body}</p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </DashboardCard>
+
+          <AlertsPanel
+            alerts={alertsQuery.data?.alerts}
+            isLoading={alertsQuery.isLoading}
+            isError={alertsQuery.isError}
+            onRetry={() => alertsQuery.refetch()}
+          />
+        </section>
+      ) : null}
+
+      <section className="pb-6">
         <DashboardCard
           title="Portfolio performance"
           description="Track contracts, SLAs and incident load across properties"
@@ -257,12 +342,7 @@ export function DashboardView({ role }: DashboardViewProps) {
             role === "admin" ? (
               <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                 <span>Admins can add, edit or delete records directly in this table.</span>
-                <Button
-                  asChild
-                  variant="outline"
-                  size="sm"
-                  className="h-8 rounded-full border-border/70 px-3"
-                >
+                <Button asChild variant="outline" size="sm" className="h-8 rounded-full border-border px-3">
                   <Link href="/tables">Open as table</Link>
                 </Button>
               </div>

--- a/apps/frontend/components/dashboard/metric-card.tsx
+++ b/apps/frontend/components/dashboard/metric-card.tsx
@@ -44,17 +44,17 @@ export function MetricCard({
   const trendColor = trend === "down" ? "text-red-500" : trend === "up" ? "text-emerald-500" : "text-muted-foreground";
 
   return (
-    <Card className={cn("h-full", className)} data-testid={testId}>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+    <Card className={cn("h-full rounded-3xl border border-border bg-card/95 shadow-sm", className)} data-testid={testId}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 p-7 pb-4">
         <div className="flex flex-col">
-          <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
-          <span className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+          <CardTitle className="text-base font-semibold text-foreground/95">{title}</CardTitle>
+          <span className="mt-3 text-3xl font-semibold tracking-tight text-foreground">
             {isLoading || isError ? "--" : value}
           </span>
         </div>
         {!isLoading && !isError && TrendIcon ? <TrendIcon className={cn("h-5 w-5", trendColor)} /> : null}
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4 p-7 pt-0">
         {isLoading ? (
           <div className="flex h-24 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-5 w-5 animate-spin" />
@@ -73,15 +73,15 @@ export function MetricCard({
         ) : null}
         {!isLoading && !isError ? (
           <div className="space-y-3">
-            {helperText ? <p className="text-sm text-muted-foreground">{helperText}</p> : null}
+            {helperText ? <p className="text-sm text-foreground/75">{helperText}</p> : null}
             {typeof change === "number" ? (
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-foreground/70">
                 {change > 0 ? "+" : ""}
                 {(change * 100).toFixed(1)}% vs. last period
               </p>
             ) : null}
             {trendPoints && trendPoints.length > 1 ? (
-              <div className="rounded-2xl border border-border/70 bg-card-contrast/60 p-3">
+              <div className="rounded-2xl border border-border bg-card-contrast/60 p-3 shadow-sm">
                 <Sparkline points={trendPoints} formatter={trendFormatter} />
               </div>
             ) : null}

--- a/apps/frontend/components/dashboard/operations-table.tsx
+++ b/apps/frontend/components/dashboard/operations-table.tsx
@@ -122,6 +122,34 @@ export function OperationsTable({ canEdit }: { canEdit: boolean }) {
     }
   });
 
+  const reorderMutation = useMutation({
+    mutationFn: async (order: Array<{ id: string; order: number }>) => {
+      const response = await fetch("/api/portfolio/reorder", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ order })
+      });
+      if (!response.ok) {
+        throw new Error("Failed to reorder rows");
+      }
+      const payload = (await response.json()) as { rows: PortfolioRow[] };
+      return payload.rows;
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["portfolio"] });
+      return { previousRows: rows };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousRows) {
+        setRows(context.previousRows);
+      }
+    },
+    onSuccess: (nextRows) => {
+      setRows(nextRows);
+      queryClient.invalidateQueries({ queryKey: ["portfolio"] });
+    }
+  });
+
   const { mutate: deleteRow, isPending: isDeleting } = deleteMutation;
 
   const columns = useMemo<ColumnDef<PortfolioRow, unknown>[]>(() => {
@@ -169,7 +197,9 @@ export function OperationsTable({ canEdit }: { canEdit: boolean }) {
           },
           parseValue: (value: string) => new Date(value).toISOString(),
           validate: (value: string) => validateDate(value) ?? validateNonEmpty(value),
-          placeholder: "2024-11-05 18:30"
+          placeholder: "2024-11-05 18:30",
+          headerClassName: "hidden md:table-cell",
+          cellClassName: "hidden md:table-cell"
         } satisfies EditableCellMeta<PortfolioRow>
       },
       {
@@ -258,7 +288,7 @@ export function OperationsTable({ canEdit }: { canEdit: boolean }) {
   }, [canEdit, deleteRow, isDeleting]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       <div className="flex items-center justify-between gap-3">
         <Button
           type="button"
@@ -286,14 +316,26 @@ export function OperationsTable({ canEdit }: { canEdit: boolean }) {
         data={rows}
         storageKey="astalla:portfolio-table:v3"
         persistenceEnabled={isPersistenceEnabled()}
-        onDataChange={(nextRows) => setRows(nextRows)}
-        className={cn(!canEdit && "opacity-90")}
+        onDataChange={(nextRows) => {
+          const previousOrder = rows.map((row) => row.id).join("|");
+          const nextOrder = nextRows.map((row) => row.id).join("|");
+
+          setRows(nextRows);
+
+          if (previousOrder !== nextOrder) {
+            reorderMutation.mutate(nextRows.map((row, index) => ({ id: row.id, order: index })));
+          }
+        }}
+        className={cn("pb-2", !canEdit && "opacity-90")}
         meta={{
           onUpdate: (rowId: string, columnId: string, value: unknown) => {
             updateMutation.mutate({ id: rowId, patch: { [columnId]: value } as Partial<PortfolioRow> });
           }
         }}
       />
+      {reorderMutation.isPending ? (
+        <p className="text-xs text-muted-foreground">Saving new order…</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/frontend/components/dashboard/property-selector.tsx
+++ b/apps/frontend/components/dashboard/property-selector.tsx
@@ -1,16 +1,25 @@
 "use client";
 
-import { ChevronDown, MapPin } from "lucide-react";
-import type { ChangeEvent } from "react";
+import { ChevronDown, MapPin, Plus } from "lucide-react";
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import { cn, isMockMode } from "@/lib/utils";
 
 export type PropertyOption = {
   id: string;
   name: string;
   city: string;
   state: string;
+};
+
+export type CreatePropertyPayload = {
+  name: string;
+  code: string;
+  city?: string;
+  state?: string;
 };
 
 const TIME_RANGES = [
@@ -24,10 +33,11 @@ type TimeRangeValue = (typeof TIME_RANGES)[number]["value"];
 interface PropertySelectorProps {
   properties: PropertyOption[];
   selectedPropertyId: string | null;
-  onPropertyChange: (propertyId: string) => void;
+  onPropertyChange: (propertyId: string | null) => void;
   timeRange: TimeRangeValue;
   onTimeRangeChange: (range: TimeRangeValue) => void;
   disabled?: boolean;
+  onCreateProperty?: (payload: CreatePropertyPayload) => Promise<PropertyOption | null> | PropertyOption | null;
 }
 
 export function PropertySelector({
@@ -36,10 +46,51 @@ export function PropertySelector({
   onPropertyChange,
   timeRange,
   onTimeRangeChange,
-  disabled
+  disabled,
+  onCreateProperty
 }: PropertySelectorProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const suggestions = useMemo(() => {
+    if (!isMockMode()) {
+      return [] as Array<Pick<CreatePropertyPayload, "name" | "code">>;
+    }
+    return [
+      { name: "Atrium Center", code: "ATRIUM" },
+      { name: "Harbor Tower", code: "HARBOR" },
+      { name: "Quartz Labs", code: "QUARTZ" }
+    ];
+  }, []);
+
+  const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (value === "__add_property") {
+      setIsDialogOpen(true);
+      return;
+    }
+    onPropertyChange(value || null);
+  };
+
+  const handleSubmit = async (payload: CreatePropertyPayload) => {
+    if (!onCreateProperty) {
+      setIsDialogOpen(false);
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      const created = await Promise.resolve(onCreateProperty(payload));
+      if (created) {
+        onPropertyChange(created.id);
+        setIsDialogOpen(false);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-4 rounded-3xl border border-border/80 bg-panel/90 p-6 shadow-sm supports-[backdrop-filter]:backdrop-blur">
+    <div className="flex flex-col gap-5 rounded-3xl border border-border bg-panel/95 p-7 shadow-sm supports-[backdrop-filter]:backdrop-blur">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
@@ -58,19 +109,20 @@ export function PropertySelector({
             <select
               id="property-select"
               className={cn(
-                "appearance-none rounded-full border border-border/80 bg-card px-4 py-2 pr-10 text-sm font-medium text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                "appearance-none rounded-full border border-border bg-card px-4 py-2 pr-10 text-sm font-medium text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 disabled && "cursor-not-allowed opacity-60"
               )}
               value={selectedPropertyId ?? ""}
-              onChange={(event: ChangeEvent<HTMLSelectElement>) => onPropertyChange(event.target.value)}
-              disabled={disabled || properties.length === 0}
+              onChange={handleSelectChange}
+              disabled={disabled}
             >
-              {properties.length === 0 ? <option value="">No properties</option> : null}
+              <option value="">Select a property</option>
               {properties.map((property) => (
                 <option key={property.id} value={property.id}>
                   {property.name} · {property.city}, {property.state}
                 </option>
               ))}
+              <option value="__add_property">+ Add property</option>
             </select>
             <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           </div>
@@ -78,7 +130,7 @@ export function PropertySelector({
       </div>
       <div className="flex flex-wrap items-center gap-3">
         <span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Time range</span>
-        <div className="flex rounded-full border border-border/70 bg-card p-1 shadow-sm">
+        <div className="flex rounded-full border border-border bg-card p-1 shadow-sm">
           {TIME_RANGES.map((option) => (
             <Button
               key={option.value}
@@ -97,8 +149,162 @@ export function PropertySelector({
           ))}
         </div>
       </div>
+      {properties.length === 0 ? (
+        <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-border/80 bg-card/40 p-5 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">No properties yet. Add one to get started.</p>
+          <Button type="button" size="sm" className="w-fit gap-2" onClick={() => setIsDialogOpen(true)}>
+            <Plus className="h-4 w-4" /> Add property
+          </Button>
+        </div>
+      ) : null}
+      <AddPropertyDialog
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        suggestions={suggestions}
+      />
     </div>
   );
 }
 
 export type { TimeRangeValue };
+
+interface AddPropertyDialogProps {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  onSubmit: (payload: CreatePropertyPayload) => void | Promise<void>;
+  isSubmitting: boolean;
+  suggestions: Array<Pick<CreatePropertyPayload, "name" | "code">>;
+}
+
+function AddPropertyDialog({ open, onOpenChange, onSubmit, isSubmitting, suggestions }: AddPropertyDialogProps) {
+  const [mounted, setMounted] = useState(false);
+  const [name, setName] = useState("");
+  const [code, setCode] = useState("");
+  const [city, setCity] = useState("");
+  const [state, setState] = useState("");
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setName("");
+      setCode("");
+      setCity("");
+      setState("");
+    }
+  }, [open]);
+
+  if (!mounted || !open) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim() || !code.trim()) {
+      return;
+    }
+    await onSubmit({
+      name: name.trim(),
+      code: code.trim(),
+      city: city.trim() || undefined,
+      state: state.trim() || undefined
+    });
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 backdrop-blur">
+      <div className="w-full max-w-md rounded-3xl border border-border bg-card p-6 shadow-xl">
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-foreground">Add a property</h3>
+          <p className="text-sm text-muted-foreground">
+            Name your property and give it a short code so you can identify it later.
+          </p>
+        </div>
+        <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-foreground" htmlFor="property-name">
+              Property name
+            </label>
+            <Input
+              id="property-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Atrium Center"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-foreground" htmlFor="property-code">
+              Property code
+            </label>
+            <Input
+              id="property-code"
+              value={code}
+              onChange={(event) => setCode(event.target.value.toUpperCase())}
+              placeholder="ATRIUM"
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="property-city">
+                City
+              </label>
+              <Input
+                id="property-city"
+                value={city}
+                onChange={(event) => setCity(event.target.value)}
+                placeholder="Austin"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="property-state">
+                State
+              </label>
+              <Input
+                id="property-state"
+                value={state}
+                onChange={(event) => setState(event.target.value.toUpperCase())}
+                placeholder="TX"
+              />
+            </div>
+          </div>
+          {suggestions.length ? (
+            <div className="space-y-2 rounded-2xl border border-dashed border-border/70 bg-card/50 p-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Try a mock property</p>
+              <div className="flex flex-wrap gap-2">
+                {suggestions.map((suggestion) => (
+                  <Button
+                    key={suggestion.code}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="rounded-full"
+                    onClick={() => {
+                      setName(suggestion.name);
+                      setCode(suggestion.code);
+                    }}
+                  >
+                    {suggestion.name}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          <div className="flex items-center justify-end gap-3">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting || !name.trim() || !code.trim()} className="gap-2">
+              {isSubmitting ? <span className="animate-pulse">Saving…</span> : <Plus className="h-4 w-4" />} Create
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/frontend/components/data-table/data-table.tsx
+++ b/apps/frontend/components/data-table/data-table.tsx
@@ -47,7 +47,7 @@ import { cn } from "@/lib/utils";
 
 import { ColumnVisibilityMenu } from "./column-visibility-menu";
 import { DragHandle } from "./drag-handle";
-import { EditableCell } from "./editable-cell";
+import { EditableCell, type EditableCellMeta } from "./editable-cell";
 import {
   type TableDensity,
   type TableLayoutState,
@@ -137,7 +137,13 @@ export function DataTable<TData extends { id: string }>({
   );
 
   const tableColumns = useMemo<ColumnDef<TData, unknown>[]>(() => {
-    return [selectionColumn, ...columns.map((column) => ({ ...column, cell: column.cell ?? EditableCell }))];
+    return [
+      selectionColumn,
+      ...columns.map((column) => ({
+        ...column,
+        cell: column.cell ?? EditableCell
+      }))
+    ];
   }, [columns, selectionColumn]);
 
   const columnIds = useMemo(
@@ -280,7 +286,7 @@ export function DataTable<TData extends { id: string }>({
     enabled: shouldVirtualize
   });
   const tableClassName = useMemo(
-    () => cn("min-w-full text-left", densityToRowClass[density]),
+    () => cn("min-w-[720px] text-left", densityToRowClass[density]),
     [density]
   );
   const noDataRow = (
@@ -336,16 +342,16 @@ export function DataTable<TData extends { id: string }>({
           </Button>
         </div>
       </div>
-      <div className="overflow-hidden rounded-2xl border border-border/60 bg-card">
+      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
         <div
           ref={tableScrollRef}
-          className="w-full overflow-auto"
+          className="w-full overflow-x-auto"
           style={shouldVirtualize ? { maxHeight: virtualizedContainerHeight } : undefined}
         >
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleColumnDragEnd}>
             <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
               <table className={tableClassName}>
-                <thead className="bg-card-contrast/60 text-xs uppercase tracking-wide text-muted-foreground">
+                <thead className="bg-card-contrast/70 text-xs uppercase tracking-wide text-muted-foreground">
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id}>
                       {headerGroup.headers.map((header) => (
@@ -399,7 +405,7 @@ interface SortableColumnHeaderProps<TData> {
 
 function SortableColumnHeader<TData>({ header }: SortableColumnHeaderProps<TData>) {
   const column = header.column;
-  const meta = (column.columnDef.meta ?? {}) as { disableDrag?: boolean };
+  const meta = (column.columnDef.meta ?? {}) as EditableCellMeta<TData>;
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: column.id,
     disabled: meta.disableDrag
@@ -411,7 +417,8 @@ function SortableColumnHeader<TData>({ header }: SortableColumnHeaderProps<TData
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        "relative select-none border-b border-border/60 bg-card-contrast/40 px-4 py-3 text-xs font-semibold uppercase text-muted-foreground",
+        "relative select-none border-b border-border bg-card-contrast/60 px-4 py-3 text-xs font-semibold uppercase text-muted-foreground",
+        meta.headerClassName,
         isDragging && "z-10 bg-card shadow-lg"
       )}
     >
@@ -461,16 +468,17 @@ function SortableRow<TData>({ row }: SortableRowProps<TData>) {
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        "border-b border-border/40 text-sm text-foreground transition",
-        isDragging ? "bg-card-contrast/60 shadow" : "hover:bg-card-contrast/40"
+        "border-b border-border/60 text-sm text-foreground transition",
+        isDragging ? "bg-card-contrast/60 shadow" : "hover:bg-card-contrast/50"
       )}
     >
       {row.getVisibleCells().map((cell) => {
         const isSelectionCell = cell.column.id === "__select";
+        const meta = (cell.column.columnDef.meta ?? {}) as EditableCellMeta<TData>;
         return (
           <td
             key={cell.id}
-            className={cn("px-4", isSelectionCell ? "w-[52px]" : "py-3")}
+            className={cn("px-4", isSelectionCell ? "w-[52px]" : "py-3", meta.cellClassName)}
           >
             {isSelectionCell ? (
               <div className="flex items-center gap-2">
@@ -507,12 +515,13 @@ function VirtualizedRow<TData>({ row, virtualRow, measureElement }: VirtualizedR
         width: "100%",
         transform: `translateY(${virtualRow.start}px)`
       }}
-      className="border-b border-border/40 text-sm text-foreground transition hover:bg-card-contrast/40"
+      className="border-b border-border/60 text-sm text-foreground transition hover:bg-card-contrast/50"
     >
       {row.getVisibleCells().map((cell) => {
         const isSelectionCell = cell.column.id === "__select";
+        const meta = (cell.column.columnDef.meta ?? {}) as EditableCellMeta<TData>;
         return (
-          <td key={cell.id} className={cn("px-4", isSelectionCell ? "w-[52px]" : "py-3")}>
+          <td key={cell.id} className={cn("px-4", isSelectionCell ? "w-[52px]" : "py-3", meta.cellClassName)}>
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </td>
         );

--- a/apps/frontend/components/data-table/editable-cell.tsx
+++ b/apps/frontend/components/data-table/editable-cell.tsx
@@ -12,6 +12,9 @@ export type EditableCellMeta<TData> = {
   formatValue?: (value: unknown, row: TData) => string;
   parseValue?: (value: string, row: TData) => unknown;
   validate?: (value: string, row: TData) => string | null;
+  headerClassName?: string;
+  cellClassName?: string;
+  disableDrag?: boolean;
 };
 
 export function EditableCell<TData>({

--- a/apps/frontend/lib/portfolio-store.ts
+++ b/apps/frontend/lib/portfolio-store.ts
@@ -8,6 +8,7 @@ export type PortfolioRecord = {
   monthlyCost: number;
   occupancy: number;
   incidents: number;
+  order: number;
 };
 
 const initialRecords: PortfolioRecord[] = [
@@ -20,7 +21,8 @@ const initialRecords: PortfolioRecord[] = [
     slaHours: 12,
     monthlyCost: 48000,
     occupancy: 92,
-    incidents: 1
+    incidents: 1,
+    order: 0
   },
   {
     id: "prop-2",
@@ -31,7 +33,8 @@ const initialRecords: PortfolioRecord[] = [
     slaHours: 4,
     monthlyCost: 72000,
     occupancy: 87,
-    incidents: 4
+    incidents: 4,
+    order: 1
   },
   {
     id: "prop-3",
@@ -42,7 +45,8 @@ const initialRecords: PortfolioRecord[] = [
     slaHours: 30,
     monthlyCost: 56000,
     occupancy: 81,
-    incidents: 3
+    incidents: 3,
+    order: 2
   },
   {
     id: "prop-4",
@@ -53,7 +57,8 @@ const initialRecords: PortfolioRecord[] = [
     slaHours: 48,
     monthlyCost: 39500,
     occupancy: 68,
-    incidents: 6
+    incidents: 6,
+    order: 3
   },
   {
     id: "prop-5",
@@ -64,7 +69,8 @@ const initialRecords: PortfolioRecord[] = [
     slaHours: 16,
     monthlyCost: 61000,
     occupancy: 95,
-    incidents: 0
+    incidents: 0,
+    order: 4
   },
   {
     id: "prop-6",
@@ -75,7 +81,8 @@ const initialRecords: PortfolioRecord[] = [
     slaHours: 10,
     monthlyCost: 45200,
     occupancy: 78,
-    incidents: 5
+    incidents: 5,
+    order: 5
   }
 ];
 
@@ -100,13 +107,14 @@ function createId() {
 
 export function listPortfolioRecords(): PortfolioRecord[] {
   ensureSeeded();
-  return Array.from(store.values());
+  return Array.from(store.values()).sort((a, b) => a.order - b.order);
 }
 
 export function createPortfolioRecord(partial?: Partial<PortfolioRecord>): PortfolioRecord {
   ensureSeeded();
   const id = createId();
   const now = new Date().toISOString();
+  const highestOrder = Math.max(0, ...Array.from(store.values()).map((record) => record.order));
   const record: PortfolioRecord = {
     id,
     name: partial?.name ?? "New property",
@@ -116,7 +124,8 @@ export function createPortfolioRecord(partial?: Partial<PortfolioRecord>): Portf
     slaHours: partial?.slaHours ?? 12,
     monthlyCost: partial?.monthlyCost ?? 25000,
     occupancy: partial?.occupancy ?? 80,
-    incidents: partial?.incidents ?? 0
+    incidents: partial?.incidents ?? 0,
+    order: partial?.order ?? highestOrder + 1
   };
   store.set(id, record);
   return record;
@@ -140,4 +149,22 @@ export function updatePortfolioRecord(id: string, patch: Partial<PortfolioRecord
 export function deletePortfolioRecord(id: string) {
   ensureSeeded();
   store.delete(id);
+}
+
+export function reorderPortfolioRecords(order: Array<{ id: string; order: number }>): PortfolioRecord[] {
+  ensureSeeded();
+  const existingIds = new Set(store.keys());
+
+  order.forEach(({ id, order: nextOrder }) => {
+    if (!existingIds.has(id)) {
+      return;
+    }
+    const current = store.get(id);
+    if (!current) {
+      return;
+    }
+    store.set(id, { ...current, order: nextOrder });
+  });
+
+  return listPortfolioRecords();
 }


### PR DESCRIPTION
## Summary
- brighten card borders/text, add responsive layout tweaks, and surface empty-state messaging when no property is selected
- add an "+ Add property" modal with mock suggestions and graceful property list/metric fallbacks
- enable draggable column/row order persistence with horizontal scrolling and breakpoint visibility in the portfolio table

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68e03e7e10488322b498bf8494984141