### PR TITLE
Connections Center: Sources CRUD + Run Sync (Entrata/GA4/Ads/GBP)

### DIFF
--- a/apps/backend/prisma/migrations/20250107000000_add_source_account_fields/migration.sql
+++ b/apps/backend/prisma/migrations/20250107000000_add_source_account_fields/migration.sql
@@ -1,0 +1,7 @@
+-- Add optional metadata fields to SourceAccount
+ALTER TABLE "SourceAccount"
+  ADD COLUMN "name" TEXT,
+  ADD COLUMN "status" TEXT,
+  ADD COLUMN "lastSuccessAt" TIMESTAMP(3),
+  ADD COLUMN "lastErrorAt" TIMESTAMP(3),
+  ADD COLUMN "enabled" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -126,6 +126,11 @@ model SourceAccount {
   propertyId  String
   type        SourceAccountType
   credential  Json
+  name        String?
+  status      String?
+  lastSuccessAt DateTime?
+  lastErrorAt DateTime?
+  enabled     Boolean           @default(true)
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
 

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { PropertiesModule } from "./properties/properties.module";
 import { ProvidersModule } from "./providers/providers.module";
 import { ReportsModule } from "./reports/reports.module";
 import { ReviewsModule } from "./reviews/reviews.module";
+import { SourcesModule } from "./sources/sources.module";
 
 @Module({
   imports: [
@@ -44,7 +45,8 @@ import { ReviewsModule } from "./reviews/reviews.module";
     ReviewsModule,
     ReportsModule,
     AlertsModule,
-    JobsModule
+    JobsModule,
+    SourcesModule
   ]
 })
 export class AppModule {}

--- a/apps/backend/src/jobs/etl.processor.ts
+++ b/apps/backend/src/jobs/etl.processor.ts
@@ -1,0 +1,423 @@
+import { Logger } from "@nestjs/common";
+import { Prisma, ReviewProvider, SourceAccountType } from "@prisma/client";
+import { createHash } from "crypto";
+
+import type { PrismaService } from "../prisma/prisma.service";
+import type { EntrataProvider } from "../providers/entrata.provider";
+import type { Ga4Provider } from "../providers/ga4.provider";
+import type { GoogleBusinessProvider } from "../providers/gbp.provider";
+import type { GoogleAdsProvider } from "../providers/google-ads.provider";
+
+interface EtlProcessorDependencies {
+  prisma: PrismaService;
+  decrypt: (value: unknown) => Record<string, unknown>;
+  providers: {
+    entrata: EntrataProvider;
+    ga4: Ga4Provider;
+    gbp: GoogleBusinessProvider;
+    ads: GoogleAdsProvider;
+  };
+  logger?: Logger;
+}
+
+interface EtlJobPayload {
+  sourceId: string;
+  job: string;
+}
+
+let dependencies: EtlProcessorDependencies | null = null;
+
+export function configureEtlProcessor(deps: EtlProcessorDependencies) {
+  dependencies = deps;
+}
+
+export async function processEtlJob(payload: EtlJobPayload) {
+  if (!dependencies) {
+    throw new Error("ETL processor has not been configured");
+  }
+
+  const { prisma, decrypt, providers } = dependencies;
+  const logger = dependencies.logger ?? new Logger("EtlProcessor");
+
+  logger.log(`Processing ETL job ${payload.job} for source ${payload.sourceId}`);
+
+  const source = await prisma.sourceAccount.findUnique({ where: { id: payload.sourceId } });
+  if (!source) {
+    logger.warn(`Source ${payload.sourceId} no longer exists. Skipping.`);
+    return;
+  }
+
+  if (source.enabled === false) {
+    logger.warn(`Source ${payload.sourceId} disabled. Skipping.`);
+    return;
+  }
+
+  const credential = decrypt(source.credential ?? {});
+
+  try {
+    switch (source.type) {
+      case SourceAccountType.ENTRATA:
+        await syncEntrata(prisma, providers.entrata, source.propertyId, credential, logger);
+        break;
+      case SourceAccountType.GA4:
+        await syncGa4(prisma, providers.ga4, source.propertyId, credential, logger);
+        break;
+      case SourceAccountType.GOOGLE_ADS:
+        await syncGoogleAds(prisma, providers.ads, source.propertyId, credential, logger);
+        break;
+      case SourceAccountType.GBP:
+        await syncGoogleBusiness(prisma, providers.gbp, source.propertyId, credential, logger);
+        break;
+      default:
+        logger.warn(`No ETL implementation for source type ${source.type}`);
+    }
+
+    await prisma.sourceAccount.update({
+      where: { id: source.id },
+      data: {
+        status: "CONNECTED",
+        lastSuccessAt: new Date(),
+        // Preserve lastErrorAt so teams can inspect historical issues
+      }
+    });
+
+    logger.log(`ETL job ${payload.job} for source ${payload.sourceId} completed successfully`);
+  } catch (error) {
+    logger.error(`ETL job ${payload.job} for source ${payload.sourceId} failed`, error as Error);
+    await prisma.sourceAccount.update({
+      where: { id: source.id },
+      data: {
+        status: "ERROR",
+        lastErrorAt: new Date()
+      }
+    });
+    throw error;
+  }
+}
+
+function ensureString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Missing required credential field: ${field}`);
+  }
+  return value.trim();
+}
+
+async function syncEntrata(
+  prisma: PrismaService,
+  provider: EntrataProvider,
+  propertyId: string,
+  credential: Record<string, unknown>,
+  logger: Logger
+) {
+  const apiKey = ensureString(credential.apiKey, "apiKey");
+  const orgSlug = ensureString(credential.orgSlug, "orgSlug");
+  const entrataPropertyIdRaw = credential.propertyId ?? credential.propertyExternalId;
+  const entrataPropertyId = Number(entrataPropertyIdRaw);
+
+  if (!Number.isFinite(entrataPropertyId)) {
+    throw new Error("Entrata credential missing numeric propertyId");
+  }
+
+  const now = new Date();
+  const start = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+  const { leads } = await provider.fetchLeads(
+    { apiKey, orgSlug },
+    { propertyId: entrataPropertyId, from: start, to: now, perPage: 50 }
+  );
+
+  for (const lead of leads) {
+    const externalId = String(lead.applicationId ?? `${entrataPropertyId}-${lead.createdOn ?? now.toISOString()}`);
+    await prisma.lead.upsert({
+      where: {
+        propertyId_externalId: {
+          propertyId,
+          externalId
+        }
+      },
+      update: {
+        source: lead.leadSource ?? "Entrata"
+      },
+      create: {
+        propertyId,
+        externalId,
+        source: lead.leadSource ?? "Entrata",
+        createdAt: lead.createdOn ? new Date(lead.createdOn) : now,
+        gclid: lead.leadSource ?? undefined
+      }
+    });
+  }
+
+  const { events } = await provider.fetchLeadEvents(
+    { apiKey, orgSlug },
+    { propertyId: entrataPropertyId, from: start, to: now, perPage: 50 }
+  );
+
+  for (const event of events) {
+    const externalId = event.applicationId ? String(event.applicationId) : undefined;
+    const timestamp = event.dateTime ? new Date(event.dateTime) : event.date ? new Date(event.date) : now;
+    const deterministicId = hashId(`entrata:${propertyId}:${event.eventId ?? `${timestamp.getTime()}`}`);
+
+    let leadId: string | undefined;
+    if (externalId) {
+      const lead = await prisma.lead.findUnique({
+        where: {
+          propertyId_externalId: {
+            propertyId,
+            externalId
+          }
+        }
+      });
+      leadId = lead?.id;
+    }
+
+    if (!leadId) {
+      continue;
+    }
+
+    await prisma.leadEvent.upsert({
+      where: { id: deterministicId },
+      update: {
+        leadId,
+        type: event.type ?? "event",
+        occurredAt: timestamp,
+        meta: event.eventReason
+          ? {
+              reason: event.eventReason,
+              agentName: event.agentName
+            }
+          : undefined
+      },
+      create: {
+        id: deterministicId,
+        propertyId,
+        leadId,
+        type: event.type ?? "event",
+        occurredAt: timestamp,
+        meta: event.eventReason
+          ? {
+              reason: event.eventReason,
+              agentName: event.agentName
+            }
+          : undefined
+      }
+    });
+  }
+
+  logger.log(`Entrata sync wrote ${leads.length} leads and ${events.length} events for ${propertyId}`);
+}
+
+async function syncGa4(
+  prisma: PrismaService,
+  provider: Ga4Provider,
+  propertyId: string,
+  credential: Record<string, unknown>,
+  logger: Logger
+) {
+  const accessToken = ensureString(credential.accessToken, "accessToken");
+  const gaPropertyId = ensureString(credential.propertyId ?? credential.ga4PropertyId, "propertyId");
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const gaDate = formatGaDate(yesterday);
+
+  const rows = await provider.runReport<{ dimensionValues?: { value?: string }[]; metricValues?: { value?: string }[] }>(
+    {
+      accessToken,
+      propertyId: gaPropertyId,
+      body: {
+        dimensions: [{ name: "date" }],
+        metrics: [{ name: "totalUsers" }, { name: "conversions" }],
+        dateRanges: [{ startDate: gaDate, endDate: gaDate }]
+      }
+    }
+  );
+
+  for (const row of rows) {
+    const dimensionValue = row.dimensionValues?.[0]?.value ?? gaDate;
+    const metricValues = row.metricValues ?? [];
+    const totalUsers = Number(metricValues[0]?.value ?? "0");
+    const conversions = Number(metricValues[1]?.value ?? "0");
+    const day = parseGaDate(dimensionValue);
+
+    await prisma.conversionEvent.upsert({
+      where: { id: hashId(`ga4:${propertyId}:${dimensionValue}:total_users`) },
+      update: { count: Math.round(totalUsers) },
+      create: {
+        id: hashId(`ga4:${propertyId}:${dimensionValue}:total_users`),
+        propertyId,
+        day,
+        type: "ga4_total_users",
+        count: Math.round(totalUsers)
+      }
+    });
+
+    await prisma.conversionEvent.upsert({
+      where: { id: hashId(`ga4:${propertyId}:${dimensionValue}:conversions`) },
+      update: { count: Math.round(conversions) },
+      create: {
+        id: hashId(`ga4:${propertyId}:${dimensionValue}:conversions`),
+        propertyId,
+        day,
+        type: "ga4_conversions",
+        count: Math.round(conversions)
+      }
+    });
+  }
+
+  logger.log(`GA4 sync recorded ${rows.length} daily rows for ${propertyId}`);
+}
+
+async function syncGoogleAds(
+  prisma: PrismaService,
+  provider: GoogleAdsProvider,
+  propertyId: string,
+  credential: Record<string, unknown>,
+  logger: Logger
+) {
+  const accessToken = ensureString(credential.accessToken, "accessToken");
+  const customerId = ensureString(credential.customerId ?? credential.loginCustomerId ?? credential.managerCustomerId, "customerId");
+  const developerToken = typeof credential.developerToken === "string" ? credential.developerToken : undefined;
+  const loginCustomerId = typeof credential.loginCustomerId === "string" ? credential.loginCustomerId : undefined;
+
+  const query = [
+    "SELECT segments.date, campaign.id, campaign.name, metrics.cost_micros",
+    "FROM campaign",
+    "WHERE segments.date DURING YESTERDAY",
+    "LIMIT 25"
+  ].join(" ");
+
+  const rows = await provider.runQuery<GoogleAdsReportRow>({
+    accessToken,
+    customerId,
+    loginCustomerId,
+    developerToken,
+    query
+  });
+
+  for (const row of rows) {
+    const dayString = row?.segments?.date;
+    if (!dayString) continue;
+
+    const day = new Date(dayString);
+    const campaignId = row?.campaign?.id ? String(row.campaign.id) : undefined;
+    const costMicros = Number(row?.metrics?.cost_micros ?? row?.metrics?.costMicros ?? 0);
+    const cost = costMicros / 1_000_000;
+
+    await prisma.channelSpend.upsert({
+      where: { id: hashId(`ads:${propertyId}:${dayString}:${campaignId ?? "all"}`) },
+      update: { cost: new Prisma.Decimal(cost.toFixed(4)) },
+      create: {
+        id: hashId(`ads:${propertyId}:${dayString}:${campaignId ?? "all"}`),
+        propertyId,
+        day,
+        channel: "google_ads",
+        campaignId,
+        cost: new Prisma.Decimal(cost.toFixed(4)),
+        currency: "USD"
+      }
+    });
+  }
+
+  logger.log(`Google Ads sync processed ${rows.length} rows for ${propertyId}`);
+}
+
+async function syncGoogleBusiness(
+  prisma: PrismaService,
+  provider: GoogleBusinessProvider,
+  propertyId: string,
+  credential: Record<string, unknown>,
+  logger: Logger
+) {
+  const accessToken = ensureString(credential.accessToken, "accessToken");
+  const accountId = ensureString(credential.accountId, "accountId");
+  const locationId = ensureString(credential.locationId, "locationId");
+
+  const { reviews } = await provider.listReviews({
+    accessToken,
+    accountId,
+    locationId
+  });
+
+  for (const review of reviews) {
+    const reviewId = hashId(review.name ?? `${accountId}/${locationId}/${review.updateTime ?? review.createTime ?? Date.now()}`);
+    const rating = normalizeRating(review.starRating);
+    const createdAt = review.createTime ? new Date(review.createTime) : new Date();
+    const clampedRating = Math.max(0, Math.min(5, Math.round(rating)));
+
+    await prisma.review.upsert({
+      where: { id: reviewId },
+      update: {
+        rating: clampedRating,
+        text: review.comment ?? "",
+        responseText: review.reviewReply?.comment ?? null,
+        respondedAt: review.reviewReply?.updateTime ? new Date(review.reviewReply.updateTime) : null,
+        rawPayload: review
+      },
+      create: {
+        id: reviewId,
+        propertyId,
+        provider: ReviewProvider.GBP,
+        authorName: review.reviewer?.displayName ?? (review.reviewer?.isAnonymous ? "Anonymous" : "Resident"),
+        rating: clampedRating,
+        text: review.comment ?? "",
+        at: createdAt,
+        responseText: review.reviewReply?.comment ?? null,
+        respondedAt: review.reviewReply?.updateTime ? new Date(review.reviewReply.updateTime) : null,
+        rawPayload: review
+      }
+    });
+  }
+
+  logger.log(`Google Business sync stored ${reviews.length} reviews for ${propertyId}`);
+}
+
+function hashId(value: string) {
+  return createHash("sha1").update(value).digest("hex");
+}
+
+function formatGaDate(date: Date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseGaDate(value: string) {
+  if (/^\d{8}$/.test(value)) {
+    const year = Number(value.slice(0, 4));
+    const month = Number(value.slice(4, 6));
+    const day = Number(value.slice(6, 8));
+    return new Date(Date.UTC(year, month - 1, day));
+  }
+  return new Date(value);
+}
+
+function normalizeRating(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+    const lookup: Record<string, number> = {
+      ZERO: 0,
+      ONE: 1,
+      TWO: 2,
+      THREE: 3,
+      FOUR: 4,
+      FIVE: 5
+    };
+    const upper = value.toUpperCase();
+    if (upper in lookup) {
+      return lookup[upper];
+    }
+  }
+  return 0;
+}
+
+type GoogleAdsReportRow = {
+  segments?: { date?: string };
+  campaign?: { id?: string | number };
+  metrics?: { cost_micros?: string | number; costMicros?: string | number };
+};

--- a/apps/backend/src/jobs/jobs.service.ts
+++ b/apps/backend/src/jobs/jobs.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { Queue } from "bullmq";
+import { Queue, Worker } from "bullmq";
 import IORedis from "ioredis";
+
+import { processEtlJob } from "./etl.processor";
 
 @Injectable()
 export class JobsService implements OnModuleInit, OnModuleDestroy {
@@ -9,6 +11,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
   private connection?: IORedis;
   private etlQueue?: Queue;
   private alertsQueue?: Queue;
+  private etlWorker?: Worker;
 
   constructor(private readonly configService: ConfigService) {}
 
@@ -25,11 +28,23 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
       enableReadyCheck: false
     });
 
-    this.etlQueue = new Queue("etl-jobs", {
+    this.etlQueue = new Queue("etl", {
       connection: this.connection
     });
     this.alertsQueue = new Queue("alert-jobs", {
       connection: this.connection
+    });
+
+    this.etlWorker = new Worker(
+      "etl",
+      async (job) => {
+        await processEtlJob(job.data as { sourceId: string; job: string });
+      },
+      { connection: this.connection }
+    );
+
+    this.etlWorker.on("error", (error) => {
+      this.logger.error("ETL worker error", error as Error);
     });
 
     this.logger.log("BullMQ queues initialized");
@@ -38,6 +53,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
   async onModuleDestroy() {
     await this.etlQueue?.close();
     await this.alertsQueue?.close();
+    await this.etlWorker?.close();
     await this.connection?.quit();
   }
 
@@ -57,5 +73,15 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     }
 
     await this.alertsQueue.add("dispatchAlerts", {}, { removeOnComplete: true });
+  }
+
+  async enqueueEtlRun(sourceId: string, job: string) {
+    if (!this.etlQueue) {
+      this.logger.warn("ETL queue is not configured; running job synchronously");
+      return false;
+    }
+
+    await this.etlQueue.add(job || "run", { sourceId, job }, { removeOnComplete: true, attempts: 1 });
+    return true;
   }
 }

--- a/apps/backend/src/providers/entrata.provider.ts
+++ b/apps/backend/src/providers/entrata.provider.ts
@@ -177,6 +177,36 @@ export class EntrataProvider {
     }
     return Array.isArray(value) ? value : [value];
   }
+
+  async validate(rawCredential: Record<string, unknown>) {
+    try {
+      const apiKey = this.getString(rawCredential.apiKey, "apiKey");
+      const orgSlug = this.getString(rawCredential.orgSlug, "orgSlug");
+      const propertyIdValue = rawCredential.propertyId ?? rawCredential.propertyExternalId;
+      const propertyId = Number(propertyIdValue);
+
+      if (!Number.isFinite(propertyId)) {
+        throw new Error("Entrata credential missing propertyId");
+      }
+
+      const now = new Date();
+      const start = new Date(now.getTime() - 60 * 60 * 1000);
+
+      await this.fetchLeads({ apiKey, orgSlug }, { propertyId, from: start, to: now, perPage: 1 });
+      return { ok: true } as const;
+    } catch (error) {
+      const message = (error as Error).message ?? "Unable to validate Entrata credential";
+      this.logger.warn(`Entrata validation failed: ${message}`);
+      return { ok: false, message } as const;
+    }
+  }
+
+  private getString(value: unknown, field: string) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Missing credential field ${field}`);
+    }
+    return value.trim();
+  }
 }
 
 export type { EntrataCredential, EntrataLead, EntrataLeadEvent };

--- a/apps/backend/src/providers/ga4.provider.ts
+++ b/apps/backend/src/providers/ga4.provider.ts
@@ -29,4 +29,40 @@ export class Ga4Provider {
     this.logger.debug(`GA4 runReport returned ${rows.length} rows for property ${options.propertyId}`);
     return rows;
   }
+
+  async validate(rawCredential: Record<string, unknown>) {
+    try {
+      const accessToken = this.getString(rawCredential.accessToken, "accessToken");
+      const propertyId = this.getString(rawCredential.propertyId ?? rawCredential.ga4PropertyId, "propertyId");
+      const today = new Date();
+      const start = new Date(today.getTime() - 24 * 60 * 60 * 1000);
+      const date = `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}-${String(
+        start.getUTCDate()
+      ).padStart(2, "0")}`;
+
+      await this.runReport({
+        accessToken,
+        propertyId,
+        body: {
+          dimensions: [{ name: "date" }],
+          metrics: [{ name: "totalUsers" }],
+          dateRanges: [{ startDate: date, endDate: date }],
+          limit: 1
+        }
+      });
+
+      return { ok: true } as const;
+    } catch (error) {
+      const message = (error as Error).message ?? "Unable to validate GA4 credential";
+      this.logger.warn(`GA4 validation failed: ${message}`);
+      return { ok: false, message } as const;
+    }
+  }
+
+  private getString(value: unknown, field: string) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Missing credential field ${field}`);
+    }
+    return value.trim();
+  }
 }

--- a/apps/backend/src/providers/gbp.provider.ts
+++ b/apps/backend/src/providers/gbp.provider.ts
@@ -61,6 +61,28 @@ export class GoogleBusinessProvider {
       nextPageToken: response.data?.nextPageToken as string | undefined
     };
   }
+
+  async validate(rawCredential: Record<string, unknown>) {
+    try {
+      const accessToken = this.getString(rawCredential.accessToken, "accessToken");
+      const accountId = this.getString(rawCredential.accountId, "accountId");
+      const locationId = this.getString(rawCredential.locationId, "locationId");
+
+      await this.listReviews({ accessToken, accountId, locationId, pageToken: undefined });
+      return { ok: true } as const;
+    } catch (error) {
+      const message = (error as Error).message ?? "Unable to validate GBP credential";
+      this.logger.warn(`Google Business validation failed: ${message}`);
+      return { ok: false, message } as const;
+    }
+  }
+
+  private getString(value: unknown, field: string) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Missing credential field ${field}`);
+    }
+    return value.trim();
+  }
 }
 
 export type { GoogleBusinessReview, GoogleBusinessReviewOptions };

--- a/apps/backend/src/providers/google-ads.provider.ts
+++ b/apps/backend/src/providers/google-ads.provider.ts
@@ -49,4 +49,34 @@ export class GoogleAdsProvider {
     this.logger.debug(`Google Ads query returned ${rows.length} rows for customer ${options.customerId}`);
     return rows;
   }
+
+  async validate(rawCredential: Record<string, unknown>) {
+    try {
+      const accessToken = this.getString(rawCredential.accessToken, "accessToken");
+      const customerId = this.getString(rawCredential.customerId ?? rawCredential.loginCustomerId, "customerId");
+      const developerToken = typeof rawCredential.developerToken === "string" ? rawCredential.developerToken : undefined;
+      const loginCustomerId = typeof rawCredential.loginCustomerId === "string" ? rawCredential.loginCustomerId : undefined;
+
+      await this.runQuery({
+        accessToken,
+        customerId,
+        developerToken,
+        loginCustomerId,
+        query: "SELECT customer.id FROM customer LIMIT 1"
+      });
+
+      return { ok: true } as const;
+    } catch (error) {
+      const message = (error as Error).message ?? "Unable to validate Google Ads credential";
+      this.logger.warn(`Google Ads validation failed: ${message}`);
+      return { ok: false, message } as const;
+    }
+  }
+
+  private getString(value: unknown, field: string) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Missing credential field ${field}`);
+    }
+    return value.trim();
+  }
 }

--- a/apps/backend/src/sources/sources.controller.ts
+++ b/apps/backend/src/sources/sources.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, Headers, Param, Patch, Post } from "@nestjs/common";
+
+import { CreateSourceDto, UpdateSourceDto } from "./sources.dto";
+import { SourcesService } from "./sources.service";
+
+@Controller("admin/sources")
+export class SourcesController {
+  constructor(private readonly sourcesService: SourcesService) {}
+
+  @Get()
+  list(@Headers("x-mock-mode") mockHeader?: string) {
+    return this.sourcesService.list(this.shouldUseMock(mockHeader));
+  }
+
+  @Post()
+  create(@Body() dto: CreateSourceDto) {
+    return this.sourcesService.create({
+      ...dto,
+      credential: dto.credential
+    });
+  }
+
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() dto: UpdateSourceDto) {
+    return this.sourcesService.update(id, {
+      ...dto,
+      credential: dto.credential
+    });
+  }
+
+  @Delete(":id")
+  remove(@Param("id") id: string) {
+    return this.sourcesService.remove(id);
+  }
+
+  @Post(":id/run")
+  run(@Param("id") id: string) {
+    return this.sourcesService.run(id);
+  }
+
+  private shouldUseMock(header?: string) {
+    return header?.toLowerCase() === "true";
+  }
+}

--- a/apps/backend/src/sources/sources.dto.ts
+++ b/apps/backend/src/sources/sources.dto.ts
@@ -1,0 +1,49 @@
+import { IsBoolean, IsEnum, IsNotEmptyObject, IsObject, IsOptional, IsString } from "class-validator";
+
+export enum SourceTypeDto {
+  ENTRATA = "ENTRATA",
+  GA4 = "GA4",
+  ADS = "ADS",
+  GBP = "GBP"
+}
+
+export class CreateSourceDto {
+  @IsString()
+  propertyId!: string;
+
+  @IsEnum(SourceTypeDto)
+  type!: SourceTypeDto;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @IsObject()
+  @IsNotEmptyObject()
+  credential!: Record<string, unknown>;
+}
+
+export class UpdateSourceDto {
+  @IsOptional()
+  @IsString()
+  propertyId?: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @IsOptional()
+  @IsObject()
+  @IsNotEmptyObject()
+  credential?: Record<string, unknown>;
+}
+
+export type CredentialPayload = Record<string, unknown>;

--- a/apps/backend/src/sources/sources.module.ts
+++ b/apps/backend/src/sources/sources.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+
+import { SourcesController } from "./sources.controller";
+import { SourcesService } from "./sources.service";
+import { JobsModule } from "../jobs/jobs.module";
+import { PrismaModule } from "../prisma/prisma.module";
+import { ProvidersModule } from "../providers/providers.module";
+
+@Module({
+  imports: [PrismaModule, ProvidersModule, JobsModule],
+  controllers: [SourcesController],
+  providers: [SourcesService],
+  exports: [SourcesService]
+})
+export class SourcesModule {}

--- a/apps/backend/src/sources/sources.service.ts
+++ b/apps/backend/src/sources/sources.service.ts
@@ -1,0 +1,326 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Prisma, SourceAccountType } from "@prisma/client";
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypto";
+
+import { CreateSourceDto, CredentialPayload, SourceTypeDto, UpdateSourceDto } from "./sources.dto";
+import { configureEtlProcessor, processEtlJob } from "../jobs/etl.processor";
+import { JobsService } from "../jobs/jobs.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { EntrataProvider } from "../providers/entrata.provider";
+import { Ga4Provider } from "../providers/ga4.provider";
+import { GoogleBusinessProvider } from "../providers/gbp.provider";
+import { GoogleAdsProvider } from "../providers/google-ads.provider";
+
+export type SourceStatus = "CONNECTED" | "ERROR" | "UNVERIFIED";
+
+interface ProviderValidationResult {
+  ok: boolean;
+  message?: string;
+}
+
+interface SourceSummary {
+  id: string;
+  name?: string | null;
+  propertyId?: string;
+  type: SourceTypeDto;
+  status: SourceStatus;
+  lastSuccessAt?: string | null;
+  lastErrorAt?: string | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+  validationMessage?: string;
+}
+
+const DTO_TO_PRISMA: Record<SourceTypeDto, SourceAccountType> = {
+  [SourceTypeDto.ENTRATA]: SourceAccountType.ENTRATA,
+  [SourceTypeDto.GA4]: SourceAccountType.GA4,
+  [SourceTypeDto.ADS]: SourceAccountType.GOOGLE_ADS,
+  [SourceTypeDto.GBP]: SourceAccountType.GBP
+};
+
+const PRISMA_TO_DTO: Record<SourceAccountType, SourceTypeDto | undefined> = {
+  [SourceAccountType.ENTRATA]: SourceTypeDto.ENTRATA,
+  [SourceAccountType.GA4]: SourceTypeDto.GA4,
+  [SourceAccountType.GBP]: SourceTypeDto.GBP,
+  [SourceAccountType.GOOGLE_ADS]: SourceTypeDto.ADS,
+  [SourceAccountType.WORDPRESS]: undefined
+};
+
+const MOCK_SOURCES: SourceSummary[] = [
+  {
+    id: "mock-entrata",
+    name: "Entrata demo property",
+    propertyId: "prop-atrium",
+    type: SourceTypeDto.ENTRATA,
+    status: "CONNECTED",
+    lastSuccessAt: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
+    lastErrorAt: null,
+    enabled: true,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 5).toISOString()
+  },
+  {
+    id: "mock-ga4",
+    name: "GA4 demo property",
+    propertyId: "prop-harbor",
+    type: SourceTypeDto.GA4,
+    status: "UNVERIFIED",
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    enabled: true,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 10).toISOString()
+  },
+  {
+    id: "mock-ads",
+    name: "Google Ads sandbox",
+    propertyId: "prop-quartz",
+    type: SourceTypeDto.ADS,
+    status: "ERROR",
+    lastSuccessAt: null,
+    lastErrorAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    enabled: false,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 15).toISOString()
+  }
+];
+
+@Injectable()
+export class SourcesService {
+  private readonly logger = new Logger(SourcesService.name);
+  private readonly encryptionKey?: Buffer;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+    private readonly jobsService: JobsService,
+    private readonly entrataProvider: EntrataProvider,
+    private readonly ga4Provider: Ga4Provider,
+    private readonly googleAdsProvider: GoogleAdsProvider,
+    private readonly gbpProvider: GoogleBusinessProvider
+  ) {
+    const configuredKey = this.configService.get<string>("ENCRYPTION_KEY") ?? process.env.ENCRYPTION_KEY;
+    if (configuredKey && configuredKey.trim().length > 0) {
+      this.encryptionKey = createHash("sha256").update(configuredKey).digest();
+    } else {
+      this.logger.warn(
+        "ENCRYPTION_KEY not configured. Source credentials will be stored unencrypted. Configure this in production environments."
+      );
+    }
+
+    configureEtlProcessor({
+      prisma: this.prisma,
+      decrypt: (value) => this.decryptCredential(value),
+      providers: {
+        entrata: this.entrataProvider,
+        ga4: this.ga4Provider,
+        ads: this.googleAdsProvider,
+        gbp: this.gbpProvider
+      },
+      logger: new Logger("EtlProcessor")
+    });
+  }
+
+  async list(useMockFallback: boolean) {
+    try {
+      const sources = await this.prisma.sourceAccount.findMany({
+        orderBy: { createdAt: "asc" }
+      });
+
+      if (sources.length === 0 && useMockFallback) {
+        return { sources: MOCK_SOURCES };
+      }
+
+      return { sources: sources.map((source) => this.toSummary(source)) };
+    } catch (error) {
+      this.logger.error("Unable to load sources", error as Error);
+      if (useMockFallback) {
+        return { sources: MOCK_SOURCES };
+      }
+      throw error;
+    }
+  }
+
+  async create(dto: CreateSourceDto & { credential: CredentialPayload }) {
+    const prismaType = DTO_TO_PRISMA[dto.type];
+    if (!prismaType) {
+      throw new Error(`Unsupported source type: ${dto.type}`);
+    }
+
+    const now = new Date();
+    const source = await this.prisma.sourceAccount.create({
+      data: {
+        propertyId: dto.propertyId,
+        type: prismaType,
+        name: dto.name,
+        credential: this.encryptCredential(dto.credential),
+        enabled: dto.enabled ?? true,
+        status: "UNVERIFIED",
+        lastSuccessAt: null,
+        lastErrorAt: null,
+        createdAt: now,
+        updatedAt: now
+      }
+    });
+
+    const result = await this.validateAndUpdate(source.id);
+    return {
+      source: this.toSummary(result.source),
+      validationMessage: result.validation.message
+    };
+  }
+
+  async update(id: string, dto: UpdateSourceDto & { credential?: CredentialPayload }) {
+    const data: Prisma.SourceAccountUpdateInput = {};
+
+    if (dto.propertyId) {
+      data.property = { connect: { id: dto.propertyId } };
+    }
+    if (dto.name !== undefined) {
+      data.name = dto.name;
+    }
+    if (dto.enabled !== undefined) {
+      data.enabled = dto.enabled;
+    }
+    if (dto.credential) {
+      data.credential = this.encryptCredential(dto.credential);
+    }
+
+    const updated = await this.prisma.sourceAccount.update({
+      where: { id },
+      data
+    });
+
+    const result = await this.validateAndUpdate(updated.id);
+    return {
+      source: this.toSummary(result.source),
+      validationMessage: result.validation.message
+    };
+  }
+
+  async remove(id: string) {
+    await this.prisma.sourceAccount.delete({ where: { id } });
+    return { ok: true };
+  }
+
+  async run(id: string) {
+    const queued = await this.jobsService.enqueueEtlRun(id, "manual-sync");
+    if (queued) {
+      return { ok: true, mode: "queued" };
+    }
+
+    await processEtlJob({ sourceId: id, job: "manual-sync" });
+    return { ok: true, mode: "immediate" };
+  }
+
+  private encryptCredential(credential: CredentialPayload): Prisma.JsonValue {
+    if (!this.encryptionKey) {
+      return credential as Prisma.JsonObject;
+    }
+
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", this.encryptionKey, iv);
+    const payload = JSON.stringify(credential);
+    const encrypted = Buffer.concat([cipher.update(payload, "utf8"), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const packed = Buffer.concat([iv, authTag, encrypted]).toString("base64");
+    return { enc: packed };
+  }
+
+  private decryptCredential(value: unknown): CredentialPayload {
+    if (!value || typeof value !== "object") {
+      return {};
+    }
+
+    if ("enc" in (value as Record<string, unknown>)) {
+      const encrypted = (value as Record<string, string>).enc;
+      if (!this.encryptionKey || !encrypted) {
+        return {};
+      }
+
+      const raw = Buffer.from(encrypted, "base64");
+      const iv = raw.subarray(0, 12);
+      const authTag = raw.subarray(12, 28);
+      const ciphertext = raw.subarray(28);
+
+      const decipher = createDecipheriv("aes-256-gcm", this.encryptionKey, iv);
+      decipher.setAuthTag(authTag);
+      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+      try {
+        return JSON.parse(decrypted) as CredentialPayload;
+      } catch (error) {
+        this.logger.error("Failed to parse decrypted credential", error as Error);
+        return {};
+      }
+    }
+
+    return value as CredentialPayload;
+  }
+
+  private async validateAndUpdate(id: string) {
+    const source = await this.prisma.sourceAccount.findUniqueOrThrow({ where: { id } });
+    const validation = await this.validate(source);
+    const now = new Date();
+
+    const data: Prisma.SourceAccountUpdateInput = {
+      status: validation.ok ? "CONNECTED" : "ERROR",
+      lastSuccessAt: validation.ok ? now : source.lastSuccessAt,
+      lastErrorAt: validation.ok ? source.lastErrorAt : now
+    };
+
+    const updated = await this.prisma.sourceAccount.update({ where: { id }, data });
+    return { source: updated, validation };
+  }
+
+  private async validate(source: Prisma.SourceAccount): Promise<ProviderValidationResult> {
+    const credential = this.decryptCredential(source.credential);
+
+    try {
+      switch (source.type) {
+        case SourceAccountType.ENTRATA:
+          return this.wrapValidationResult(await this.entrataProvider.validate(credential));
+        case SourceAccountType.GA4:
+          return this.wrapValidationResult(await this.ga4Provider.validate(credential));
+        case SourceAccountType.GOOGLE_ADS:
+          return this.wrapValidationResult(await this.googleAdsProvider.validate(credential));
+        case SourceAccountType.GBP:
+          return this.wrapValidationResult(await this.gbpProvider.validate(credential));
+        default:
+          return { ok: false, message: `Validation not implemented for ${source.type}` };
+      }
+    } catch (error) {
+      this.logger.error(`Validation failed for source ${source.id}`, error as Error);
+      return { ok: false, message: (error as Error).message };
+    }
+  }
+
+  private wrapValidationResult(result: boolean | ProviderValidationResult): ProviderValidationResult {
+    if (typeof result === "boolean") {
+      return { ok: result };
+    }
+    return result;
+  }
+
+  private toSummary(source: Prisma.SourceAccount): SourceSummary {
+    const type = PRISMA_TO_DTO[source.type];
+    if (!type) {
+      throw new Error(`Cannot map source type ${source.type}`);
+    }
+
+    return {
+      id: source.id,
+      name: source.name,
+      propertyId: source.propertyId,
+      type,
+      status: (source.status as SourceStatus) ?? "UNVERIFIED",
+      lastSuccessAt: source.lastSuccessAt ? source.lastSuccessAt.toISOString() : null,
+      lastErrorAt: source.lastErrorAt ? source.lastErrorAt.toISOString() : null,
+      enabled: source.enabled ?? true,
+      createdAt: source.createdAt.toISOString(),
+      updatedAt: source.updatedAt.toISOString()
+    };
+  }
+}

--- a/apps/frontend/app/admin/sources/page.tsx
+++ b/apps/frontend/app/admin/sources/page.tsx
@@ -1,0 +1,19 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { SourcesAdminView } from "./sources-view";
+import { authOptions } from "@/lib/auth-options";
+
+export default async function AdminSourcesPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  if (session.user?.role !== "admin") {
+    redirect("/dashboard");
+  }
+
+  return <SourcesAdminView />;
+}

--- a/apps/frontend/app/admin/sources/sources-view.tsx
+++ b/apps/frontend/app/admin/sources/sources-view.tsx
@@ -1,0 +1,621 @@
+
+"use client";
+
+import { useCallback, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Pencil, Play, Plus, Trash } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { api } from "@/lib/api-client";
+import { createSource, deleteSource, listSources, runSource, updateSource } from "@/lib/api/sources";
+import { cn } from "@/lib/utils";
+import type {
+  CreateSourceRequest,
+  PropertiesResponse,
+  SourceAccount,
+  SourceMutationResponse,
+  SourceType,
+  UpdateSourceRequest
+} from "@shared/api";
+
+interface BannerState {
+  tone: "success" | "error" | "info";
+  message: string;
+}
+
+interface ModalState {
+  mode: "create" | "edit";
+  source?: SourceAccount;
+}
+
+interface SourceFormValues {
+  propertyId: string;
+  type: SourceType;
+  name: string;
+  enabled: boolean;
+  credential: Record<string, string>;
+}
+
+const TYPE_LABELS: Record<SourceType, string> = {
+  ENTRATA: "Entrata",
+  GA4: "Google Analytics 4",
+  ADS: "Google Ads",
+  GBP: "Google Business Profile"
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  CONNECTED: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  ERROR: "bg-red-100 text-red-800 border-red-200",
+  UNVERIFIED: "bg-amber-100 text-amber-800 border-amber-200"
+};
+
+function buildInitialValues(type: SourceType): SourceFormValues {
+  return {
+    propertyId: "",
+    type,
+    name: "",
+    enabled: true,
+    credential: {}
+  };
+}
+
+function cleanCredential(credential: Record<string, string>) {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(credential)) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      result[key] = value.trim();
+    }
+  }
+  return result;
+}
+
+function formatTimestamp(value?: string | null) {
+  if (!value) return "—";
+  try {
+    const date = new Date(value);
+    return date.toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function SourceStatusBadge({ status }: { status?: string | null }) {
+  if (!status) {
+    return (
+      <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+        Unverified
+      </span>
+    );
+  }
+  const style = STATUS_STYLES[status] ?? STATUS_STYLES.UNVERIFIED;
+  const label = status.charAt(0) + status.slice(1).toLowerCase();
+  return (
+    <span className={cn("inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium", style)}>{label}</span>
+  );
+}
+
+interface SourceFormProps {
+  mode: "create" | "edit";
+  values: SourceFormValues;
+  onChange: (next: SourceFormValues) => void;
+  onSubmit: (values: SourceFormValues) => void;
+  onClose: () => void;
+  isSubmitting: boolean;
+  properties?: PropertiesResponse["properties"];
+}
+
+function SourceForm({ mode, values, onChange, onSubmit, onClose, isSubmitting, properties }: SourceFormProps) {
+  const updateField = <K extends keyof SourceFormValues>(field: K, value: SourceFormValues[K]) => {
+    onChange({ ...values, [field]: value });
+  };
+
+  const updateCredential = (key: string, value: string) => {
+    onChange({ ...values, credential: { ...values.credential, [key]: value } });
+  };
+
+  const handleTypeChange = (type: SourceType) => {
+    onChange({ ...values, type, credential: {} });
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onSubmit(values);
+  };
+
+  const propertyOptions = properties ?? [];
+  const typeOptions = Object.entries(TYPE_LABELS) as [SourceType, string][];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+      <div className="w-full max-w-xl rounded-2xl border border-border bg-card p-6 shadow-2xl">
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">
+              {mode === "create" ? "Add connection" : `Edit ${TYPE_LABELS[values.type]}`}
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {mode === "create"
+                ? "Provide credentials for the integration you want to connect. We'll verify immediately after saving."
+                : "Update the connection details. Leave credential fields blank to keep the current secret values."}
+            </p>
+          </div>
+          <button type="button" className="text-muted-foreground transition hover:text-foreground" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-1 text-sm font-medium text-foreground">
+            Integration type
+            <select
+              className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
+              value={values.type}
+              onChange={(event) => handleTypeChange(event.target.value as SourceType)}
+              disabled={mode === "edit"}
+            >
+              {typeOptions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm font-medium text-foreground">
+              Property
+              <select
+                className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
+                value={values.propertyId}
+                onChange={(event) => updateField("propertyId", event.target.value)}
+                required
+              >
+                <option value="" disabled>
+                  Select property
+                </option>
+                {propertyOptions.map((property) => (
+                  <option key={property.id} value={property.id}>
+                    {property.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-foreground">
+              Display name
+              <Input
+                value={values.name}
+                onChange={(event) => updateField("name", event.target.value)}
+                placeholder="Optional"
+              />
+            </label>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="source-enabled"
+              checked={values.enabled}
+              onCheckedChange={(checked) => updateField("enabled", Boolean(checked))}
+            />
+            <label htmlFor="source-enabled" className="text-sm text-foreground">
+              Enable this connection
+            </label>
+          </div>
+
+          <Separator />
+
+          <CredentialFields
+            type={values.type}
+            credential={values.credential}
+            onChange={updateCredential}
+            mode={mode}
+          />
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {mode === "create" ? "Save connection" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function CredentialFields({
+  type,
+  credential,
+  onChange,
+  mode
+}: {
+  type: SourceType;
+  credential: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+  mode: "create" | "edit";
+}) {
+  const commonDescription =
+    mode === "create"
+      ? "All fields are encrypted before storing."
+      : "Leave any field blank to keep the current stored credential.";
+
+  switch (type) {
+    case "ENTRATA":
+      return (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Provide your Entrata API key and organization slug. {commonDescription}
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Organization slug"
+              value={credential.orgSlug ?? ""}
+              onChange={(value) => onChange("orgSlug", value)}
+              placeholder="example-org"
+              required={mode === "create"}
+            />
+            <Field
+              label="API key"
+              value={credential.apiKey ?? ""}
+              onChange={(value) => onChange("apiKey", value)}
+              placeholder="Paste secure token"
+              required={mode === "create"}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Entrata property ID"
+              value={credential.propertyId ?? ""}
+              onChange={(value) => onChange("propertyId", value)}
+              placeholder="Numeric property ID"
+              required={mode === "create"}
+            />
+            <Field
+              label="Custom base URL"
+              value={credential.baseUrl ?? ""}
+              onChange={(value) => onChange("baseUrl", value)}
+              placeholder="https://apis.entrata.com"
+            />
+          </div>
+        </div>
+      );
+    case "GA4":
+      return (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Provide an access token or service account exchange token and the GA4 property ID. {commonDescription}
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Access token"
+              value={credential.accessToken ?? ""}
+              onChange={(value) => onChange("accessToken", value)}
+              placeholder="ya29..."
+              required={mode === "create"}
+            />
+            <Field
+              label="GA4 property ID"
+              value={credential.propertyId ?? ""}
+              onChange={(value) => onChange("propertyId", value)}
+              placeholder="properties/123456"
+              required={mode === "create"}
+            />
+          </div>
+        </div>
+      );
+    case "ADS":
+      return (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Connect a Google Ads customer. Include the developer token if you override the default. {commonDescription}
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Access token"
+              value={credential.accessToken ?? ""}
+              onChange={(value) => onChange("accessToken", value)}
+              placeholder="ya29..."
+              required={mode === "create"}
+            />
+            <Field
+              label="Customer ID"
+              value={credential.customerId ?? ""}
+              onChange={(value) => onChange("customerId", value)}
+              placeholder="123-456-7890"
+              required={mode === "create"}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Manager customer ID"
+              value={credential.loginCustomerId ?? ""}
+              onChange={(value) => onChange("loginCustomerId", value)}
+              placeholder="Optional MCC ID"
+            />
+            <Field
+              label="Developer token"
+              value={credential.developerToken ?? ""}
+              onChange={(value) => onChange("developerToken", value)}
+              placeholder="Optional developer token"
+            />
+          </div>
+        </div>
+      );
+    case "GBP":
+      return (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Provide Google Business access and location identifiers. {commonDescription}
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Access token"
+              value={credential.accessToken ?? ""}
+              onChange={(value) => onChange("accessToken", value)}
+              placeholder="ya29..."
+              required={mode === "create"}
+            />
+            <Field
+              label="Account ID"
+              value={credential.accountId ?? ""}
+              onChange={(value) => onChange("accountId", value)}
+              placeholder="accounts/123456"
+              required={mode === "create"}
+            />
+          </div>
+          <Field
+            label="Location ID"
+            value={credential.locationId ?? ""}
+            onChange={(value) => onChange("locationId", value)}
+            placeholder="locations/123456"
+            required={mode === "create"}
+          />
+        </div>
+      );
+    default:
+      return null;
+  }
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+  required
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-sm font-medium text-foreground">
+      {label}
+      <Input value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} required={required} />
+    </label>
+  );
+}
+
+export function SourcesAdminView() {
+  const queryClient = useQueryClient();
+  const [banner, setBanner] = useState<BannerState | null>(null);
+  const [modal, setModal] = useState<ModalState | null>(null);
+  const [formValues, setFormValues] = useState<SourceFormValues>(buildInitialValues("ENTRATA"));
+
+  const sourcesQuery = useQuery({ queryKey: ["admin-sources"], queryFn: listSources });
+  const propertiesQuery = useQuery({ queryKey: ["properties"], queryFn: api.properties });
+
+  const handleSuccess = useCallback(
+    (response: SourceMutationResponse, action: "created" | "updated") => {
+      queryClient.invalidateQueries({ queryKey: ["admin-sources"] });
+      const tone: BannerState["tone"] = response.source.status === "ERROR" ? "error" : "success";
+      const validationMessage = response.validationMessage
+        ? response.validationMessage
+        : action === "created"
+          ? "Connection saved."
+          : "Changes saved.";
+      setBanner({ tone, message: validationMessage });
+      setModal(null);
+    },
+    [queryClient]
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateSourceRequest) => createSource(payload),
+    onSuccess: (data) => handleSuccess(data, "created"),
+    onError: (error: unknown) => {
+      setBanner({ tone: "error", message: (error as Error).message ?? "Unable to create source." });
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateSourceRequest }) => updateSource(id, payload),
+    onSuccess: (data) => handleSuccess(data, "updated"),
+    onError: (error: unknown) => {
+      setBanner({ tone: "error", message: (error as Error).message ?? "Unable to update source." });
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSource(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-sources"] });
+      setBanner({ tone: "info", message: "Connection removed." });
+    },
+    onError: (error: unknown) => {
+      setBanner({ tone: "error", message: (error as Error).message ?? "Unable to delete source." });
+    }
+  });
+
+  const runMutation = useMutation({
+    mutationFn: (id: string) => runSource(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-sources"] });
+      setBanner({ tone: "success", message: "Sync triggered. Check back in a moment." });
+    },
+    onError: (error: unknown) => {
+      setBanner({ tone: "error", message: (error as Error).message ?? "Unable to run sync." });
+    }
+  });
+
+  const sources = sourcesQuery.data?.sources ?? [];
+
+  const openModal = (type: SourceType, source?: SourceAccount) => {
+    if (source) {
+      setFormValues({
+        propertyId: source.propertyId ?? "",
+        type: source.type,
+        name: source.name ?? "",
+        enabled: source.enabled,
+        credential: {}
+      });
+      setModal({ mode: "edit", source });
+    } else {
+      setFormValues(buildInitialValues(type));
+      setModal({ mode: "create" });
+    }
+  };
+
+  const handleSubmit = (values: SourceFormValues) => {
+    const credential = cleanCredential(values.credential);
+    if (modal?.mode === "create") {
+      const payload: CreateSourceRequest = {
+        propertyId: values.propertyId,
+        type: values.type,
+        name: values.name.trim() || undefined,
+        credential,
+        enabled: values.enabled
+      };
+      createMutation.mutate(payload);
+    } else if (modal?.mode === "edit" && modal.source) {
+      const payload: UpdateSourceRequest = {
+        propertyId: values.propertyId,
+        name: values.name.trim() || undefined,
+        enabled: values.enabled,
+        ...(Object.keys(credential).length > 0 ? { credential } : {})
+      };
+      updateMutation.mutate({ id: modal.source.id, payload });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Connections / Sources</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Manage API credentials for Entrata, Google Analytics, Ads, and Business Profile providers.
+          </p>
+        </div>
+        <Button onClick={() => openModal("ENTRATA")}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add connection
+        </Button>
+      </header>
+
+      {banner ? (
+        <div
+          className={cn(
+            "flex items-start justify-between gap-3 rounded-xl border px-4 py-3 text-sm",
+            banner.tone === "success" && "border-emerald-200 bg-emerald-50 text-emerald-800",
+            banner.tone === "error" && "border-red-200 bg-red-50 text-red-800",
+            banner.tone === "info" && "border-blue-200 bg-blue-50 text-blue-800"
+          )}
+        >
+          <span>{banner.message}</span>
+          <button className="text-xs underline" onClick={() => setBanner(null)}>
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
+      {sourcesQuery.isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading connections...
+        </div>
+      ) : null}
+
+      {sourcesQuery.isError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          Unable to load sources. Please try again shortly.
+        </div>
+      ) : null}
+
+      {!sourcesQuery.isLoading && sources.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border px-6 py-12 text-center">
+          <p className="text-base font-medium text-foreground">No connections yet</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Connect your first integration to begin syncing operational data into the dashboard.
+          </p>
+          <Button className="mt-4" variant="outline" onClick={() => openModal("ENTRATA")}>
+            <Plus className="mr-2 h-4 w-4" /> Add connection
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4">
+        {sources.map((source) => (
+          <article
+            key={source.id}
+            className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="space-y-1">
+              <div className="flex flex-wrap items-center gap-3">
+                <h3 className="text-lg font-semibold text-foreground">{source.name || TYPE_LABELS[source.type]}</h3>
+                <SourceStatusBadge status={source.status} />
+                {!source.enabled ? (
+                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">Disabled</span>
+                ) : null}
+              </div>
+              <p className="text-sm text-muted-foreground">{TYPE_LABELS[source.type]}</p>
+              <p className="text-xs text-muted-foreground">Last success: {formatTimestamp(source.lastSuccessAt)}</p>
+              {source.status === "ERROR" ? (
+                <p className="text-xs text-red-600">Validation failed. Update credentials and try again.</p>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => runMutation.mutate(source.id)}
+                disabled={runMutation.isPending}
+              >
+                {runMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Play className="mr-2 h-4 w-4" />}
+                Run sync
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => openModal(source.type, source)}>
+                <Pencil className="mr-2 h-4 w-4" /> Edit
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-red-600 hover:bg-red-50"
+                onClick={() => deleteMutation.mutate(source.id)}
+                disabled={deleteMutation.isPending}
+              >
+                <Trash className="mr-2 h-4 w-4" /> Delete
+              </Button>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {modal ? (
+        <SourceForm
+          mode={modal.mode}
+          values={formValues}
+          onChange={setFormValues}
+          onSubmit={handleSubmit}
+          onClose={() => setModal(null)}
+          isSubmitting={createMutation.isPending || updateMutation.isPending}
+          properties={propertiesQuery.data?.properties}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/dashboard-shell.tsx
+++ b/apps/frontend/components/dashboard/dashboard-shell.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import { Search } from "lucide-react";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import type { MeResponse } from "@shared/api";
 
 import { ThemeToggle } from "./theme-toggle";
@@ -21,6 +24,14 @@ export default function DashboardShell({
   const displayName = user.name?.trim() || "Set your name";
   const displayEmail = user.email?.trim() || "Add your email";
   const initials = displayName.charAt(0).toUpperCase();
+  const pathname = usePathname();
+
+  const links = [
+    { href: "/dashboard", label: "Dashboard" },
+    ...(role === "admin"
+      ? ([{ href: "/admin/sources", label: "Connections / Integrations" }] as const)
+      : [])
+  ];
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -57,6 +68,23 @@ export default function DashboardShell({
               ) : null}
             </div>
           </div>
+          <nav className="mt-6 flex flex-wrap items-center gap-3 text-sm font-medium text-muted-foreground">
+            {links.map((link) => {
+              const isActive = pathname === link.href;
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={cn(
+                    "rounded-full border border-transparent px-4 py-1.5 transition hover:text-foreground",
+                    isActive && "border-border bg-card text-foreground"
+                  )}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
         </div>
       </header>
       <ScrollArea className="flex-1">

--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -196,6 +196,11 @@ export function DashboardView({ role }: DashboardViewProps) {
             >
               Add a property
             </Button>
+            {role === "admin" ? (
+              <Button asChild variant="outline" className="rounded-full px-6">
+                <Link href="/admin/sources">Connect a data source →</Link>
+              </Button>
+            ) : null}
           </div>
         </section>
       ) : null}

--- a/apps/frontend/lib/api/sources.ts
+++ b/apps/frontend/lib/api/sources.ts
@@ -1,0 +1,75 @@
+import {
+  createSourceRequestSchema,
+  listSourcesResponseSchema,
+  sourceMutationResponseSchema,
+  updateSourceRequestSchema,
+  type CreateSourceRequest,
+  type ListSourcesResponse,
+  type SourceMutationResponse,
+  type UpdateSourceRequest
+} from "@shared/api";
+
+import { apiBaseUrl, isMockMode } from "../utils";
+
+async function request<T>(
+  path: string,
+  init: RequestInit,
+  schema?: { parse: (data: unknown) => T }
+): Promise<T extends void ? void : T> {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      "x-mock-mode": isMockMode() ? "true" : "false",
+      ...(init.headers ?? {})
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Request failed for ${path}: ${response.status} ${body}`);
+  }
+
+  if (!schema) {
+    return undefined as T extends void ? void : T;
+  }
+
+  const json = await response.json();
+  return schema.parse(json);
+}
+
+export async function listSources(): Promise<ListSourcesResponse> {
+  return request<ListSourcesResponse>("/admin/sources", { method: "GET" }, listSourcesResponseSchema);
+}
+
+export async function createSource(payload: CreateSourceRequest): Promise<SourceMutationResponse> {
+  const body = JSON.stringify(createSourceRequestSchema.parse(payload));
+  return request<SourceMutationResponse>(
+    "/admin/sources",
+    {
+      method: "POST",
+      body
+    },
+    sourceMutationResponseSchema
+  );
+}
+
+export async function updateSource(id: string, payload: UpdateSourceRequest): Promise<SourceMutationResponse> {
+  const body = JSON.stringify(updateSourceRequestSchema.parse(payload));
+  return request<SourceMutationResponse>(
+    `/admin/sources/${id}`,
+    {
+      method: "PATCH",
+      body
+    },
+    sourceMutationResponseSchema
+  );
+}
+
+export async function deleteSource(id: string): Promise<void> {
+  await request<void>(`/admin/sources/${id}`, { method: "DELETE" });
+}
+
+export async function runSource(id: string): Promise<void> {
+  await request<void>(`/admin/sources/${id}/run`, { method: "POST" });
+}

--- a/packages/shared/dist/schemas.d.ts
+++ b/packages/shared/dist/schemas.d.ts
@@ -651,6 +651,204 @@ export declare const alertsResponseSchema: z.ZodObject<{
         severity: "high" | "medium" | "low";
     }[];
 }>;
+export declare const sourceTypeSchema: z.ZodEnum<["ENTRATA", "GA4", "ADS", "GBP"]>;
+export declare const sourceStatusSchema: z.ZodEnum<["CONNECTED", "ERROR", "UNVERIFIED"]>;
+export declare const sourceAccountSchema: z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    propertyId: z.ZodOptional<z.ZodString>;
+    type: z.ZodEnum<["ENTRATA", "GA4", "ADS", "GBP"]>;
+    status: z.ZodOptional<z.ZodNullable<z.ZodEnum<["CONNECTED", "ERROR", "UNVERIFIED"]>>>;
+    lastSuccessAt: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    lastErrorAt: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    enabled: z.ZodBoolean;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+    enabled: boolean;
+    name?: string | null | undefined;
+    status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+    propertyId?: string | undefined;
+    lastSuccessAt?: string | null | undefined;
+    lastErrorAt?: string | null | undefined;
+}, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+    enabled: boolean;
+    name?: string | null | undefined;
+    status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+    propertyId?: string | undefined;
+    lastSuccessAt?: string | null | undefined;
+    lastErrorAt?: string | null | undefined;
+}>;
+export declare const listSourcesResponseSchema: z.ZodObject<{
+    sources: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        propertyId: z.ZodOptional<z.ZodString>;
+        type: z.ZodEnum<["ENTRATA", "GA4", "ADS", "GBP"]>;
+        status: z.ZodOptional<z.ZodNullable<z.ZodEnum<["CONNECTED", "ERROR", "UNVERIFIED"]>>>;
+        lastSuccessAt: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        lastErrorAt: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        enabled: z.ZodBoolean;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    }, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    sources: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    }[];
+}, {
+    sources: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    }[];
+}>;
+export declare const createSourceRequestSchema: z.ZodObject<{
+    propertyId: z.ZodString;
+    type: z.ZodEnum<["ENTRATA", "GA4", "ADS", "GBP"]>;
+    name: z.ZodOptional<z.ZodString>;
+    credential: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    enabled: z.ZodOptional<z.ZodBoolean>;
+}, "strip", z.ZodTypeAny, {
+    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+    propertyId: string;
+    credential: Record<string, unknown>;
+    name?: string | undefined;
+    enabled?: boolean | undefined;
+}, {
+    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+    propertyId: string;
+    credential: Record<string, unknown>;
+    name?: string | undefined;
+    enabled?: boolean | undefined;
+}>;
+export declare const updateSourceRequestSchema: z.ZodObject<{
+    propertyId: z.ZodOptional<z.ZodString>;
+    name: z.ZodOptional<z.ZodString>;
+    credential: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+    enabled: z.ZodOptional<z.ZodBoolean>;
+}, "strip", z.ZodTypeAny, {
+    name?: string | undefined;
+    propertyId?: string | undefined;
+    enabled?: boolean | undefined;
+    credential?: Record<string, unknown> | undefined;
+}, {
+    name?: string | undefined;
+    propertyId?: string | undefined;
+    enabled?: boolean | undefined;
+    credential?: Record<string, unknown> | undefined;
+}>;
+export declare const sourceMutationResponseSchema: z.ZodObject<{
+    source: z.ZodObject<{
+        id: z.ZodString;
+        name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        propertyId: z.ZodOptional<z.ZodString>;
+        type: z.ZodEnum<["ENTRATA", "GA4", "ADS", "GBP"]>;
+        status: z.ZodOptional<z.ZodNullable<z.ZodEnum<["CONNECTED", "ERROR", "UNVERIFIED"]>>>;
+        lastSuccessAt: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        lastErrorAt: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        enabled: z.ZodBoolean;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    }, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    }>;
+    validationMessage: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    source: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    };
+    validationMessage?: string | undefined;
+}, {
+    source: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
+        enabled: boolean;
+        name?: string | null | undefined;
+        status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
+        propertyId?: string | undefined;
+        lastSuccessAt?: string | null | undefined;
+        lastErrorAt?: string | null | undefined;
+    };
+    validationMessage?: string | undefined;
+}>;
 export declare const propertiesResponseSchema: z.ZodObject<{
     properties: z.ZodArray<z.ZodObject<Pick<{
         id: z.ZodString;
@@ -721,3 +919,10 @@ export type WeeklyReportResponse = z.infer<typeof weeklyReportSchema>;
 export type Alert = z.infer<typeof alertSchema>;
 export type AlertsResponse = z.infer<typeof alertsResponseSchema>;
 export type PropertiesResponse = z.infer<typeof propertiesResponseSchema>;
+export type SourceType = z.infer<typeof sourceTypeSchema>;
+export type SourceStatus = z.infer<typeof sourceStatusSchema>;
+export type SourceAccount = z.infer<typeof sourceAccountSchema>;
+export type ListSourcesResponse = z.infer<typeof listSourcesResponseSchema>;
+export type CreateSourceRequest = z.infer<typeof createSourceRequestSchema>;
+export type UpdateSourceRequest = z.infer<typeof updateSourceRequestSchema>;
+export type SourceMutationResponse = z.infer<typeof sourceMutationResponseSchema>;

--- a/packages/shared/dist/schemas.js
+++ b/packages/shared/dist/schemas.js
@@ -176,6 +176,40 @@ export const alertSchema = z.object({
 export const alertsResponseSchema = z.object({
     alerts: z.array(alertSchema)
 });
+export const sourceTypeSchema = z.enum(["ENTRATA", "GA4", "ADS", "GBP"]);
+export const sourceStatusSchema = z.enum(["CONNECTED", "ERROR", "UNVERIFIED"]);
+export const sourceAccountSchema = z.object({
+    id: z.string(),
+    name: z.string().nullable().optional(),
+    propertyId: z.string().optional(),
+    type: sourceTypeSchema,
+    status: sourceStatusSchema.nullable().optional(),
+    lastSuccessAt: z.string().datetime({ offset: true }).nullable().optional(),
+    lastErrorAt: z.string().datetime({ offset: true }).nullable().optional(),
+    enabled: z.boolean(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const listSourcesResponseSchema = z.object({
+    sources: z.array(sourceAccountSchema)
+});
+export const createSourceRequestSchema = z.object({
+    propertyId: z.string(),
+    type: sourceTypeSchema,
+    name: z.string().optional(),
+    credential: z.record(z.unknown()),
+    enabled: z.boolean().optional()
+});
+export const updateSourceRequestSchema = z.object({
+    propertyId: z.string().optional(),
+    name: z.string().optional(),
+    credential: z.record(z.unknown()).optional(),
+    enabled: z.boolean().optional()
+});
+export const sourceMutationResponseSchema = z.object({
+    source: sourceAccountSchema,
+    validationMessage: z.string().optional()
+});
 export const propertiesResponseSchema = z.object({
     properties: z.array(propertySchema.pick({
         id: true,

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -207,6 +207,46 @@ export const alertsResponseSchema = z.object({
   alerts: z.array(alertSchema)
 });
 
+export const sourceTypeSchema = z.enum(["ENTRATA", "GA4", "ADS", "GBP"]);
+export const sourceStatusSchema = z.enum(["CONNECTED", "ERROR", "UNVERIFIED"]);
+
+export const sourceAccountSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable().optional(),
+  propertyId: z.string().optional(),
+  type: sourceTypeSchema,
+  status: sourceStatusSchema.nullable().optional(),
+  lastSuccessAt: z.string().datetime({ offset: true }).nullable().optional(),
+  lastErrorAt: z.string().datetime({ offset: true }).nullable().optional(),
+  enabled: z.boolean(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export const listSourcesResponseSchema = z.object({
+  sources: z.array(sourceAccountSchema)
+});
+
+export const createSourceRequestSchema = z.object({
+  propertyId: z.string(),
+  type: sourceTypeSchema,
+  name: z.string().optional(),
+  credential: z.record(z.unknown()),
+  enabled: z.boolean().optional()
+});
+
+export const updateSourceRequestSchema = z.object({
+  propertyId: z.string().optional(),
+  name: z.string().optional(),
+  credential: z.record(z.unknown()).optional(),
+  enabled: z.boolean().optional()
+});
+
+export const sourceMutationResponseSchema = z.object({
+  source: sourceAccountSchema,
+  validationMessage: z.string().optional()
+});
+
 export const propertiesResponseSchema = z.object({
   properties: z.array(
     propertySchema.pick({
@@ -243,3 +283,10 @@ export type WeeklyReportResponse = z.infer<typeof weeklyReportSchema>;
 export type Alert = z.infer<typeof alertSchema>;
 export type AlertsResponse = z.infer<typeof alertsResponseSchema>;
 export type PropertiesResponse = z.infer<typeof propertiesResponseSchema>;
+export type SourceType = z.infer<typeof sourceTypeSchema>;
+export type SourceStatus = z.infer<typeof sourceStatusSchema>;
+export type SourceAccount = z.infer<typeof sourceAccountSchema>;
+export type ListSourcesResponse = z.infer<typeof listSourcesResponseSchema>;
+export type CreateSourceRequest = z.infer<typeof createSourceRequestSchema>;
+export type UpdateSourceRequest = z.infer<typeof updateSourceRequestSchema>;
+export type SourceMutationResponse = z.infer<typeof sourceMutationResponseSchema>;


### PR DESCRIPTION
## Summary
- extend `SourceAccount` with connection metadata and add the associated Prisma migration
- add a Sources module with credential encryption, provider validation, and ETL job triggers backed by BullMQ or inline execution
- publish shared source schemas/types and build the admin Connections UI with CRUD, run sync, navigation, and dashboard CTA updates

## Testing
- pnpm --filter apps-backend lint
- pnpm --filter apps-frontend lint
- pnpm --filter apps-backend typecheck *(fails: Prisma engine download blocked in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04b5bd6bc8322b8bda1799e572c4b