### PR TITLE
App shell: Sidebar IA + Tabs + Client Live Dashboards (subdomains)

### DIFF
--- a/apps/backend/prisma/migrations/20250111000000_public_dashboards/migration.sql
+++ b/apps/backend/prisma/migrations/20250111000000_public_dashboards/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "PublicDashboard" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "propertyId" TEXT,
+    "title" TEXT NOT NULL,
+    "subdomain" TEXT NOT NULL,
+    "accessToken" TEXT,
+    "config" JSONB NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PublicDashboard_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublicDashboard_subdomain_key" ON "PublicDashboard"("subdomain");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublicDashboard_accessToken_key" ON "PublicDashboard"("accessToken");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -137,6 +137,19 @@ model SourceAccount {
   @@index([propertyId, type], name: "idx_source_account_property_type")
 }
 
+model PublicDashboard {
+  id          String   @id @default(cuid())
+  orgId       String
+  propertyId  String?
+  title       String
+  subdomain   String   @unique
+  accessToken String?  @unique
+  config      Json
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
 model Lead {
   id           String        @id @default(cuid())
   property     Property      @relation(fields: [propertyId], references: [id])

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -8,6 +8,8 @@ import { MetricsModule } from "./metrics/metrics.module";
 import { PrismaModule } from "./prisma/prisma.module";
 import { PropertiesModule } from "./properties/properties.module";
 import { ProvidersModule } from "./providers/providers.module";
+import { PublicModule } from "./public/public.module";
+import { PublicDashboardsModule } from "./public-dashboards/public-dashboards.module";
 import { ReportsModule } from "./reports/reports.module";
 import { ReviewsModule } from "./reviews/reviews.module";
 import { SourcesModule } from "./sources/sources.module";
@@ -43,6 +45,8 @@ import { SourcesModule } from "./sources/sources.module";
     AuthModule,
     MetricsModule,
     ReviewsModule,
+    PublicModule,
+    PublicDashboardsModule,
     ReportsModule,
     AlertsModule,
     JobsModule,

--- a/apps/backend/src/public-dashboards/dto/create-public-dashboard.dto.ts
+++ b/apps/backend/src/public-dashboards/dto/create-public-dashboard.dto.ts
@@ -1,0 +1,26 @@
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+export class CreatePublicDashboardDto {
+  @IsString()
+  @IsNotEmpty()
+  title!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  subdomain!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  orgId!: string;
+
+  @IsOptional()
+  @IsString()
+  propertyId?: string;
+
+  @IsOptional()
+  config?: unknown;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/apps/backend/src/public-dashboards/dto/update-public-dashboard.dto.ts
+++ b/apps/backend/src/public-dashboards/dto/update-public-dashboard.dto.ts
@@ -1,0 +1,26 @@
+import { IsBoolean, IsOptional, IsString } from "class-validator";
+
+export class UpdatePublicDashboardDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  subdomain?: string;
+
+  @IsOptional()
+  @IsString()
+  orgId?: string;
+
+  @IsOptional()
+  @IsString()
+  propertyId?: string | null;
+
+  @IsOptional()
+  config?: unknown;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/apps/backend/src/public-dashboards/public-dashboards.controller.ts
+++ b/apps/backend/src/public-dashboards/public-dashboards.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post } from "@nestjs/common";
+
+import { CreatePublicDashboardDto } from "./dto/create-public-dashboard.dto";
+import { UpdatePublicDashboardDto } from "./dto/update-public-dashboard.dto";
+import { PublicDashboardsService } from "./public-dashboards.service";
+
+@Controller("admin/public-dashboards")
+export class PublicDashboardsController {
+  constructor(private readonly publicDashboardsService: PublicDashboardsService) {}
+
+  @Get()
+  list() {
+    return this.publicDashboardsService.list();
+  }
+
+  @Post()
+  create(@Body() payload: CreatePublicDashboardDto) {
+    return this.publicDashboardsService.create(payload);
+  }
+
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() payload: UpdatePublicDashboardDto) {
+    return this.publicDashboardsService.update(id, payload);
+  }
+
+  @Delete(":id")
+  remove(@Param("id") id: string) {
+    return this.publicDashboardsService.remove(id);
+  }
+}

--- a/apps/backend/src/public-dashboards/public-dashboards.module.ts
+++ b/apps/backend/src/public-dashboards/public-dashboards.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+
+import { PublicDashboardsController } from "./public-dashboards.controller";
+import { PublicDashboardsService } from "./public-dashboards.service";
+import { PrismaModule } from "../prisma/prisma.module";
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PublicDashboardsController],
+  providers: [PublicDashboardsService],
+  exports: [PublicDashboardsService]
+})
+export class PublicDashboardsModule {}

--- a/apps/backend/src/public-dashboards/public-dashboards.service.ts
+++ b/apps/backend/src/public-dashboards/public-dashboards.service.ts
@@ -1,0 +1,111 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+
+import { PrismaService } from "../prisma/prisma.service";
+import { CreatePublicDashboardDto } from "./dto/create-public-dashboard.dto";
+import { UpdatePublicDashboardDto } from "./dto/update-public-dashboard.dto";
+
+@Injectable()
+export class PublicDashboardsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list() {
+    const dashboards = await this.prisma.publicDashboard.findMany({
+      orderBy: { createdAt: "desc" }
+    });
+
+    return { dashboards };
+  }
+
+  async create(payload: CreatePublicDashboardDto) {
+    const subdomain = this.normalizeSubdomain(payload.subdomain);
+    const data: Prisma.PublicDashboardCreateInput = {
+      title: payload.title.trim(),
+      subdomain,
+      orgId: payload.orgId,
+      propertyId: payload.propertyId ?? null,
+      config: payload.config ?? { widgets: [] },
+      isActive: payload.isActive ?? true
+    };
+
+    try {
+      return await this.prisma.publicDashboard.create({ data });
+    } catch (error) {
+      this.handlePrismaError(error, subdomain);
+    }
+  }
+
+  async update(id: string, payload: UpdatePublicDashboardDto) {
+    const data: Prisma.PublicDashboardUpdateInput = {};
+
+    if (payload.title !== undefined) {
+      data.title = payload.title.trim();
+    }
+    if (payload.subdomain !== undefined) {
+      data.subdomain = this.normalizeSubdomain(payload.subdomain);
+    }
+    if (payload.orgId !== undefined) {
+      data.orgId = payload.orgId;
+    }
+    if (payload.propertyId !== undefined) {
+      data.propertyId = payload.propertyId || null;
+    }
+    if (payload.config !== undefined) {
+      data.config = payload.config;
+    }
+    if (payload.isActive !== undefined) {
+      data.isActive = payload.isActive;
+    }
+
+    if (Object.keys(data).length === 0) {
+      throw new BadRequestException("No updates provided");
+    }
+
+    try {
+      return await this.prisma.publicDashboard.update({ where: { id }, data });
+    } catch (error) {
+      this.handlePrismaError(error, payload.subdomain);
+    }
+  }
+
+  async remove(id: string) {
+    try {
+      await this.prisma.publicDashboard.delete({ where: { id } });
+      return { success: true };
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+        throw new NotFoundException("Dashboard not found");
+      }
+      throw error;
+    }
+  }
+
+  private normalizeSubdomain(value: string) {
+    const slug = value
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/-{2,}/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+    if (!slug) {
+      throw new BadRequestException("Subdomain is required");
+    }
+
+    return slug;
+  }
+
+  private handlePrismaError(error: unknown, subdomain?: string): never {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        throw new BadRequestException(
+          `Subdomain ${subdomain ?? ""} is already in use. Choose a different value.`
+        );
+      }
+      if (error.code === "P2025") {
+        throw new NotFoundException("Dashboard not found");
+      }
+    }
+
+    throw error;
+  }
+}

--- a/apps/backend/src/public/public.controller.ts
+++ b/apps/backend/src/public/public.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Query } from "@nestjs/common";
+
+import { PrismaService } from "../prisma/prisma.service";
+
+type DashboardWidget = {
+  id?: string;
+  label?: string;
+  value?: unknown;
+};
+
+type PublicDashboardConfig = {
+  widgets?: DashboardWidget[];
+  [key: string]: unknown;
+};
+
+@Controller("public")
+export class PublicController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Get("resolve")
+  async resolve(@Query("host") host: string) {
+    const sanitizedHost = (host ?? "").toLowerCase().split(":")[0];
+    const parts = sanitizedHost.split(".");
+    const subdomain = parts.length > 2 ? parts[0] : null;
+
+    if (!subdomain) {
+      return { error: "no subdomain" };
+    }
+
+    const publicDashboard = await this.prisma.publicDashboard.findUnique({
+      where: { subdomain }
+    });
+
+    if (!publicDashboard || !publicDashboard.isActive) {
+      return { error: "not found" };
+    }
+
+    const config = (publicDashboard.config as PublicDashboardConfig) ?? {};
+    const widgets = Array.isArray(config.widgets) ? config.widgets : [];
+
+    return {
+      title: publicDashboard.title,
+      config,
+      widgets
+    };
+  }
+}

--- a/apps/backend/src/public/public.module.ts
+++ b/apps/backend/src/public/public.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+
+import { PublicController } from "./public.controller";
+import { PrismaModule } from "../prisma/prisma.module";
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PublicController]
+})
+export class PublicModule {}

--- a/apps/frontend/app/analytics/page.tsx
+++ b/apps/frontend/app/analytics/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { ArrowRight, BarChart3, LineChart, PieChart, SlidersHorizontal } from "lucide-react";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { authOptions } from "@/lib/auth-options";
+
+const chartPlaceholders = [
+  { id: "occupancy", title: "Occupancy trend", description: "Trailing 90 days" },
+  { id: "leasing", title: "Leasing velocity", description: "Leads → leases" },
+  { id: "spend", title: "Marketing spend mix", description: "Channel contribution" },
+  { id: "reviews", title: "Sentiment pulse", description: "Review volume" },
+  { id: "conversion", title: "Funnel conversion", description: "Tours to leases" },
+  { id: "applications", title: "Applications by source", description: "Last 30 days" }
+];
+
+export default async function AnalyticsPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const isAdmin = session.user?.role !== "viewer";
+
+  return (
+    <div className="space-y-6">
+      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Analytics</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Compare performance across properties, channels, and time ranges. Dashboards are wired and ready for your data.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/80 px-3 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover">
+              <SlidersHorizontal className="h-4 w-4" />
+              Filters
+            </button>
+            <button className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/60 px-3 py-2 text-sm text-muted-foreground transition hover:text-foreground">
+              <BarChart3 className="h-4 w-4" />
+              Property
+            </button>
+            <button className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/60 px-3 py-2 text-sm text-muted-foreground transition hover:text-foreground">
+              <LineChart className="h-4 w-4" />
+              Channel
+            </button>
+            <button className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/60 px-3 py-2 text-sm text-muted-foreground transition hover:text-foreground">
+              <PieChart className="h-4 w-4" />
+              Segment
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {chartPlaceholders.map((chart) => (
+          <div
+            key={chart.id}
+            className="card-surface flex flex-col rounded-2xl border bg-white/90 p-5 shadow-card transition hover:shadow-cardHover"
+          >
+            <div className="mb-4">
+              <h2 className="text-base font-semibold text-foreground">{chart.title}</h2>
+              <p className="text-sm text-muted-foreground">{chart.description}</p>
+            </div>
+            <div className="flex flex-1 items-center justify-center rounded-xl border border-dashed border-border/70 bg-slate-50/70 p-6 text-sm text-muted-foreground">
+              Chart will render here once your sources are connected.
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {isAdmin ? (
+        <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Need data to explore?</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Connect your marketing sources and share a read-only analytics workspace with operations teams.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/admin/sources"
+                className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/80 px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover"
+              >
+                Connect a source
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/reports"
+                className="inline-flex items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary transition hover:bg-brand-primary/20"
+              >
+                Publish a live dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/app/api/public/resolve/route.ts
+++ b/apps/frontend/app/api/public/resolve/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const host = req.nextUrl.searchParams.get("host");
+  if (!host) {
+    return NextResponse.json({ error: "missing host" }, { status: 400 });
+  }
+
+  const apiBaseUrl =
+    process.env.NEXT_PUBLIC_API_BASE_URL ?? process.env.API_BASE_URL ?? process.env.BACKEND_URL;
+
+  if (!apiBaseUrl) {
+    return NextResponse.json({ error: "API base url not configured" }, { status: 500 });
+  }
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/public/resolve?host=${encodeURIComponent(host)}`, {
+      headers: {
+        "x-internal": "1"
+      },
+      cache: "no-store"
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to reach API", details: String(error) }, { status: 502 });
+  }
+}

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
@@ -12,6 +14,41 @@ export default async function DashboardPage() {
   }
 
   const role = session.user?.role === "viewer" ? "viewer" : "admin";
+  const isAdmin = role === "admin";
 
-  return <DashboardView role={role} />;
+  return (
+    <div className="space-y-6">
+      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <DashboardView role={role} />
+      </div>
+      {isAdmin ? (
+        <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Accelerate your rollout</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Connect marketing sources and publish a live dashboard for your teams in minutes.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/admin/sources"
+                className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/80 px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover"
+              >
+                Connect a source
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/reports"
+                className="inline-flex items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary transition hover:bg-brand-primary/20"
+              >
+                Publish a live dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -32,7 +32,8 @@
   --card: var(--slate-1);
   --card-contrast: var(--slate-3);
   --card-foreground: var(--foreground);
-  --border: var(--slate-6);
+  --border: var(--slate-5);
+  --border-strong: 210 16% 78%;
   --muted: var(--slate-3);
   --muted-foreground: var(--slate-11);
   --foreground: var(--slate-12);
@@ -41,7 +42,17 @@
   --ring: var(--violet-8);
   --destructive: var(--tomato-9);
   --destructive-foreground: var(--tomato-12);
-  --radius: 1.25rem;
+  --brand-primary: var(--violet-9);
+  --brand-primary-foreground: var(--violet-12);
+  --brand-secondary: 151 81% 46%;
+  --brand-secondary-foreground: 152 40% 16%;
+  --success: 151 81% 46%;
+  --success-foreground: 152 40% 16%;
+  --warning: 34 100% 65%;
+  --warning-foreground: 28 80% 20%;
+  --danger: var(--tomato-9);
+  --danger-foreground: var(--tomato-12);
+  --radius: 14px;
 
   /* Legacy tokens mapped to new system */
   --background: var(--bg);
@@ -93,18 +104,32 @@
   --ring: var(--violet-7);
   --destructive: var(--tomato-9);
   --destructive-foreground: var(--tomato-12);
+  --brand-primary: var(--violet-8);
+  --brand-primary-foreground: var(--violet-12);
+  --brand-secondary: 151 70% 40%;
+  --brand-secondary-foreground: 149 60% 88%;
+  --success: 151 70% 40%;
+  --success-foreground: 149 60% 88%;
+  --warning: 34 100% 60%;
+  --warning-foreground: 48 100% 90%;
+  --danger: var(--tomato-9);
+  --danger-foreground: var(--tomato-12);
 }
 
 body {
-  background: radial-gradient(120% 120% at 10% 0%, hsl(var(--accent) / 0.15) 0%, transparent 45%),
-    radial-gradient(100% 100% at 100% 0%, hsl(var(--muted) / 0.12) 0%, transparent 50%),
-    hsl(var(--bg));
+  background: radial-gradient(120% 120% at 10% 0%, hsl(var(--brand-primary) / 0.12) 0%, transparent 45%),
+    radial-gradient(160% 140% at 90% 0%, hsl(var(--brand-secondary) / 0.08) 0%, transparent 52%),
+    linear-gradient(135deg, hsl(var(--panel)) 0%, hsl(var(--bg)) 38%, #fff 100%);
   color: hsl(var(--foreground));
 }
 
 @layer base {
   * {
     @apply border-border;
+  }
+
+  .card-surface {
+    border-color: hsl(var(--border-strong));
   }
 
   *:focus-visible {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { AppProviders } from "@/components/providers/app-providers";
+import { Sidebar } from "@/components/shell/sidebar";
+import { Topbar } from "@/components/shell/topbar";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -16,10 +19,36 @@ export default function RootLayout({
 }: {
   children: ReactNode;
 }) {
+  const headerList = headers();
+  const hostHeader = headerList.get("host") ?? "";
+  const configuredMainHost = process.env.NEXT_PUBLIC_MAIN_HOST ?? "astalla.com";
+  const host = hostHeader.split(":")[0];
+  const mainHost = configuredMainHost.split(":")[0];
+  const hostSegments = host.split(".");
+  const mainHostSegments = mainHost.split(".");
+  const isPublicHost =
+    Boolean(mainHost) &&
+    hostSegments.length > mainHostSegments.length &&
+    host.endsWith(mainHost);
+
   return (
     <html lang="en" className={inter.variable} suppressHydrationWarning>
-      <body className="min-h-screen bg-background font-sans antialiased">
-        <AppProviders>{children}</AppProviders>
+      <body className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-white font-sans text-slate-900 antialiased">
+        <AppProviders>
+          {isPublicHost ? (
+            <main className="min-h-screen">{children}</main>
+          ) : (
+            <div className="flex min-h-screen">
+              <Sidebar />
+              <div className="flex min-h-screen flex-1 flex-col bg-transparent">
+                <Topbar />
+                <main className="flex-1 min-h-0 p-6">
+                  <div className="mx-auto flex max-w-6xl flex-col gap-6">{children}</div>
+                </main>
+              </div>
+            </div>
+          )}
+        </AppProviders>
       </body>
     </html>
   );

--- a/apps/frontend/app/public/page.tsx
+++ b/apps/frontend/app/public/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
+export default function PublicDashboard() {
+  const searchParams = useSearchParams();
+  const host = searchParams.get("x-host") || "";
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["public-dashboard", host],
+    queryFn: async () => {
+      if (!host) {
+        throw new Error("missing host");
+      }
+      const response = await fetch(`/api/public/resolve?host=${encodeURIComponent(host)}`, {
+        cache: "no-store"
+      });
+      if (!response.ok) {
+        throw new Error("not found");
+      }
+      return response.json();
+    }
+  });
+
+  if (isLoading) {
+    return <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">Loading dashboard…</div>;
+  }
+
+  if (isError || !data) {
+    return <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">Dashboard not found.</div>;
+  }
+
+  const widgets = Array.isArray(data.widgets) ? data.widgets : [];
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 py-12">
+      <header className="space-y-2 text-center">
+        <h1 className="text-3xl font-semibold text-foreground">{data.title}</h1>
+        <p className="text-sm text-muted-foreground">Read-only experience powered by Astalla.</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {widgets.length === 0 ? (
+          <div className="col-span-full rounded-2xl border border-dashed border-border/70 bg-white/80 p-10 text-center text-sm text-muted-foreground">
+            Dashboard widgets will appear here once the owner publishes a layout.
+          </div>
+        ) : (
+          widgets.map((widget: any) => (
+            <div key={widget.id ?? widget.label} className="card-surface rounded-2xl border bg-white/90 p-5 shadow-card">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">{widget.label ?? widget.id}</div>
+              <div className="mt-2 text-3xl font-semibold text-foreground">{widget.value ?? "—"}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/reports/page.tsx
+++ b/apps/frontend/app/reports/page.tsx
@@ -1,10 +1,10 @@
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
-import { SourcesAdminView } from "./sources-view";
+import { ReportsView } from "@/components/reports/reports-view";
 import { authOptions } from "@/lib/auth-options";
 
-export default async function AdminSourcesPage() {
+export default async function ReportsPage() {
   const session = await getServerSession(authOptions);
 
   if (!session) {
@@ -15,11 +15,5 @@ export default async function AdminSourcesPage() {
     redirect("/dashboard");
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
-        <SourcesAdminView />
-      </div>
-    </div>
-  );
+  return <ReportsView />;
 }

--- a/apps/frontend/app/tables/page.tsx
+++ b/apps/frontend/app/tables/page.tsx
@@ -1,8 +1,30 @@
+import Link from "next/link";
+import { ArrowRight, ClipboardList, Database, Layers3, PlusCircle } from "lucide-react";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
-import { TableWorkspace } from "@/components/tables/table-workspace";
 import { authOptions } from "@/lib/auth-options";
+
+const tableIdeas = [
+  {
+    id: "pipeline",
+    title: "Leasing pipeline",
+    description: "Track prospects from lead to lease with filters for source, agent, and property.",
+    icon: Layers3
+  },
+  {
+    id: "operations",
+    title: "Operations tasks",
+    description: "Monitor unit turns, maintenance tickets, and SLAs in a shared workspace.",
+    icon: ClipboardList
+  },
+  {
+    id: "integrations",
+    title: "Data integrations",
+    description: "Blend CRM, PMS, and marketing data to create custom tables for leadership reviews.",
+    icon: Database
+  }
+];
 
 export default async function TablesIndexPage() {
   const session = await getServerSession(authOptions);
@@ -11,5 +33,68 @@ export default async function TablesIndexPage() {
     redirect("/login");
   }
 
-  return <TableWorkspace tableId="" />;
+  const isAdmin = session.user?.role !== "viewer";
+
+  return (
+    <div className="space-y-6">
+      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Tables</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Build collaborative tables to track leasing, operations, and marketing workflows. Your layouts will sync across the
+              team.
+            </p>
+          </div>
+          <button
+            className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary opacity-70"
+            type="button"
+            disabled
+          >
+            <PlusCircle className="h-4 w-4" />
+            Create table (coming soon)
+          </button>
+        </div>
+        <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {tableIdeas.map(({ id, title, description, icon: Icon }) => (
+            <div key={id} className="card-surface flex flex-col gap-3 rounded-2xl border bg-white/90 p-5 shadow-card">
+              <Icon className="h-5 w-5 text-brand-primary" />
+              <div>
+                <h2 className="text-base font-semibold text-foreground">{title}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {isAdmin ? (
+        <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Prep your tables with real data</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Connect sources and publish a read-only dashboard so teams can explore live KPIs alongside their tables.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/admin/sources"
+                className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/80 px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover"
+              >
+                Connect a source
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/reports"
+                className="inline-flex items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary transition hover:bg-brand-primary/20"
+              >
+                Publish a live dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/frontend/components/reports/reports-view.tsx
+++ b/apps/frontend/components/reports/reports-view.tsx
@@ -1,0 +1,482 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowUpRight,
+  ExternalLink,
+  Globe2,
+  Loader2,
+  Pencil,
+  Plus,
+  Power,
+  Trash2
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api } from "@/lib/api-client";
+import {
+  createPublicDashboard,
+  deletePublicDashboard,
+  listPublicDashboards,
+  updatePublicDashboard
+} from "@/lib/api/public-dashboards";
+import type { PublicDashboard } from "@shared/api";
+
+const LAYOUT_TEMPLATES = [
+  {
+    id: "executive",
+    name: "Executive summary",
+    description: "Top-line KPIs for leadership standups",
+    config: {
+      widgets: [
+        { id: "occupancy", label: "Occupancy rate", value: "95%" },
+        { id: "leasing", label: "Leases signed", value: "42" },
+        { id: "pipeline", label: "Active pipeline", value: "$186k" }
+      ],
+      filters: []
+    }
+  },
+  {
+    id: "leasing",
+    name: "Leasing velocity",
+    description: "Track conversions from lead to lease",
+    config: {
+      widgets: [
+        { id: "leads", label: "New leads", value: "128" },
+        { id: "tours", label: "Tours scheduled", value: "64" },
+        { id: "applications", label: "Applications approved", value: "27" }
+      ],
+      filters: ["Last 30 days"]
+    }
+  },
+  {
+    id: "marketing",
+    name: "Marketing efficiency",
+    description: "Blend spend and performance data for campaigns",
+    config: {
+      widgets: [
+        { id: "spend", label: "Marketing spend", value: "$24.5k" },
+        { id: "cpl", label: "Cost per lead", value: "$182" },
+        { id: "roi", label: "Projected ROI", value: "3.4x" }
+      ],
+      filters: ["Multi-channel"]
+    }
+  }
+] as const;
+
+const MAIN_HOST = (process.env.NEXT_PUBLIC_MAIN_HOST ?? "astalla.com").replace(/^https?:\/\//, "");
+
+interface DashboardFormState {
+  title: string;
+  subdomain: string;
+  propertyId: string;
+  layoutId: string;
+  config: unknown;
+}
+
+interface ModalState {
+  open: boolean;
+  mode: "create" | "edit";
+  dashboard?: PublicDashboard;
+}
+
+const DEFAULT_FORM: DashboardFormState = {
+  title: "",
+  subdomain: "",
+  propertyId: "",
+  layoutId: LAYOUT_TEMPLATES[0].id,
+  config: LAYOUT_TEMPLATES[0].config
+};
+
+export function ReportsView() {
+  const queryClient = useQueryClient();
+  const [modalState, setModalState] = useState<ModalState>({ open: false, mode: "create" });
+  const [formState, setFormState] = useState<DashboardFormState>(DEFAULT_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [pendingDashboardId, setPendingDashboardId] = useState<string | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const meQuery = useQuery({ queryKey: ["me"], queryFn: api.me });
+  const propertiesQuery = useQuery({ queryKey: ["properties"], queryFn: api.properties });
+  const dashboardsQuery = useQuery({ queryKey: ["public-dashboards"], queryFn: listPublicDashboards });
+
+  const dashboards = dashboardsQuery.data?.dashboards ?? [];
+  const orgId = meQuery.data?.orgId ?? modalState.dashboard?.orgId ?? "";
+
+  const createMutation = useMutation({
+    mutationFn: createPublicDashboard,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["public-dashboards"] });
+      closeModal();
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: Record<string, unknown> }) =>
+      updatePublicDashboard(id, payload),
+    onMutate: ({ id }) => {
+      setPendingDashboardId(id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["public-dashboards"] });
+      closeModal();
+    },
+    onSettled: () => {
+      setPendingDashboardId(null);
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deletePublicDashboard(id),
+    onMutate: (id) => {
+      setPendingDeleteId(id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["public-dashboards"] });
+    },
+    onSettled: () => {
+      setPendingDeleteId(null);
+    }
+  });
+
+  const propertyOptions = propertiesQuery.data?.properties ?? [];
+
+  const layoutOptions = useMemo(() => LAYOUT_TEMPLATES, []);
+
+  const openCreateModal = () => {
+    const defaultPropertyId = propertyOptions[0]?.id ?? "";
+    setFormState({ ...DEFAULT_FORM, propertyId: defaultPropertyId });
+    setModalState({ open: true, mode: "create" });
+    setFormError(null);
+  };
+
+  const openEditModal = (dashboard: PublicDashboard) => {
+    setFormState({
+      title: dashboard.title,
+      subdomain: dashboard.subdomain,
+      propertyId: dashboard.propertyId ?? "",
+      layoutId: "custom",
+      config: dashboard.config ?? { widgets: [] }
+    });
+    setModalState({ open: true, mode: "edit", dashboard });
+    setFormError(null);
+  };
+
+  const closeModal = () => {
+    setModalState({ open: false, mode: "create" });
+    setFormState(DEFAULT_FORM);
+    setFormError(null);
+  };
+
+  const updateField = <K extends keyof DashboardFormState>(field: K, value: DashboardFormState[K]) => {
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleLayoutChange = (layoutId: string) => {
+    if (layoutId === "custom") {
+      updateField("layoutId", layoutId);
+      return;
+    }
+
+    const layout = layoutOptions.find((option) => option.id === layoutId);
+    if (layout) {
+      setFormState((prev) => ({ ...prev, layoutId, config: layout.config }));
+    }
+  };
+
+  const submitForm = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!orgId) {
+      setFormError("We need your organization id before publishing. Refresh and try again.");
+      return;
+    }
+
+    const payload = {
+      title: formState.title.trim(),
+      subdomain: formState.subdomain.trim(),
+      orgId,
+      propertyId: formState.propertyId || undefined,
+      config: formState.config
+    };
+
+    try {
+      if (modalState.mode === "create") {
+        await createMutation.mutateAsync(payload);
+      } else if (modalState.dashboard) {
+        await updateMutation.mutateAsync({ id: modalState.dashboard.id, payload });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to save dashboard";
+      setFormError(message);
+    }
+  };
+
+  const slugPreview = formState.subdomain ? `${formState.subdomain}.${MAIN_HOST}` : `your-team.${MAIN_HOST}`;
+
+  return (
+    <div className="space-y-6">
+      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Reports & templates</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Launch ready-made scorecards and automate delivery to property and regional teams.
+            </p>
+          </div>
+          <Button
+            onClick={openCreateModal}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow-card hover:bg-brand-primary/90"
+          >
+            <Plus className="h-4 w-4" />
+            Create live dashboard
+          </Button>
+        </div>
+        <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {layoutOptions.map((layout) => (
+            <div key={layout.id} className="card-surface flex flex-col gap-3 rounded-2xl border bg-white/90 p-5 shadow-card">
+              <div className="flex items-center gap-3">
+                <Globe2 className="h-5 w-5 text-brand-primary" />
+                <div>
+                  <h2 className="text-base font-semibold text-foreground">{layout.name}</h2>
+                  <p className="text-sm text-muted-foreground">{layout.description}</p>
+                </div>
+              </div>
+              <div className="rounded-xl border border-dashed border-border/70 bg-slate-50/70 p-4 text-xs text-muted-foreground">
+                <div className="font-semibold text-foreground">Widget preview</div>
+                <ul className="mt-2 space-y-1">
+                  {layout.config.widgets.map((widget: any) => (
+                    <li key={widget.id} className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>{widget.label}</span>
+                      <span className="font-medium text-foreground">{widget.value}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Live dashboards</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Publish secure read-only dashboards on branded subdomains. Share links with leadership or property teams.
+            </p>
+          </div>
+          <Button variant="outline" className="inline-flex items-center gap-2" onClick={openCreateModal}>
+            <Plus className="h-4 w-4" />
+            New live dashboard
+          </Button>
+        </div>
+
+        {dashboardsQuery.isLoading ? (
+          <div className="flex h-32 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : dashboardsQuery.isError ? (
+          <div className="mt-6 rounded-xl border border-dashed border-danger/40 bg-danger/5 p-8 text-center text-sm text-danger">
+            We couldn’t load your live dashboards. Refresh the page or try again shortly.
+          </div>
+        ) : dashboards.length === 0 ? (
+          <div className="mt-6 rounded-xl border border-dashed border-border/70 bg-slate-50/70 p-8 text-center text-sm text-muted-foreground">
+            No live dashboards yet. Use the templates above to publish your first experience.
+          </div>
+        ) : (
+          <div className="mt-6 space-y-4">
+            {dashboards.map((dashboard) => {
+              const url = `https://${dashboard.subdomain}.${MAIN_HOST}`;
+              const isUpdating = pendingDashboardId === dashboard.id;
+              const isDeleting = pendingDeleteId === dashboard.id;
+
+              return (
+                <div
+                  key={dashboard.id}
+                  className="card-surface flex flex-col gap-4 rounded-2xl border bg-white/90 p-5 shadow-card transition hover:shadow-cardHover md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <div className="flex items-center gap-3">
+                      <span className="rounded-full border border-border bg-slate-50/80 px-3 py-1 text-xs font-medium text-muted-foreground">
+                        {dashboard.isActive ? "Active" : "Paused"}
+                      </span>
+                      <h3 className="text-base font-semibold text-foreground">{dashboard.title}</h3>
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-brand-primary hover:underline"
+                      >
+                        {url}
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                      <span>Subdomain: {dashboard.subdomain}</span>
+                      {dashboard.propertyId ? <span>Property scope: {dashboard.propertyId}</span> : <span>Org-wide</span>}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      variant="outline"
+                      className="inline-flex items-center gap-2"
+                      onClick={() =>
+                        updateMutation.mutate({ id: dashboard.id, payload: { isActive: !dashboard.isActive } })
+                      }
+                      disabled={isUpdating || isDeleting}
+                    >
+                      {isUpdating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Power className="h-4 w-4" />}
+                      {dashboard.isActive ? "Pause" : "Activate"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      className="inline-flex items-center gap-2"
+                      onClick={() => openEditModal(dashboard)}
+                      disabled={isDeleting}
+                    >
+                      <Pencil className="h-4 w-4" />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="outline"
+                      className="inline-flex items-center gap-2 text-danger"
+                      onClick={() => deleteMutation.mutate(dashboard.id)}
+                      disabled={isDeleting || isUpdating}
+                    >
+                      {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {modalState.open ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
+          <div className="w-full max-w-xl rounded-2xl border bg-white p-6 shadow-card">
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-foreground">
+                  {modalState.mode === "create" ? "Create live dashboard" : "Edit live dashboard"}
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Choose a layout, assign a subdomain, and we will render a secure read-only dashboard for your clients.
+                </p>
+              </div>
+              <button className="text-muted-foreground transition hover:text-foreground" onClick={closeModal}>
+                ×
+              </button>
+            </div>
+            <form className="mt-4 space-y-4" onSubmit={submitForm}>
+              <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+                Title
+                <Input
+                  value={formState.title}
+                  onChange={(event) => updateField("title", event.target.value)}
+                  placeholder="Midwest portfolio dashboard"
+                  required
+                />
+              </label>
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+                  Subdomain
+                  <Input
+                    value={formState.subdomain}
+                    onChange={(event) =>
+                      updateField("subdomain", event.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))
+                    }
+                    placeholder="acme"
+                    pattern="[a-z0-9-]+"
+                    required
+                  />
+                  <span className="text-xs font-normal text-muted-foreground">https://{slugPreview}</span>
+                </label>
+                <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+                  Property scope (optional)
+                  <select
+                    className="rounded-lg border border-border bg-white px-3 py-2 text-sm text-foreground"
+                    value={formState.propertyId}
+                    onChange={(event) => updateField("propertyId", event.target.value)}
+                  >
+                    <option value="">All properties</option>
+                    {propertyOptions.map((property) => (
+                      <option key={property.id} value={property.id}>
+                        {property.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
+                Pick from existing dashboard layout
+                <select
+                  className="rounded-lg border border-border bg-white px-3 py-2 text-sm text-foreground"
+                  value={formState.layoutId}
+                  onChange={(event) => {
+                    const layoutId = event.target.value;
+                    updateField("layoutId", layoutId);
+                    handleLayoutChange(layoutId);
+                  }}
+                >
+                  {layoutOptions.map((layout) => (
+                    <option key={layout.id} value={layout.id}>
+                      {layout.name}
+                    </option>
+                  ))}
+                  {modalState.mode === "edit" ? <option value="custom">Keep current layout</option> : null}
+                </select>
+              </label>
+              <div className="rounded-xl border border-dashed border-border/70 bg-slate-50/70 p-4 text-xs text-muted-foreground">
+                <div className="font-semibold text-foreground">Layout preview</div>
+                <ul className="mt-2 space-y-1">
+                  {(Array.isArray((formState.config as any)?.widgets)
+                    ? ((formState.config as any).widgets as any[])
+                    : []).map((widget) => (
+                    <li key={widget.id ?? widget.label} className="flex items-center justify-between">
+                      <span>{widget.label ?? widget.id}</span>
+                      <span className="font-medium text-foreground">{widget.value ?? "—"}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+                <div className="flex flex-col">
+                  <span>Org scope</span>
+                  <span className="font-medium text-foreground">{orgId || "Loading…"}</span>
+                </div>
+                <a
+                  href={`https://${slugPreview}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-brand-primary"
+                >
+                  Preview URL
+                  <ArrowUpRight className="h-3.5 w-3.5" />
+                </a>
+              </div>
+              {formError ? <div className="rounded-lg bg-danger/10 px-3 py-2 text-sm text-danger">{formError}</div> : null}
+              <div className="flex items-center justify-end gap-3">
+                <Button type="button" variant="outline" onClick={closeModal}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+                  {(createMutation.isPending || updateMutation.isPending) ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
+                  {modalState.mode === "create" ? "Create dashboard" : "Save changes"}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/components/shell/sidebar.tsx
+++ b/apps/frontend/components/shell/sidebar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import { usePathname } from "next/navigation";
+import type { LucideIcon } from "lucide-react";
+import { BarChart3, FileChartLine, LayoutDashboard, PlugZap, Table2 } from "lucide-react";
+
+type SidebarItem = {
+  href: Route;
+  label: string;
+  icon: LucideIcon;
+};
+
+const items: SidebarItem[] = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/tables", label: "Tables", icon: Table2 },
+  { href: "/admin/sources", label: "Sources / Connections", icon: PlugZap },
+  { href: "/reports", label: "Reports", icon: FileChartLine }
+];
+
+export function Sidebar() {
+  const path = usePathname();
+
+  return (
+    <aside className="sticky top-0 hidden h-screen w-64 shrink-0 border-r bg-white/75 backdrop-blur-xl lg:block">
+      <div className="flex h-16 items-center border-b px-6 text-lg font-semibold tracking-tight">
+        <span className="text-brand-primary">Astalla</span>
+      </div>
+      <nav className="space-y-1 px-3 py-4">
+        {items.map(({ href, label, icon: Icon }) => {
+          const active = path?.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`group flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition ${
+                active
+                  ? "bg-brand-primary/10 font-medium text-brand-primary"
+                  : "text-muted-foreground hover:bg-white hover:text-foreground"
+              }`}
+            >
+              <Icon className="h-4 w-4" />
+              <span>{label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/apps/frontend/components/shell/topbar.tsx
+++ b/apps/frontend/components/shell/topbar.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Search, UserCircle2 } from "lucide-react";
+
+export function Topbar() {
+  return (
+    <header className="sticky top-0 z-30 border-b border-border/80 bg-white/70 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-6">
+        <div className="ml-auto flex items-center gap-4">
+          <div className="relative hidden md:block">
+            <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+            <input
+              className="w-64 rounded-lg border border-border/80 bg-white/80 py-2 pl-9 pr-3 text-sm text-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/40"
+              placeholder="Search…"
+              type="search"
+            />
+          </div>
+          <button className="inline-flex items-center gap-2 rounded-lg border border-border/80 bg-white/80 px-3 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover">
+            <UserCircle2 className="h-4 w-4" />
+            Account
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/frontend/lib/api/public-dashboards.ts
+++ b/apps/frontend/lib/api/public-dashboards.ts
@@ -1,0 +1,73 @@
+import {
+  createPublicDashboardRequestSchema,
+  publicDashboardListResponseSchema,
+  publicDashboardSchema,
+  updatePublicDashboardRequestSchema,
+  type CreatePublicDashboardRequest,
+  type PublicDashboard,
+  type PublicDashboardListResponse,
+  type UpdatePublicDashboardRequest
+} from "@shared/api";
+
+import { apiBaseUrl, isMockMode } from "../utils";
+
+interface SchemaParser<T> {
+  parse(data: unknown): T;
+}
+
+async function request(path: string, init: RequestInit): Promise<void>;
+async function request<T>(path: string, init: RequestInit, schema: SchemaParser<T>): Promise<T>;
+async function request<T>(path: string, init: RequestInit, schema?: SchemaParser<T>): Promise<T | void> {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      "x-mock-mode": isMockMode() ? "true" : "false",
+      ...(init.headers ?? {})
+    }
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Request failed for ${path}: ${response.status} ${message}`);
+  }
+
+  if (!schema) {
+    return;
+  }
+
+  const json = await response.json();
+  return schema.parse(json);
+}
+
+export async function listPublicDashboards(): Promise<PublicDashboardListResponse> {
+  return request<PublicDashboardListResponse>("/admin/public-dashboards", { method: "GET" }, publicDashboardListResponseSchema);
+}
+
+export async function createPublicDashboard(payload: CreatePublicDashboardRequest): Promise<PublicDashboard> {
+  const body = JSON.stringify(createPublicDashboardRequestSchema.parse(payload));
+  return request<PublicDashboard>(
+    "/admin/public-dashboards",
+    {
+      method: "POST",
+      body
+    },
+    publicDashboardSchema
+  );
+}
+
+export async function updatePublicDashboard(id: string, payload: UpdatePublicDashboardRequest): Promise<PublicDashboard> {
+  const body = JSON.stringify(updatePublicDashboardRequestSchema.parse(payload));
+  return request<PublicDashboard>(
+    `/admin/public-dashboards/${id}`,
+    {
+      method: "PATCH",
+      body
+    },
+    publicDashboardSchema
+  );
+}
+
+export async function deletePublicDashboard(id: string): Promise<void> {
+  await request(`/admin/public-dashboards/${id}`, { method: "DELETE" });
+}

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const MAIN_HOST = process.env.NEXT_PUBLIC_MAIN_HOST ?? "astalla.com";
+
+export function middleware(req: NextRequest) {
+  const hostHeader = req.headers.get("host") ?? "";
+  const host = hostHeader.split(":")[0];
+  const mainHost = MAIN_HOST.split(":")[0];
+  const hostParts = host.split(".");
+  const mainParts = mainHost.split(".");
+  const isSubdomain = hostParts.length > mainParts.length && host.endsWith(mainHost);
+
+  if (isSubdomain) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/public";
+    url.searchParams.set("x-host", host);
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next|api|static|favicon.ico).*)"]
+};

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -29,6 +29,28 @@ const config: Config = {
           DEFAULT: "hsl(var(--accent))",
           foreground: "hsl(var(--accent-contrast))"
         },
+        brand: {
+          primary: {
+            DEFAULT: "hsl(var(--brand-primary))",
+            foreground: "hsl(var(--brand-primary-foreground))"
+          },
+          secondary: {
+            DEFAULT: "hsl(var(--brand-secondary))",
+            foreground: "hsl(var(--brand-secondary-foreground))"
+          }
+        },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))"
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))"
+        },
+        danger: {
+          DEFAULT: "hsl(var(--danger))",
+          foreground: "hsl(var(--danger-foreground))"
+        },
         secondary: {
           DEFAULT: "hsl(var(--panel))",
           foreground: "hsl(var(--foreground))"
@@ -47,9 +69,14 @@ const config: Config = {
         }
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)"
+        xl: "18px",
+        lg: "14px",
+        md: "12px",
+        sm: "10px"
+      },
+      boxShadow: {
+        card: "0 10px 30px -18px rgba(15, 23, 42, 0.35), 0 12px 24px -20px rgba(15, 23, 42, 0.28)",
+        cardHover: "0 20px 40px -20px rgba(15, 23, 42, 0.4), 0 18px 32px -24px rgba(15, 23, 42, 0.35)"
       },
       keyframes: {
         "accordion-down": {

--- a/packages/shared/dist/schemas.d.ts
+++ b/packages/shared/dist/schemas.d.ts
@@ -896,6 +896,160 @@ export declare const propertiesResponseSchema: z.ZodObject<{
         region?: string | undefined;
     }[];
 }>;
+export declare const publicDashboardSchema: z.ZodObject<{
+    id: z.ZodString;
+    orgId: z.ZodString;
+    propertyId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    title: z.ZodString;
+    subdomain: z.ZodString;
+    accessToken: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    config: z.ZodUnknown;
+    isActive: z.ZodBoolean;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    orgId: string;
+    title: string;
+    subdomain: string;
+    isActive: boolean;
+    propertyId?: string | null | undefined;
+    accessToken?: string | null | undefined;
+    config?: unknown;
+}, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    orgId: string;
+    title: string;
+    subdomain: string;
+    isActive: boolean;
+    propertyId?: string | null | undefined;
+    accessToken?: string | null | undefined;
+    config?: unknown;
+}>;
+export declare const publicDashboardListResponseSchema: z.ZodObject<{
+    dashboards: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        orgId: z.ZodString;
+        propertyId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        title: z.ZodString;
+        subdomain: z.ZodString;
+        accessToken: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        config: z.ZodUnknown;
+        isActive: z.ZodBoolean;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        orgId: string;
+        title: string;
+        subdomain: string;
+        isActive: boolean;
+        propertyId?: string | null | undefined;
+        accessToken?: string | null | undefined;
+        config?: unknown;
+    }, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        orgId: string;
+        title: string;
+        subdomain: string;
+        isActive: boolean;
+        propertyId?: string | null | undefined;
+        accessToken?: string | null | undefined;
+        config?: unknown;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    dashboards: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        orgId: string;
+        title: string;
+        subdomain: string;
+        isActive: boolean;
+        propertyId?: string | null | undefined;
+        accessToken?: string | null | undefined;
+        config?: unknown;
+    }[];
+}, {
+    dashboards: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        orgId: string;
+        title: string;
+        subdomain: string;
+        isActive: boolean;
+        propertyId?: string | null | undefined;
+        accessToken?: string | null | undefined;
+        config?: unknown;
+    }[];
+}>;
+export declare const createPublicDashboardRequestSchema: z.ZodObject<{
+    title: z.ZodString;
+    subdomain: z.ZodString;
+    orgId: z.ZodString;
+    propertyId: z.ZodNullable<z.ZodOptional<z.ZodString>>;
+    config: z.ZodUnknown;
+    isActive: z.ZodOptional<z.ZodBoolean>;
+}, "strip", z.ZodTypeAny, {
+    orgId: string;
+    title: string;
+    subdomain: string;
+    propertyId?: string | null | undefined;
+    config?: unknown;
+    isActive?: boolean | undefined;
+}, {
+    orgId: string;
+    title: string;
+    subdomain: string;
+    propertyId?: string | null | undefined;
+    config?: unknown;
+    isActive?: boolean | undefined;
+}>;
+export declare const updatePublicDashboardRequestSchema: z.ZodEffects<z.ZodObject<{
+    title: z.ZodOptional<z.ZodString>;
+    subdomain: z.ZodOptional<z.ZodString>;
+    orgId: z.ZodOptional<z.ZodString>;
+    propertyId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    config: z.ZodOptional<z.ZodUnknown>;
+    isActive: z.ZodOptional<z.ZodBoolean>;
+}, "strip", z.ZodTypeAny, {
+    orgId?: string | undefined;
+    propertyId?: string | null | undefined;
+    title?: string | undefined;
+    subdomain?: string | undefined;
+    config?: unknown;
+    isActive?: boolean | undefined;
+}, {
+    orgId?: string | undefined;
+    propertyId?: string | null | undefined;
+    title?: string | undefined;
+    subdomain?: string | undefined;
+    config?: unknown;
+    isActive?: boolean | undefined;
+}>, {
+    orgId?: string | undefined;
+    propertyId?: string | null | undefined;
+    title?: string | undefined;
+    subdomain?: string | undefined;
+    config?: unknown;
+    isActive?: boolean | undefined;
+}, {
+    orgId?: string | undefined;
+    propertyId?: string | null | undefined;
+    title?: string | undefined;
+    subdomain?: string | undefined;
+    config?: unknown;
+    isActive?: boolean | undefined;
+}>;
 export type Org = z.infer<typeof orgSchema>;
 export type Property = z.infer<typeof propertySchema>;
 export type User = z.infer<typeof userSchema>;
@@ -926,3 +1080,7 @@ export type ListSourcesResponse = z.infer<typeof listSourcesResponseSchema>;
 export type CreateSourceRequest = z.infer<typeof createSourceRequestSchema>;
 export type UpdateSourceRequest = z.infer<typeof updateSourceRequestSchema>;
 export type SourceMutationResponse = z.infer<typeof sourceMutationResponseSchema>;
+export type PublicDashboard = z.infer<typeof publicDashboardSchema>;
+export type PublicDashboardListResponse = z.infer<typeof publicDashboardListResponseSchema>;
+export type CreatePublicDashboardRequest = z.infer<typeof createPublicDashboardRequestSchema>;
+export type UpdatePublicDashboardRequest = z.infer<typeof updatePublicDashboardRequestSchema>;

--- a/packages/shared/dist/schemas.js
+++ b/packages/shared/dist/schemas.js
@@ -220,3 +220,38 @@ export const propertiesResponseSchema = z.object({
         region: true
     }))
 });
+export const publicDashboardSchema = z.object({
+    id: z.string(),
+    orgId: z.string(),
+    propertyId: z.string().nullable().optional(),
+    title: z.string(),
+    subdomain: z.string(),
+    accessToken: z.string().nullable().optional(),
+    config: z.unknown(),
+    isActive: z.boolean(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const publicDashboardListResponseSchema = z.object({
+    dashboards: z.array(publicDashboardSchema)
+});
+export const createPublicDashboardRequestSchema = z.object({
+    title: z.string().min(1),
+    subdomain: z.string().min(1),
+    orgId: z.string().min(1),
+    propertyId: z.string().optional().nullable(),
+    config: z.unknown(),
+    isActive: z.boolean().optional()
+});
+export const updatePublicDashboardRequestSchema = z
+    .object({
+    title: z.string().optional(),
+    subdomain: z.string().optional(),
+    orgId: z.string().optional(),
+    propertyId: z.string().nullable().optional(),
+    config: z.unknown().optional(),
+    isActive: z.boolean().optional()
+})
+    .refine((payload) => Object.keys(payload).length > 0, {
+    message: "Update payload cannot be empty"
+});

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -260,6 +260,45 @@ export const propertiesResponseSchema = z.object({
   )
 });
 
+export const publicDashboardSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  propertyId: z.string().nullable().optional(),
+  title: z.string(),
+  subdomain: z.string(),
+  accessToken: z.string().nullable().optional(),
+  config: z.unknown(),
+  isActive: z.boolean(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export const publicDashboardListResponseSchema = z.object({
+  dashboards: z.array(publicDashboardSchema)
+});
+
+export const createPublicDashboardRequestSchema = z.object({
+  title: z.string().min(1),
+  subdomain: z.string().min(1),
+  orgId: z.string().min(1),
+  propertyId: z.string().optional().nullable(),
+  config: z.unknown(),
+  isActive: z.boolean().optional()
+});
+
+export const updatePublicDashboardRequestSchema = z
+  .object({
+    title: z.string().optional(),
+    subdomain: z.string().optional(),
+    orgId: z.string().optional(),
+    propertyId: z.string().nullable().optional(),
+    config: z.unknown().optional(),
+    isActive: z.boolean().optional()
+  })
+  .refine((payload) => Object.keys(payload).length > 0, {
+    message: "Update payload cannot be empty"
+  });
+
 export type Org = z.infer<typeof orgSchema>;
 export type Property = z.infer<typeof propertySchema>;
 export type User = z.infer<typeof userSchema>;
@@ -290,3 +329,7 @@ export type ListSourcesResponse = z.infer<typeof listSourcesResponseSchema>;
 export type CreateSourceRequest = z.infer<typeof createSourceRequestSchema>;
 export type UpdateSourceRequest = z.infer<typeof updateSourceRequestSchema>;
 export type SourceMutationResponse = z.infer<typeof sourceMutationResponseSchema>;
+export type PublicDashboard = z.infer<typeof publicDashboardSchema>;
+export type PublicDashboardListResponse = z.infer<typeof publicDashboardListResponseSchema>;
+export type CreatePublicDashboardRequest = z.infer<typeof createPublicDashboardRequestSchema>;
+export type UpdatePublicDashboardRequest = z.infer<typeof updatePublicDashboardRequestSchema>;


### PR DESCRIPTION
## Summary
- overhaul the frontend shell with Tailwind design tokens, a persistent sidebar/topbar, and refreshed globals for gradient surfaces and card shadows
- scaffold analytics, tables, sources, and reports areas with cohesive card layouts, plus a reports management UI for creating and listing live dashboards
- add public dashboard subdomain routing, API and middleware plumbing, along with backend Prisma model/migration and admin CRUD endpoints for published dashboards
- ensure external live dashboard links use standard anchors so typed routing builds succeed
- type the sidebar navigation hrefs so Next.js typed routes accept the Link targets during builds

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68e0551ac3c08322b792cc3307af1050