### PR TITLE
fix: align table column type options with enum

### DIFF
--- a/apps/frontend/app/tables/page.tsx
+++ b/apps/frontend/app/tables/page.tsx
@@ -1,100 +1,32 @@
-import Link from "next/link";
-import { ArrowRight, ClipboardList, Database, Layers3, PlusCircle } from "lucide-react";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
+import { TablesClient } from "./tables-client";
 import { authOptions } from "@/lib/auth-options";
 
-const tableIdeas = [
-  {
-    id: "pipeline",
-    title: "Leasing pipeline",
-    description: "Track prospects from lead to lease with filters for source, agent, and property.",
-    icon: Layers3
-  },
-  {
-    id: "operations",
-    title: "Operations tasks",
-    description: "Monitor unit turns, maintenance tickets, and SLAs in a shared workspace.",
-    icon: ClipboardList
-  },
-  {
-    id: "integrations",
-    title: "Data integrations",
-    description: "Blend CRM, PMS, and marketing data to create custom tables for leadership reviews.",
-    icon: Database
-  }
-];
-
-export default async function TablesIndexPage() {
+export default async function TablesPage() {
   const session = await getServerSession(authOptions);
 
   if (!session) {
     redirect("/login");
   }
 
-  const isAdmin = session.user?.role !== "viewer";
+  const canManage = session.user?.role !== "viewer";
 
   return (
     <div className="space-y-6">
-      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <h1 className="text-xl font-semibold text-foreground">Tables</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Build collaborative tables to track leasing, operations, and marketing workflows. Your layouts will sync across the
-              team.
+      <div className="rounded-3xl border border-border bg-white/80 p-6 shadow-card">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-xl font-semibold text-foreground">Tables workspace</h1>
+            <p className="text-sm text-muted-foreground">
+              Design collaborative grids for leasing, operations, and marketing workflows. Configure columns, views, and CSV flows
+              without leaving the dashboard.
             </p>
           </div>
-          <button
-            className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary opacity-70"
-            type="button"
-            disabled
-          >
-            <PlusCircle className="h-4 w-4" />
-            Create table (coming soon)
-          </button>
-        </div>
-        <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {tableIdeas.map(({ id, title, description, icon: Icon }) => (
-            <div key={id} className="card-surface flex flex-col gap-3 rounded-2xl border bg-white/90 p-5 shadow-card">
-              <Icon className="h-5 w-5 text-brand-primary" />
-              <div>
-                <h2 className="text-base font-semibold text-foreground">{title}</h2>
-                <p className="mt-1 text-sm text-muted-foreground">{description}</p>
-              </div>
-            </div>
-          ))}
         </div>
       </div>
-      {isAdmin ? (
-        <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-foreground">Prep your tables with real data</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Connect sources and publish a read-only dashboard so teams can explore live KPIs alongside their tables.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href="/admin/sources"
-                className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/80 px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover"
-              >
-                Connect a source
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-              <Link
-                href="/reports"
-                className="inline-flex items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary transition hover:bg-brand-primary/20"
-              >
-                Publish a live dashboard
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      <TablesClient canManage={canManage} />
     </div>
   );
 }

--- a/apps/frontend/app/tables/tables-client.tsx
+++ b/apps/frontend/app/tables/tables-client.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Search } from "lucide-react";
+
+import {
+  useCreateTableMutation,
+  useTables
+} from "@/lib/api/tables";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TableGrid } from "@/components/tables/TableGrid";
+
+interface TablesClientProps {
+  canManage: boolean;
+}
+
+export function TablesClient({ canManage }: TablesClientProps) {
+  const { data, isLoading } = useTables();
+  const createTableMutation = useCreateTableMutation();
+  const [selectedTableId, setSelectedTableId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (!selectedTableId && data && data.length) {
+      setSelectedTableId(data[0].id);
+    }
+  }, [data, selectedTableId]);
+
+  const filteredTables = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return data;
+    }
+    return data.filter((table) => table.name.toLowerCase().includes(query));
+  }, [data, search]);
+
+  const handleCreateTable = async () => {
+    if (!name.trim()) {
+      return;
+    }
+    const payload = { name: name.trim(), description: description.trim() || undefined };
+    const table = await createTableMutation.mutateAsync(payload);
+    setIsModalOpen(false);
+    setName("");
+    setDescription("");
+    setSelectedTableId(table.id);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid gap-6 lg:grid-cols-[280px,1fr]">
+        <div className="space-y-4">
+          <div className="rounded-3xl border border-border bg-white/80 p-4 shadow-card">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-muted-foreground">Tables</h2>
+              <Button
+                type="button"
+                size="sm"
+                className="rounded-full"
+                onClick={() => setIsModalOpen(true)}
+                disabled={!canManage}
+              >
+                <Plus className="mr-2 h-4 w-4" /> New table
+              </Button>
+            </div>
+            <div className="mt-4 flex items-center gap-2 rounded-2xl border border-border/60 bg-muted/40 px-3 py-2">
+              <Search className="h-4 w-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search tables"
+                className="h-8 border-none bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
+              />
+            </div>
+            <div className="mt-4 space-y-2">
+              {isLoading ? (
+                <div className="space-y-2">
+                  {[...Array(4)].map((_, index) => (
+                    <div key={index} className="h-10 w-full animate-pulse rounded-2xl bg-muted/50" />
+                  ))}
+                </div>
+              ) : filteredTables.length ? (
+                filteredTables.map((table) => {
+                  const isSelected = table.id === selectedTableId;
+                  return (
+                    <button
+                      key={table.id}
+                      type="button"
+                      onClick={() => setSelectedTableId(table.id)}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left text-sm transition ${
+                        isSelected
+                          ? "border-brand-primary bg-brand-primary/10 text-brand-primary shadow-cardHover"
+                          : "border-border/60 bg-white/80 text-foreground hover:border-brand-primary/50 hover:shadow-card"
+                      }`}
+                    >
+                      <div className="font-medium">{table.name}</div>
+                      {table.description ? (
+                        <div className="text-xs text-muted-foreground">{table.description}</div>
+                      ) : null}
+                    </button>
+                  );
+                })
+              ) : (
+                <p className="text-sm text-muted-foreground">No tables found.</p>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4">
+          {selectedTableId ? (
+            <TableGrid tableId={selectedTableId} />
+          ) : (
+            <div className="flex h-[480px] items-center justify-center rounded-3xl border border-dashed border-border/70 bg-white/80 p-10 text-center shadow-card">
+              <div className="space-y-3">
+                <h3 className="text-lg font-semibold text-foreground">Create a table to get started</h3>
+                <p className="text-sm text-muted-foreground">
+                  Tables let you design custom workflows, capture updates, and share context with your team.
+                </p>
+                <Button type="button" onClick={() => setIsModalOpen(true)} className="rounded-full" disabled={!canManage}>
+                  <Plus className="mr-2 h-4 w-4" /> New table
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      {isModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 px-4 backdrop-blur">
+          <div className="w-full max-w-md rounded-3xl border border-border bg-card/95 p-6 shadow-xl">
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold text-foreground">Create table</h3>
+              <p className="text-sm text-muted-foreground">Name your table and add an optional description.</p>
+            </div>
+            <div className="mt-6 space-y-4">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground" htmlFor="table-name">
+                  Name
+                </label>
+                <Input
+                  id="table-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="e.g. Leasing pipeline"
+                  autoFocus
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground" htmlFor="table-description">
+                  Description
+                </label>
+                <Input
+                  id="table-description"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  placeholder="How your team will use this table"
+                />
+              </div>
+              <div className="flex items-center justify-end gap-3">
+                <Button type="button" variant="ghost" onClick={() => setIsModalOpen(false)} disabled={createTableMutation.isPending}>
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleCreateTable}
+                  disabled={!name.trim() || createTableMutation.isPending}
+                  className="gap-2"
+                >
+                  {createTableMutation.isPending ? (
+                    "Creating…"
+                  ) : (
+                    <>
+                      <Plus className="h-4 w-4" /> Create
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/components/tables/ColumnMenu.tsx
+++ b/apps/frontend/components/tables/ColumnMenu.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+import { type TableColumnDto } from "@/lib/api/tables";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+
+interface ColumnMenuProps {
+  column: TableColumnDto;
+  onRename: () => void;
+  onToggleVisibility: () => void;
+  onDelete: () => void;
+  isHidden: boolean;
+}
+
+export function ColumnMenu({ column, onRename, onToggleVisibility, onDelete, isHidden }: ColumnMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-7 w-7 rounded-full text-muted-foreground hover:text-foreground">
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" side="bottom" className="min-w-[10rem]">
+        <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+          {column.name}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onRename}>Rename</DropdownMenuItem>
+        <DropdownMenuItem onSelect={onToggleVisibility}>
+          {isHidden ? "Show column" : "Hide column"}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-destructive" onSelect={onDelete}>
+          Delete column
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/frontend/components/tables/ImportCsvModal.tsx
+++ b/apps/frontend/components/tables/ImportCsvModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { UploadCloud } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface ImportCsvModalProps {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  onSubmit: (file: File) => Promise<void> | void;
+  isSubmitting?: boolean;
+  summary?: { createdColumns: number; createdRows: number } | null;
+}
+
+export function ImportCsvModal({ open, onOpenChange, onSubmit, isSubmitting, summary }: ImportCsvModalProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setFile(null);
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    }
+  }, [open]);
+
+  if (!mounted || !open) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!file) {
+      return;
+    }
+    await onSubmit(file);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 backdrop-blur">
+      <div className="w-full max-w-lg rounded-3xl border border-border bg-card/95 p-6 shadow-xl">
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-brand-primary/10">
+            <UploadCloud className="h-5 w-5 text-brand-primary" />
+          </div>
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Import CSV</h2>
+            <p className="text-sm text-muted-foreground">
+              Upload a CSV file. Headers will be matched to existing columns and new columns will be created as needed.
+            </p>
+          </div>
+        </div>
+        <form className="mt-6 space-y-6" onSubmit={handleSubmit}>
+          <div className="rounded-2xl border border-dashed border-border/70 bg-muted/40 p-6 text-center">
+            <input
+              ref={inputRef}
+              type="file"
+              accept=".csv,text/csv"
+              className="sr-only"
+              id="table-import-input"
+              onChange={(event) => {
+                const target = event.target;
+                const nextFile = target.files?.[0];
+                setFile(nextFile ?? null);
+              }}
+            />
+            <label htmlFor="table-import-input" className="cursor-pointer text-sm font-medium text-brand-primary hover:underline">
+              {file ? file.name : "Choose a CSV file"}
+            </label>
+            <p className="mt-2 text-xs text-muted-foreground">UTF-8 encoded files work best.</p>
+          </div>
+          {summary ? (
+            <div className="rounded-2xl border border-border/70 bg-card/70 p-4 text-sm text-foreground">
+              Imported {summary.createdRows} rows and {summary.createdColumns} new columns.
+            </div>
+          ) : null}
+          <div className="flex items-center justify-end gap-3">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!file || isSubmitting} className="gap-2">
+              {isSubmitting ? "Importing…" : "Start import"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/tables/TableGrid.tsx
+++ b/apps/frontend/components/tables/TableGrid.tsx
@@ -1,0 +1,1340 @@
+"use client";
+
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Key } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+  horizontalListSortingStrategy
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { formatDistanceToNow } from "date-fns";
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  Filter,
+  FolderPlus,
+  Plus,
+  Rows,
+  Trash2
+} from "lucide-react";
+
+import {
+  ColumnType,
+  type TableColumnDto,
+  type TableRowDto,
+  type TableViewDto,
+  useCreateColumnMutation,
+  useCreateRowMutation,
+  useCreateViewMutation,
+  useDeleteColumnMutation,
+  useDeleteRowMutation,
+  useDeleteViewMutation,
+  useExportCsvMutation,
+  useImportCsvMutation,
+  usePatchRowCellsMutation,
+  useReorderRowsMutation,
+  useTable,
+  useUpdateColumnMutation,
+  useUpdateViewMutation
+} from "@/lib/api/tables";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import { ColumnMenu } from "./ColumnMenu";
+import { ImportCsvModal } from "./ImportCsvModal";
+import { ViewMenu } from "./ViewMenu";
+
+type GridRow = {
+  __meta: TableRowDto;
+} & Record<string, unknown>;
+
+type ColumnKind = TableColumnDto["type"];
+
+type FilterCondition = {
+  columnId: string;
+  value: string;
+};
+
+type SortCondition = {
+  columnId: string;
+  direction: "asc" | "desc";
+};
+
+type ViewConfig = {
+  filters?: FilterCondition[];
+  sorts?: SortCondition[];
+  hidden?: string[];
+  columnOrder?: string[];
+};
+
+interface TableGridProps {
+  tableId: string;
+}
+
+const COLUMN_TYPE_OPTIONS: Array<{ label: string; value: ColumnKind }> = [
+  { label: "Text", value: ColumnType.TEXT },
+  { label: "Number", value: ColumnType.NUMBER },
+  { label: "Date", value: ColumnType.DATE },
+  { label: "Boolean", value: ColumnType.BOOLEAN },
+  { label: "Select", value: ColumnType.SELECT },
+  { label: "Reference", value: ColumnType.REFERENCE }
+];
+
+function parseViewConfig(value: unknown): ViewConfig {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const config = value as Record<string, unknown>;
+  const filters = Array.isArray(config.filters)
+    ? (config.filters
+        .map((item) => {
+          if (item && typeof item === "object") {
+            const columnId = String((item as any).columnId ?? "");
+            const val = String((item as any).value ?? "");
+            if (columnId) {
+              return { columnId, value: val } satisfies FilterCondition;
+            }
+          }
+          return null;
+        })
+        .filter(Boolean) as FilterCondition[])
+    : undefined;
+  const sorts = Array.isArray(config.sorts)
+    ? (config.sorts
+        .map((item) => {
+          if (item && typeof item === "object") {
+            const columnId = String((item as any).columnId ?? "");
+            const direction = (item as any).direction === "desc" ? "desc" : "asc";
+            if (columnId) {
+              return { columnId, direction } satisfies SortCondition;
+            }
+          }
+          return null;
+        })
+        .filter(Boolean) as SortCondition[])
+    : undefined;
+  const hidden = Array.isArray(config.hidden)
+    ? (config.hidden.map((item) => String(item ?? "")).filter(Boolean) as string[])
+    : undefined;
+  const columnOrder = Array.isArray(config.columnOrder)
+    ? (config.columnOrder.map((item) => String(item ?? "")).filter(Boolean) as string[])
+    : undefined;
+  return { filters, sorts, hidden, columnOrder };
+}
+
+function buildConfig({
+  filters,
+  sorts,
+  columnVisibility,
+  columnOrder
+}: {
+  filters: FilterCondition[];
+  sorts: SortCondition[];
+  columnVisibility: Record<string, boolean>;
+  columnOrder: string[];
+}): ViewConfig {
+  const hidden = Object.entries(columnVisibility)
+    .filter(([, visible]) => !visible)
+    .map(([columnId]) => columnId);
+  return {
+    filters: filters.length ? filters : undefined,
+    sorts: sorts.length ? sorts : undefined,
+    hidden: hidden.length ? hidden : undefined,
+    columnOrder: columnOrder.length ? columnOrder : undefined
+  };
+}
+
+function getCellValue(row: TableRowDto, columnId: string) {
+  const cell = row.cells.find(
+    (entry: TableRowDto["cells"][number]) => entry.columnId === columnId
+  );
+  return cell?.value ?? null;
+}
+
+function normalizeValue(type: ColumnKind, value: unknown) {
+  if (value === null || value === undefined) {
+    if (type === "BOOLEAN") {
+      return false;
+    }
+    return "";
+  }
+  if (type === "BOOLEAN") {
+    return Boolean(value);
+  }
+  if (type === "NUMBER") {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : "";
+  }
+  return value as any;
+}
+
+function applyFilters(rows: TableRowDto[], filters: FilterCondition[], columnMap: Map<string, TableColumnDto>) {
+  if (!filters.length) {
+    return rows;
+  }
+  return rows.filter((row) =>
+    filters.every((filter) => {
+      const column = columnMap.get(filter.columnId);
+      if (!column) {
+        return true;
+      }
+      const value = getCellValue(row, column.id);
+      if (value === null || value === undefined) {
+        return false;
+      }
+      if (column.type === "BOOLEAN") {
+        return String(value).toLowerCase() === filter.value.toLowerCase();
+      }
+      return String(value).toLowerCase().includes(filter.value.toLowerCase());
+    })
+  );
+}
+
+function applySorts(rows: TableRowDto[], sorts: SortCondition[], columnMap: Map<string, TableColumnDto>) {
+  if (!sorts.length) {
+    return rows;
+  }
+  const sorted = [...rows];
+  const compare = (a: TableRowDto, b: TableRowDto, column: TableColumnDto, direction: "asc" | "desc") => {
+    const aValue = getCellValue(a, column.id);
+    const bValue = getCellValue(b, column.id);
+    const multiplier = direction === "asc" ? 1 : -1;
+    if (aValue === bValue) {
+      return 0;
+    }
+    if (aValue === null || aValue === undefined) {
+      return -1 * multiplier;
+    }
+    if (bValue === null || bValue === undefined) {
+      return 1 * multiplier;
+    }
+    if (column.type === "NUMBER") {
+      return (Number(aValue) - Number(bValue)) * multiplier;
+    }
+    if (column.type === "DATE") {
+      return (new Date(String(aValue)).getTime() - new Date(String(bValue)).getTime()) * multiplier;
+    }
+    if (column.type === "BOOLEAN") {
+      return (aValue === bValue ? 0 : aValue ? 1 : -1) * multiplier;
+    }
+    const aStr = String(aValue).toLowerCase();
+    const bStr = String(bValue).toLowerCase();
+    if (aStr === bStr) {
+      return 0;
+    }
+    return (aStr > bStr ? 1 : -1) * multiplier;
+  };
+
+  sorted.sort((a, b) => {
+    for (const sort of sorts) {
+      const column = columnMap.get(sort.columnId);
+      if (!column) {
+        continue;
+      }
+      const result = compare(a, b, column, sort.direction);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return 0;
+  });
+  return sorted;
+}
+
+type VirtualItem = {
+  key: Key;
+  index: number;
+  start: number;
+  size: number;
+};
+
+interface SortableRowProps {
+  row: any;
+  virtualRow: VirtualItem;
+  allowDrag: boolean;
+}
+
+function SortableRow({ row, virtualRow, allowDrag }: SortableRowProps) {
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
+    id: row.original.__meta.id,
+    disabled: !allowDrag
+  });
+
+  const y = (transform?.y ?? 0) + virtualRow.start;
+  const x = transform?.x ?? 0;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        height: `${virtualRow.size}px`,
+        transform: CSS.Transform.toString({ x, y, scaleX: 1, scaleY: 1 }),
+        transition,
+        zIndex: isDragging ? 10 : undefined,
+        position: "absolute",
+        width: "100%"
+      }}
+      className={cn(
+        "flex items-stretch border-b border-border/60 bg-white/70 last:border-none",
+        isDragging ? "shadow-cardHover" : undefined
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      {row.getVisibleCells().map((cell: any) => (
+        <div
+          key={cell.id}
+          className={cn(
+            "flex min-h-full flex-1 items-center border-r border-border/40 px-3 text-sm text-foreground last:border-r-0",
+            cell.column.getSize() ? undefined : "min-w-[12rem]"
+          )}
+          style={{ width: cell.column.getSize() ? `${cell.column.getSize()}px` : undefined }}
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TableGrid({ tableId }: TableGridProps) {
+  const { data, isLoading } = useTable(tableId);
+  const createColumnMutation = useCreateColumnMutation(tableId);
+  const updateColumnMutation = useUpdateColumnMutation(tableId);
+  const deleteColumnMutation = useDeleteColumnMutation(tableId);
+  const deleteViewMutation = useDeleteViewMutation(tableId);
+  const createRowMutation = useCreateRowMutation(tableId);
+  const patchCellsMutation = usePatchRowCellsMutation(tableId);
+  const reorderRowsMutation = useReorderRowsMutation(tableId);
+  const deleteRowMutation = useDeleteRowMutation(tableId);
+  const createViewMutation = useCreateViewMutation(tableId);
+  const updateViewMutation = useUpdateViewMutation(tableId);
+  const exportCsvMutation = useExportCsvMutation(tableId);
+  const importCsvMutation = useImportCsvMutation(tableId);
+
+  const columns = useMemo<TableColumnDto[]>(() => data?.columns ?? [], [data?.columns]);
+  const rows = useMemo<TableRowDto[]>(() => data?.rows ?? [], [data?.rows]);
+  const views = useMemo<TableViewDto[]>(() => data?.views ?? [], [data?.views]);
+
+  const columnMap = useMemo(
+    () => new Map(columns.map((column: TableColumnDto) => [column.id, column])),
+    [columns]
+  );
+  const baseColumnOrder = useMemo(() => columns.map((column: TableColumnDto) => column.id), [columns]);
+
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({});
+  const [columnOrder, setColumnOrder] = useState<string[]>(baseColumnOrder);
+  const [rowOrder, setRowOrder] = useState<string[]>([]);
+  const [filters, setFilters] = useState<FilterCondition[]>([]);
+  const [sorts, setSorts] = useState<SortCondition[]>([]);
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+  const [isAddColumnOpen, setIsAddColumnOpen] = useState(false);
+  const [newColumnName, setNewColumnName] = useState("");
+  const [newColumnType, setNewColumnType] = useState<ColumnKind>("TEXT");
+  const [isImportOpen, setIsImportOpen] = useState(false);
+  const [importSummary, setImportSummary] = useState<{ createdColumns: number; createdRows: number } | null>(null);
+  const [editingColumnId, setEditingColumnId] = useState<string | null>(null);
+  const [editingColumnName, setEditingColumnName] = useState("");
+
+  const reorderDisabled = Boolean(filters.length || sorts.length);
+
+  useEffect(() => {
+    setColumnOrder(baseColumnOrder);
+  }, [baseColumnOrder]);
+
+  useEffect(() => {
+    setColumnVisibility((prev) => {
+      const next: Record<string, boolean> = {};
+      for (const column of columns) {
+        next[column.id] = prev[column.id] ?? true;
+      }
+      return next;
+    });
+  }, [columns]);
+
+  useEffect(() => {
+    const ordered = [...rows]
+      .sort((a, b) => a.position - b.position)
+      .map((row) => row.id);
+    setRowOrder(ordered);
+  }, [rows]);
+
+  useEffect(() => {
+    const activeView = activeViewId
+      ? views.find((view: TableViewDto) => view.id === activeViewId)
+      : null;
+    if (!activeView) {
+      setFilters([]);
+      setSorts([]);
+      setColumnVisibility((prev) => {
+        const next: Record<string, boolean> = {};
+        for (const column of columns) {
+          next[column.id] = prev[column.id] ?? true;
+        }
+        return next;
+      });
+      setColumnOrder(baseColumnOrder);
+      return;
+    }
+    const parsed = parseViewConfig(activeView.config);
+    setFilters(parsed.filters ?? []);
+    setSorts(parsed.sorts ?? []);
+    setColumnVisibility(() => {
+      const hidden = new Set(parsed.hidden ?? []);
+      const next: Record<string, boolean> = {};
+      for (const column of columns) {
+        next[column.id] = !hidden.has(column.id);
+      }
+      return next;
+    });
+    setColumnOrder(parsed.columnOrder?.length ? parsed.columnOrder : baseColumnOrder);
+  }, [activeViewId, views, columns, baseColumnOrder]);
+
+  useEffect(() => {
+    setSelectedRows((prev) => {
+      const next = new Set<string>();
+      for (const row of rows) {
+        if (prev.has(row.id)) {
+          next.add(row.id);
+        }
+      }
+      return next;
+    });
+  }, [rows]);
+
+  const orderedRows = useMemo(() => {
+    const rowMap = new Map(rows.map((row) => [row.id, row] as const));
+    return rowOrder
+      .map((rowId) => rowMap.get(rowId))
+      .filter((row): row is TableRowDto => Boolean(row));
+  }, [rowOrder, rows]);
+
+  const filteredRows = useMemo(() => applyFilters(orderedRows, filters, columnMap), [orderedRows, filters, columnMap]);
+  const sortedRows = useMemo(() => applySorts(filteredRows, sorts, columnMap), [filteredRows, sorts, columnMap]);
+
+  const gridRows = useMemo<GridRow[]>(() => {
+    return sortedRows.map((row) => {
+      const record: GridRow = { __meta: row };
+      for (const column of columns) {
+        record[column.id] = getCellValue(row, column.id);
+      }
+      return record;
+    });
+  }, [sortedRows, columns]);
+
+  const handleRowDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (reorderDisabled) {
+        return;
+      }
+      const activeId = String(event.active.id);
+      const overId = event.over ? String(event.over.id) : null;
+      if (!overId || activeId === overId) {
+        return;
+      }
+      setRowOrder((prev) => {
+        const activeIndex = prev.indexOf(activeId);
+        const overIndex = prev.indexOf(overId);
+        if (activeIndex === -1 || overIndex === -1) {
+          return prev;
+        }
+        const next = arrayMove(prev, activeIndex, overIndex);
+        reorderRowsMutation.mutate(next.map((rowId, index) => ({ rowId, position: index + 1 })));
+        return next;
+      });
+    },
+    [reorderRowsMutation, reorderDisabled]
+  );
+
+  const handleToggleColumnVisibility = useCallback(
+    (columnId: string) => {
+      setColumnVisibility((prev) => {
+        const next = { ...prev, [columnId]: !prev[columnId] };
+        if (activeViewId) {
+          const config = buildConfig({ filters, sorts, columnVisibility: next, columnOrder });
+          updateViewMutation.mutate({ id: activeViewId, payload: { config } });
+        }
+        return next;
+      });
+    },
+    [activeViewId, columnOrder, filters, sorts, updateViewMutation]
+  );
+
+  const handleDeleteColumn = useCallback(
+    (columnId: string) => {
+      if (!window.confirm("Delete this column?")) {
+        return;
+      }
+      deleteColumnMutation.mutate(columnId);
+    },
+    [deleteColumnMutation]
+  );
+
+  const startRenameColumn = useCallback((column: TableColumnDto) => {
+    setEditingColumnId(column.id);
+    setEditingColumnName(column.name);
+  }, []);
+
+  const commitRename = useCallback(
+    (columnId: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed) {
+        setEditingColumnId(null);
+        return;
+      }
+      updateColumnMutation.mutate({ id: columnId, payload: { name: trimmed } });
+      setEditingColumnId(null);
+    },
+    [updateColumnMutation]
+  );
+
+  const handleCommitCell = useCallback(
+    (rowId: string, columnId: string, value: unknown) => {
+      patchCellsMutation.mutate({ rowId, cells: [{ columnId, value }] });
+    },
+    [patchCellsMutation]
+  );
+
+  const columnDefs = useMemo<ColumnDef<GridRow>[]>(() => {
+    const defs: ColumnDef<GridRow>[] = [];
+
+    defs.push({
+      id: "__select__",
+      header: () => (
+        <Checkbox
+          checked={selectedRows.size > 0 && selectedRows.size === gridRows.length}
+          onCheckedChange={(value) => {
+            if (value) {
+              setSelectedRows(new Set(gridRows.map((row) => row.__meta.id)));
+            } else {
+              setSelectedRows(new Set());
+            }
+          }}
+          aria-label="Select all rows"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={selectedRows.has(row.original.__meta.id)}
+          onCheckedChange={(value) => {
+            setSelectedRows((prev) => {
+              const next = new Set(prev);
+              if (value) {
+                next.add(row.original.__meta.id);
+              } else {
+                next.delete(row.original.__meta.id);
+              }
+              return next;
+            });
+          }}
+          aria-label="Select row"
+        />
+      ),
+      size: 40,
+      enableResizing: false
+    });
+
+    defs.push({
+      id: "__position__",
+      header: () => <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">#</span>,
+      cell: ({ row }) => (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Rows className="h-3.5 w-3.5" />
+          {row.index + 1}
+        </div>
+      ),
+      size: 64,
+      enableResizing: false
+    });
+
+    for (const column of columns) {
+      defs.push({
+        id: column.id,
+        accessorKey: column.id,
+        header: () => (
+          <ColumnHeader
+            column={column}
+            columnVisibility={columnVisibility}
+            onToggleVisibility={() => handleToggleColumnVisibility(column.id)}
+            onDelete={() => handleDeleteColumn(column.id)}
+            onStartRename={() => startRenameColumn(column)}
+            isEditing={editingColumnId === column.id}
+            editingName={editingColumnName}
+            onEditingNameChange={setEditingColumnName}
+            onCommit={(next) => commitRename(column.id, next)}
+          />
+        ),
+        cell: ({ row, getValue }) => (
+          <CellEditor
+            column={column}
+            row={row.original.__meta}
+            value={getValue()}
+            onCommit={(next) => handleCommitCell(row.original.__meta.id, column.id, next)}
+          />
+        ),
+        size: 200
+      });
+    }
+
+    return defs;
+  }, [
+    columns,
+    columnVisibility,
+    selectedRows,
+    gridRows,
+    editingColumnId,
+    editingColumnName,
+    handleToggleColumnVisibility,
+    handleDeleteColumn,
+    startRenameColumn,
+    commitRename,
+    handleCommitCell
+  ]);
+
+  const tableColumnOrder = useMemo(() => ["__select__", "__position__", ...columnOrder], [columnOrder]);
+
+  const columnDragItems = tableColumnOrder;
+
+  const table = useReactTable({
+    data: gridRows,
+    columns: columnDefs,
+    state: {
+      columnOrder: tableColumnOrder,
+      columnVisibility
+    },
+    onColumnOrderChange: (updater) => {
+      const nextOrder = typeof updater === "function" ? (updater as (old: string[]) => string[])(tableColumnOrder) : updater;
+      const filtered = nextOrder.filter((id) => id !== "__select__" && id !== "__position__");
+      setColumnOrder(filtered);
+    },
+    getCoreRowModel: getCoreRowModel()
+  });
+
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const rowModel = table.getRowModel();
+  const rowVirtualizer = useVirtualizer({
+    count: rowModel.rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 44,
+    overscan: 8
+  });
+
+  const rowSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const columnSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const handleAddRow = () => {
+    createRowMutation.mutate(undefined);
+  };
+
+  const handleDeleteSelected = () => {
+    const ids = Array.from(selectedRows);
+    if (!ids.length) {
+      return;
+    }
+    if (!window.confirm(`Delete ${ids.length} row${ids.length === 1 ? "" : "s"}?`)) {
+      return;
+    }
+    Promise.all(ids.map((id) => deleteRowMutation.mutateAsync(id))).then(() => {
+      setSelectedRows(new Set());
+    });
+  };
+
+  const handleAddColumn = async () => {
+    const name = newColumnName.trim() || "New column";
+    await createColumnMutation.mutateAsync({ name, type: newColumnType });
+    setNewColumnName("");
+    setNewColumnType("TEXT");
+    setIsAddColumnOpen(false);
+  };
+
+  const handleSaveCurrentView = useCallback(async () => {
+    const name = window.prompt("Name your view");
+    if (!name) {
+      return;
+    }
+    const config = buildConfig({ filters, sorts, columnVisibility, columnOrder });
+    const view = await createViewMutation.mutateAsync({ name, config });
+    setActiveViewId(view.id);
+  }, [createViewMutation, filters, sorts, columnVisibility, columnOrder]);
+
+  const handleRenameView = useCallback(
+    (viewId: string) => {
+      const view = views.find((item) => item.id === viewId);
+      const next = window.prompt("Rename view", view?.name ?? "");
+      if (!next) {
+        return;
+      }
+      updateViewMutation.mutate({ id: viewId, payload: { name: next } });
+    },
+    [updateViewMutation, views]
+  );
+
+  const handleDeleteView = useCallback(
+    (viewId: string) => {
+      if (!window.confirm("Delete this view?")) {
+        return;
+      }
+      deleteViewMutation.mutate(viewId, {
+        onSuccess: () => {
+          setActiveViewId((current) => (current === viewId ? null : current));
+        }
+      });
+    },
+    [deleteViewMutation]
+  );
+
+  useEffect(() => {
+    setColumnVisibility((prev) => {
+      const next: Record<string, boolean> = {};
+      for (const columnId of columnOrder) {
+        next[columnId] = prev[columnId] ?? true;
+      }
+      return next;
+    });
+  }, [columnOrder]);
+
+  const handleColumnOrderChange = useCallback(
+    (event: DragEndEvent) => {
+      const activeId = String(event.active.id);
+      const overId = event.over ? String(event.over.id) : null;
+      if (!overId || activeId === overId) {
+        return;
+      }
+      setColumnOrder((prev) => {
+        const activeIndex = prev.indexOf(activeId);
+        const overIndex = prev.indexOf(overId);
+        if (activeIndex === -1 || overIndex === -1) {
+          return prev;
+        }
+        const next = arrayMove(prev, activeIndex, overIndex);
+        const movedColumnId = activeId;
+        const newPosition = next.indexOf(movedColumnId) + 1;
+        updateColumnMutation.mutate({ id: movedColumnId, payload: { position: newPosition } });
+        if (activeViewId) {
+          const config = buildConfig({ filters, sorts, columnVisibility, columnOrder: next });
+          updateViewMutation.mutate({ id: activeViewId, payload: { config } });
+        }
+        return next;
+      });
+    },
+    [activeViewId, columnVisibility, filters, sorts, updateColumnMutation, updateViewMutation]
+  );
+
+  const handleFilterChange = useCallback(
+    (nextFilters: FilterCondition[]) => {
+      setFilters(nextFilters);
+      if (activeViewId) {
+        const config = buildConfig({ filters: nextFilters, sorts, columnVisibility, columnOrder });
+        updateViewMutation.mutate({ id: activeViewId, payload: { config } });
+      }
+    },
+    [activeViewId, sorts, columnVisibility, columnOrder, updateViewMutation]
+  );
+
+  const handleSortChange = useCallback(
+    (nextSorts: SortCondition[]) => {
+      setSorts(nextSorts);
+      if (activeViewId) {
+        const config = buildConfig({ filters, sorts: nextSorts, columnVisibility, columnOrder });
+        updateViewMutation.mutate({ id: activeViewId, payload: { config } });
+      }
+    },
+    [activeViewId, filters, columnVisibility, columnOrder, updateViewMutation]
+  );
+
+  const handleImport = useCallback(
+    async (file: File) => {
+      const summary = await importCsvMutation.mutateAsync(file);
+      setImportSummary(summary);
+    },
+    [importCsvMutation]
+  );
+
+  const footerText = useMemo(() => {
+    if (!data?.updatedAt) {
+      return null;
+    }
+    const actor = data.updatedBy ?? "system";
+    return `Last updated by ${actor} ${formatDistanceToNow(new Date(data.updatedAt), { addSuffix: true })}`;
+  }, [data]);
+
+  const hasColumns = columns.length > 0;
+  const hasRows = gridRows.length > 0;
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[480px] items-center justify-center rounded-3xl border border-border bg-white/80 shadow-card">
+        <span className="text-sm text-muted-foreground">Loading table…</span>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <ViewMenu
+          views={views}
+          activeViewId={activeViewId}
+          onSelect={setActiveViewId}
+          onSaveCurrent={handleSaveCurrentView}
+          onRename={handleRenameView}
+          onDelete={handleDeleteView}
+          isSaving={createViewMutation.isPending}
+        />
+        <div className="flex flex-wrap items-center gap-2 rounded-full border border-border/60 bg-white/70 px-3 py-1">
+          <Filter className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground">Filters</span>
+          {filters.map((filter, index) => (
+            <span
+              key={`${filter.columnId}-${index}`}
+              className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs"
+            >
+              {columnMap.get(filter.columnId)?.name ?? "Column"}: {filter.value || "Any"}
+            </span>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 rounded-full px-2 text-xs"
+            onClick={() =>
+              handleFilterChange([
+                ...filters,
+                { columnId: columns[0]?.id ?? "", value: "" }
+              ])
+            }
+            disabled={!columns.length}
+          >
+            Add filter
+          </Button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 rounded-full border border-border/60 bg-white/70 px-3 py-1">
+          <ArrowDown className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground">Sorts</span>
+          {sorts.map((sort, index) => (
+            <span key={`${sort.columnId}-${index}`} className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs">
+              {columnMap.get(sort.columnId)?.name ?? "Column"}: {sort.direction === "asc" ? "A→Z" : "Z→A"}
+            </span>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 rounded-full px-2 text-xs"
+            onClick={() =>
+              handleSortChange([
+                ...sorts,
+                { columnId: columns[0]?.id ?? "", direction: "asc" }
+              ])
+            }
+            disabled={!columns.length}
+          >
+            Add sort
+          </Button>
+        </div>
+        <div className="flex-1" />
+        <Button type="button" variant="outline" className="rounded-full" onClick={() => setIsImportOpen(true)}>
+          Import CSV
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-full"
+          onClick={() => exportCsvMutation.mutate(activeViewId ?? undefined)}
+        >
+          Export CSV
+        </Button>
+        <Button type="button" className="rounded-full bg-brand-primary text-white" onClick={() => setIsAddColumnOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" /> Column
+        </Button>
+        <Button type="button" className="rounded-full" onClick={handleAddRow}>
+          <Plus className="mr-2 h-4 w-4" /> Row
+        </Button>
+      </div>
+
+      {filters.length ? (
+        <div className="space-y-3 rounded-3xl border border-border/70 bg-white/80 p-4 shadow-card">
+          {filters.map((filter, index) => (
+            <div key={`${filter.columnId}-${index}`} className="flex flex-wrap items-center gap-3">
+              <select
+                className="rounded-xl border border-border/60 bg-white px-3 py-2 text-sm"
+                value={filter.columnId}
+                onChange={(event) => {
+                  const updated = [...filters];
+                  updated[index] = { ...filter, columnId: event.target.value };
+                  handleFilterChange(updated);
+                }}
+              >
+                {columns.map((column) => (
+                  <option key={column.id} value={column.id}>
+                    {column.name}
+                  </option>
+                ))}
+              </select>
+              <Input
+                className="w-48"
+                value={filter.value}
+                onChange={(event) => {
+                  const updated = [...filters];
+                  updated[index] = { ...filter, value: event.target.value };
+                  handleFilterChange(updated);
+                }}
+                placeholder="Contains…"
+              />
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  const updated = filters.filter((_, idx) => idx !== index);
+                  handleFilterChange(updated);
+                }}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          <p className="text-xs text-muted-foreground">Filters update instantly. Save as a view to keep them.</p>
+        </div>
+      ) : null}
+
+      {sorts.length ? (
+        <div className="space-y-3 rounded-3xl border border-border/70 bg-white/80 p-4 shadow-card">
+          {sorts.map((sort, index) => (
+            <div key={`${sort.columnId}-${index}`} className="flex flex-wrap items-center gap-3">
+              <select
+                className="rounded-xl border border-border/60 bg-white px-3 py-2 text-sm"
+                value={sort.columnId}
+                onChange={(event) => {
+                  const updated = [...sorts];
+                  updated[index] = { ...sort, columnId: event.target.value };
+                  handleSortChange(updated);
+                }}
+              >
+                {columns.map((column) => (
+                  <option key={column.id} value={column.id}>
+                    {column.name}
+                  </option>
+                ))}
+              </select>
+              <Button
+                type="button"
+                variant="secondary"
+                className="rounded-full"
+                onClick={() => {
+                  const updated = [...sorts];
+                  updated[index] = {
+                    ...sort,
+                    direction: sort.direction === "asc" ? "desc" : "asc"
+                  };
+                  handleSortChange(updated);
+                }}
+              >
+                {sort.direction === "asc" ? <ArrowUp className="h-4 w-4" /> : <ArrowDown className="h-4 w-4" />}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  const updated = sorts.filter((_, idx) => idx !== index);
+                  handleSortChange(updated);
+                }}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          {reorderDisabled ? (
+            <p className="text-xs text-muted-foreground">Row drag is disabled while filters or sorts are active.</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="relative flex-1 overflow-hidden rounded-3xl border border-border bg-white/80 shadow-card">
+        {!hasColumns ? (
+          <div className="flex h-full items-center justify-center p-10 text-center">
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold text-foreground">Create your first column</h3>
+              <p className="text-sm text-muted-foreground">
+                Define the fields your team needs. Add a column to start building your workspace.
+              </p>
+              <Button type="button" onClick={() => setIsAddColumnOpen(true)} className="rounded-full">
+                <Plus className="mr-2 h-4 w-4" /> Add column
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="sticky top-0 z-10 border-b border-border/60 bg-white/90">
+              <DndContext sensors={columnSensors} collisionDetection={closestCenter} onDragEnd={handleColumnOrderChange}>
+                <SortableContext items={columnDragItems} strategy={horizontalListSortingStrategy}>
+                  <div className="flex">
+                    {table.getHeaderGroups().map((headerGroup) => (
+                      <Fragment key={headerGroup.id}>
+                        {headerGroup.headers.map((header) => (
+                          <SortableColumnHeader
+                            key={header.id}
+                            header={header}
+                            disableDrag={header.column.id === "__select__" || header.column.id === "__position__"}
+                          />
+                        ))}
+                      </Fragment>
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            </div>
+            {!hasRows ? (
+              <div className="flex h-full items-center justify-center p-10 text-center">
+                <div className="space-y-3">
+                  <h3 className="text-lg font-semibold text-foreground">Add your first row</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Capture records manually or import a CSV to bring in existing data.
+                  </p>
+                  <div className="flex flex-wrap items-center justify-center gap-3">
+                    <Button type="button" onClick={handleAddRow} className="rounded-full">
+                      <Plus className="mr-2 h-4 w-4" /> Add row
+                    </Button>
+                    <Button type="button" variant="outline" className="rounded-full" onClick={() => setIsImportOpen(true)}>
+                      Import CSV
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <DndContext sensors={rowSensors} collisionDetection={closestCenter} onDragEnd={handleRowDragEnd}>
+                <SortableContext items={rowModel.rows.map((row) => row.original.__meta.id)} strategy={verticalListSortingStrategy}>
+                  <div ref={parentRef} className="h-[520px] overflow-auto">
+                    <div style={{ height: `${rowVirtualizer.getTotalSize()}px`, position: "relative" }}>
+                      {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                        const row = rowModel.rows[virtualRow.index];
+                        return (
+                          <SortableRow key={row.id} row={row} virtualRow={virtualRow} allowDrag={!reorderDisabled} />
+                        );
+                      })}
+                    </div>
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between rounded-3xl border border-dashed border-border/70 bg-white/70 px-4 py-3 text-xs text-muted-foreground">
+        <div>
+          {selectedRows.size > 0 ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="gap-1 text-destructive"
+              onClick={handleDeleteSelected}
+            >
+              <Trash2 className="h-4 w-4" /> Delete selected ({selectedRows.size})
+            </Button>
+          ) : (
+            <span>Select rows to bulk delete.</span>
+          )}
+        </div>
+        {footerText ? <span>{footerText}</span> : null}
+      </div>
+
+      {isAddColumnOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 px-4 backdrop-blur">
+          <div className="w-full max-w-md rounded-3xl border border-border bg-card/95 p-6 shadow-xl">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-brand-primary/10">
+                <FolderPlus className="h-5 w-5 text-brand-primary" />
+              </div>
+              <div className="space-y-1">
+                <h3 className="text-lg font-semibold text-foreground">Add column</h3>
+                <p className="text-sm text-muted-foreground">Name the column and choose the type.</p>
+              </div>
+            </div>
+            <div className="mt-6 space-y-4">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground" htmlFor="column-name">
+                  Column name
+                </label>
+                <Input
+                  id="column-name"
+                  value={newColumnName}
+                  onChange={(event) => setNewColumnName(event.target.value)}
+                  placeholder="e.g. Status"
+                  autoFocus
+                />
+              </div>
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-foreground">Type</span>
+                <div className="grid grid-cols-2 gap-2">
+                  {COLUMN_TYPE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setNewColumnType(option.value)}
+                      className={cn(
+                        "flex items-center gap-2 rounded-2xl border border-border/60 bg-white/80 px-3 py-2 text-left text-sm",
+                        newColumnType === option.value ? "border-brand-primary text-brand-primary" : "hover:border-brand-primary/60"
+                      )}
+                    >
+                      {newColumnType === option.value ? <Check className="h-4 w-4" /> : <span className="h-4 w-4" />}
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-3">
+                <Button type="button" variant="ghost" onClick={() => setIsAddColumnOpen(false)}>
+                  Cancel
+                </Button>
+                <Button type="button" onClick={handleAddColumn} disabled={createColumnMutation.isPending}>
+                  {createColumnMutation.isPending ? "Adding…" : "Add column"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <ImportCsvModal
+        open={isImportOpen}
+        onOpenChange={(next) => {
+          setIsImportOpen(next);
+          if (!next) {
+            setImportSummary(null);
+          }
+        }}
+        onSubmit={handleImport}
+        isSubmitting={importCsvMutation.isPending}
+        summary={importSummary}
+      />
+    </div>
+  );
+}
+
+interface ColumnHeaderProps {
+  column: TableColumnDto;
+  columnVisibility: Record<string, boolean>;
+  onToggleVisibility: () => void;
+  onDelete: () => void;
+  onStartRename: () => void;
+  isEditing: boolean;
+  editingName: string;
+  onEditingNameChange: (value: string) => void;
+  onCommit: (value: string) => void;
+}
+
+interface SortableColumnHeaderProps {
+  header: any;
+  disableDrag?: boolean;
+}
+
+function SortableColumnHeader({ header, disableDrag = false }: SortableColumnHeaderProps) {
+  const { setNodeRef, attributes, listeners, transform, transition } = useSortable({
+    id: header.column.id,
+    disabled: disableDrag
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        width: header.column.getSize() ? `${header.column.getSize()}px` : undefined,
+        transform: CSS.Transform.toString(transform ?? { x: 0, y: 0, scaleX: 1, scaleY: 1 }),
+        transition
+      }}
+      className="flex min-h-[44px] flex-1 items-center border-r border-border/40 bg-white/80 px-3 text-sm font-medium text-muted-foreground last:border-r-0"
+      {...attributes}
+      {...(!disableDrag ? listeners : {})}
+    >
+      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+    </div>
+  );
+}
+
+function ColumnHeader({
+  column,
+  columnVisibility,
+  onToggleVisibility,
+  onDelete,
+  onStartRename,
+  isEditing,
+  editingName,
+  onEditingNameChange,
+  onCommit
+}: ColumnHeaderProps) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      {isEditing ? (
+        <Input
+          value={editingName}
+          onChange={(event) => onEditingNameChange(event.target.value)}
+          onBlur={() => onCommit(editingName)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              onCommit(editingName);
+            }
+            if (event.key === "Escape") {
+              onCommit(column.name);
+            }
+          }}
+          className="h-8 rounded-lg"
+          autoFocus
+        />
+      ) : (
+        <button
+          type="button"
+          className="text-left text-sm font-semibold text-foreground"
+          onDoubleClick={() => onStartRename()}
+        >
+          {column.name}
+        </button>
+      )}
+      <ColumnMenu
+        column={column}
+        onRename={onStartRename}
+        onToggleVisibility={onToggleVisibility}
+        onDelete={onDelete}
+        isHidden={!columnVisibility[column.id]}
+      />
+    </div>
+  );
+}
+
+interface CellEditorProps {
+  column: TableColumnDto;
+  row: TableRowDto;
+  value: unknown;
+  onCommit: (value: unknown) => void;
+}
+
+function CellEditor({ column, value, onCommit }: CellEditorProps) {
+  const [draft, setDraft] = useState(normalizeValue(column.type, value));
+
+  useEffect(() => {
+    setDraft(normalizeValue(column.type, value));
+  }, [column.id, column.type, value]);
+
+  if (column.type === "BOOLEAN") {
+    return (
+      <Checkbox
+        checked={Boolean(draft)}
+        onCheckedChange={(checked) => {
+          setDraft(Boolean(checked));
+          onCommit(Boolean(checked));
+        }}
+      />
+    );
+  }
+
+  if (column.type === "SELECT") {
+    const options = Array.isArray((column.config as any)?.options)
+      ? (column.config as any).options
+      : [];
+    return (
+      <select
+        className="w-full rounded-lg border border-border/60 bg-white px-2 py-1 text-sm"
+        value={draft ?? ""}
+        onChange={(event) => {
+          setDraft(event.target.value);
+          onCommit(event.target.value);
+        }}
+      >
+        <option value="">Select…</option>
+        {options.map((option: any) => {
+          if (option && typeof option === "object") {
+            const optionValue = option.value ?? option.id ?? option.label ?? "";
+            const optionLabel = option.label ?? optionValue;
+            return (
+              <option key={String(optionValue)} value={optionValue}>
+                {String(optionLabel)}
+              </option>
+            );
+          }
+          return (
+            <option key={String(option)} value={String(option)}>
+              {String(option)}
+            </option>
+          );
+        })}
+      </select>
+    );
+  }
+
+  if (column.type === "DATE") {
+    const formatted = draft ? new Date(String(draft)).toISOString().slice(0, 10) : "";
+    return (
+      <Input
+        type="date"
+        value={formatted}
+        onChange={(event) => {
+          setDraft(event.target.value);
+          onCommit(event.target.value);
+        }}
+        className="h-8"
+      />
+    );
+  }
+
+  if (column.type === "NUMBER") {
+    return (
+      <Input
+        type="number"
+        value={draft === "" ? "" : String(draft)}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => onCommit(draft === "" ? null : Number(draft))}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            onCommit(draft === "" ? null : Number(draft));
+          }
+        }}
+        className="h-8"
+      />
+    );
+  }
+
+  return (
+    <Input
+      value={draft as string}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={() => onCommit(draft)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          onCommit(draft);
+        }
+      }}
+      placeholder={column.type === "REFERENCE" ? "Search records" : undefined}
+      className="h-8"
+    />
+  );
+}
+

--- a/apps/frontend/components/tables/ViewMenu.tsx
+++ b/apps/frontend/components/tables/ViewMenu.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo } from "react";
+import { Check, ChevronDown, PlusCircle, Trash2 } from "lucide-react";
+
+import { type TableViewDto } from "@/lib/api/tables";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+
+interface ViewMenuProps {
+  views: TableViewDto[];
+  activeViewId: string | null;
+  onSelect: (viewId: string | null) => void;
+  onSaveCurrent: () => void;
+  onRename: (viewId: string) => void;
+  onDelete: (viewId: string) => void;
+  isSaving?: boolean;
+}
+
+export function ViewMenu({
+  views,
+  activeViewId,
+  onSelect,
+  onSaveCurrent,
+  onRename,
+  onDelete,
+  isSaving
+}: ViewMenuProps) {
+  const activeView = useMemo(() => views.find((view) => view.id === activeViewId), [views, activeViewId]);
+  const label = activeView ? activeView.name : "Default view";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="secondary"
+          className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-white/80 px-3 py-1 text-xs font-medium shadow-sm hover:shadow-cardHover"
+        >
+          {label}
+          <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="bottom" align="start" className="w-56">
+        <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+          Views
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => onSelect(null)}>
+          <span className="flex items-center gap-2">
+            {activeViewId === null ? <Check className="h-4 w-4" /> : <span className="h-4 w-4" />}
+            Default view
+          </span>
+        </DropdownMenuItem>
+        {views.map((view) => (
+          <DropdownMenuItem key={view.id} onSelect={() => onSelect(view.id)}>
+            <span className="flex items-center gap-2">
+              {activeViewId === view.id ? <Check className="h-4 w-4" /> : <span className="h-4 w-4" />}
+              {view.name}
+            </span>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onSaveCurrent} disabled={isSaving}>
+          <PlusCircle className="mr-2 h-4 w-4" /> Save current view
+        </DropdownMenuItem>
+        {activeViewId ? (
+          <>
+            <DropdownMenuItem onSelect={() => onRename(activeViewId!)}>
+              Rename view
+            </DropdownMenuItem>
+            <DropdownMenuItem className="text-destructive" onSelect={() => onDelete(activeViewId!)}>
+              <Trash2 className="mr-2 h-4 w-4" /> Delete view
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/frontend/lib/api/tables.ts
+++ b/apps/frontend/lib/api/tables.ts
@@ -1,0 +1,368 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type CreateColumnDto,
+  type CreateTableDto,
+  type CreateViewDto,
+  type DataTableDto,
+  type TableColumnDto,
+  type TableRowDto,
+  type TableViewDto,
+  type UpdateColumnDto,
+  type UpdateViewDto
+} from "@shared/api";
+
+import { apiBaseUrl, isMockMode } from "@/lib/utils";
+
+type TableDetail = DataTableDto & {
+  columns: TableColumnDto[];
+  rows: TableRowDto[];
+  views: TableViewDto[];
+};
+
+type PatchRowCellsPayload = {
+  rowId: string;
+  cells: Array<{ columnId: string; value: unknown }>;
+};
+
+type ReorderRowsPayload = {
+  tableId: string;
+  order: Array<{ rowId: string; position: number }>;
+};
+
+type ImportCsvResult = {
+  createdColumns: number;
+  createdRows: number;
+};
+
+type TablesListResponse = DataTableDto[];
+
+type TableResponse = TableDetail;
+
+const TABLES_API_PATH = "/admin/tables";
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (contentType && contentType.includes("application/json")) {
+    return (await response.json()) as T;
+  }
+
+  // @ts-expect-error -- allow returning void for non-JSON requests
+  return undefined;
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+
+  if (!(init.body instanceof FormData)) {
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+  }
+
+  headers.set("x-mock-mode", isMockMode() ? "true" : "false");
+
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...init,
+    headers,
+    credentials: "include"
+  });
+
+  return handleResponse<T>(response);
+}
+
+async function listTables() {
+  return request<TablesListResponse>(`${TABLES_API_PATH}`);
+}
+
+async function getTable(id: string) {
+  return request<TableResponse>(`${TABLES_API_PATH}/${id}`);
+}
+
+async function createTable(payload: CreateTableDto) {
+  return request<DataTableDto>(`${TABLES_API_PATH}`, {
+    method: "POST",
+    body: JSON.stringify(payload)
+  });
+}
+
+async function createColumn(tableId: string, payload: Omit<CreateColumnDto, "tableId">) {
+  return request<TableColumnDto>(`${TABLES_API_PATH}/${tableId}/columns`, {
+    method: "POST",
+    body: JSON.stringify({ ...payload, tableId })
+  });
+}
+
+async function updateColumn(id: string, payload: UpdateColumnDto) {
+  return request<TableColumnDto>(`${TABLES_API_PATH}/columns/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload)
+  });
+}
+
+async function deleteColumn(id: string) {
+  return request<{ success: boolean }>(`${TABLES_API_PATH}/columns/${id}`, {
+    method: "DELETE"
+  });
+}
+
+async function createRow(tableId: string, afterRowId?: string) {
+  return request<TableRowDto>(`${TABLES_API_PATH}/${tableId}/rows`, {
+    method: "POST",
+    body: JSON.stringify(afterRowId ? { tableId, afterRowId } : { tableId })
+  });
+}
+
+async function patchRowCells(rowId: string, payload: PatchRowCellsPayload) {
+  return request<{ success: boolean }>(`${TABLES_API_PATH}/rows/${rowId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ ...payload, rowId })
+  });
+}
+
+async function reorderRows(tableId: string, order: ReorderRowsPayload["order"]) {
+  return request<{ success: boolean }>(`${TABLES_API_PATH}/${tableId}/rows/reorder`, {
+    method: "PATCH",
+    body: JSON.stringify({ tableId, order })
+  });
+}
+
+async function deleteRow(rowId: string) {
+  return request<{ success: boolean }>(`${TABLES_API_PATH}/rows/${rowId}`, {
+    method: "DELETE"
+  });
+}
+
+async function createView(tableId: string, payload: Omit<CreateViewDto, "tableId">) {
+  return request<TableViewDto>(`${TABLES_API_PATH}/${tableId}/views`, {
+    method: "POST",
+    body: JSON.stringify({ ...payload, tableId })
+  });
+}
+
+async function updateView(id: string, payload: UpdateViewDto) {
+  return request<TableViewDto>(`${TABLES_API_PATH}/views/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload)
+  });
+}
+
+async function deleteView(id: string) {
+  return request<{ success: boolean }>(`${TABLES_API_PATH}/views/${id}`, {
+    method: "DELETE"
+  });
+}
+
+async function exportCsv(tableId: string, viewId?: string) {
+  const searchParams = new URLSearchParams();
+  if (viewId) {
+    searchParams.set("viewId", viewId);
+  }
+  const query = searchParams.toString();
+  const response = await fetch(`${apiBaseUrl}${TABLES_API_PATH}/${tableId}/export.csv${query ? `?${query}` : ""}`, {
+    method: "GET",
+    headers: {
+      "x-mock-mode": isMockMode() ? "true" : "false"
+    },
+    credentials: "include"
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || "Failed to export CSV");
+  }
+
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${tableId}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function importCsv(tableId: string, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch(`${apiBaseUrl}${TABLES_API_PATH}/${tableId}/import.csv`, {
+    method: "POST",
+    body: formData,
+    headers: {
+      "x-mock-mode": isMockMode() ? "true" : "false"
+    },
+    credentials: "include"
+  });
+
+  return handleResponse<ImportCsvResult>(response);
+}
+
+const tableKeys = {
+  all: ["tables"] as const,
+  lists: () => [...tableKeys.all, "list"] as const,
+  list: () => [...tableKeys.lists()] as const,
+  detail: (id: string) => [...tableKeys.all, "detail", id] as const
+};
+
+export function useTables() {
+  return useQuery({
+    queryKey: tableKeys.list(),
+    queryFn: listTables
+  });
+}
+
+export function useTable(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? tableKeys.detail(id) : [...tableKeys.all, "detail", "__pending__"],
+    queryFn: () => {
+      if (!id) {
+        return Promise.reject(new Error("Missing table id"));
+      }
+      return getTable(id);
+    },
+    enabled: Boolean(id)
+  });
+}
+
+function useInvalidateTableList() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: tableKeys.list() });
+}
+
+function useInvalidateTableDetail() {
+  const queryClient = useQueryClient();
+  return (id: string) => queryClient.invalidateQueries({ queryKey: tableKeys.detail(id) });
+}
+
+export function useCreateTableMutation() {
+  const invalidate = useInvalidateTableList();
+  return useMutation({
+    mutationFn: createTable,
+    onSuccess: () => invalidate()
+  });
+}
+
+export function useCreateColumnMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (payload: { name: string; type: TableColumnDto["type"]; config?: unknown }) =>
+      createColumn(tableId, payload),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useUpdateColumnMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateColumnDto }) => updateColumn(id, payload),
+    onSuccess: (_, variables) => invalidate(tableId)
+  });
+}
+
+export function useDeleteColumnMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (id: string) => deleteColumn(id),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useCreateRowMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (afterRowId?: string) => createRow(tableId, afterRowId),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function usePatchRowCellsMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: ({ rowId, cells }: PatchRowCellsPayload) => patchRowCells(rowId, { rowId, cells }),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useReorderRowsMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (order: ReorderRowsPayload["order"]) => reorderRows(tableId, order),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useDeleteRowMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (rowId: string) => deleteRow(rowId),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useCreateViewMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  const invalidateList = useInvalidateTableList();
+  return useMutation({
+    mutationFn: (payload: { name: string; config: unknown }) => createView(tableId, payload),
+    onSuccess: () => {
+      invalidate(tableId);
+      invalidateList();
+    }
+  });
+}
+
+export function useUpdateViewMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateViewDto }) => updateView(id, payload),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useDeleteViewMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (id: string) => deleteView(id),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export function useExportCsvMutation(tableId: string) {
+  return useMutation({
+    mutationFn: (viewId?: string) => exportCsv(tableId, viewId)
+  });
+}
+
+export function useImportCsvMutation(tableId: string) {
+  const invalidate = useInvalidateTableDetail();
+  return useMutation({
+    mutationFn: (file: File) => importCsv(tableId, file),
+    onSuccess: () => invalidate(tableId)
+  });
+}
+
+export {
+  createTable,
+  listTables,
+  getTable,
+  createColumn,
+  updateColumn,
+  deleteColumn,
+  createRow,
+  patchRowCells,
+  reorderRows,
+  deleteRow,
+  createView,
+  updateView,
+  deleteView,
+  exportCsv,
+  importCsv
+};
+
+export type { TableDetail, TableColumnDto, TableRowDto, TableViewDto };

--- a/packages/shared/dist/schemas.d.ts
+++ b/packages/shared/dist/schemas.d.ts
@@ -1050,6 +1050,529 @@ export declare const updatePublicDashboardRequestSchema: z.ZodEffects<z.ZodObjec
     config?: unknown;
     isActive?: boolean | undefined;
 }>;
+export declare enum ColumnType {
+    TEXT = "TEXT",
+    NUMBER = "NUMBER",
+    DATE = "DATE",
+    BOOLEAN = "BOOLEAN",
+    SELECT = "SELECT",
+    REFERENCE = "REFERENCE"
+}
+export declare const columnTypeSchema: z.ZodNativeEnum<typeof ColumnType>;
+export declare const tableCellDtoSchema: z.ZodObject<{
+    id: z.ZodString;
+    rowId: z.ZodString;
+    columnId: z.ZodString;
+    value: z.ZodOptional<z.ZodNullable<z.ZodUnknown>>;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    rowId: string;
+    columnId: string;
+    value?: unknown;
+}, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    rowId: string;
+    columnId: string;
+    value?: unknown;
+}>;
+export declare const tableColumnDtoSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    name: z.ZodString;
+    slug: z.ZodString;
+    type: z.ZodNativeEnum<typeof ColumnType>;
+    position: z.ZodNumber;
+    config: z.ZodOptional<z.ZodUnknown>;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    type: ColumnType;
+    tableId: string;
+    slug: string;
+    position: number;
+    config?: unknown;
+}, {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    type: ColumnType;
+    tableId: string;
+    slug: string;
+    position: number;
+    config?: unknown;
+}>;
+export declare const tableRowDtoSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    position: z.ZodNumber;
+    cells: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rowId: z.ZodString;
+        columnId: z.ZodString;
+        value: z.ZodOptional<z.ZodNullable<z.ZodUnknown>>;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        rowId: string;
+        columnId: string;
+        value?: unknown;
+    }, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        rowId: string;
+        columnId: string;
+        value?: unknown;
+    }>, "many">;
+    createdBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    updatedBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    tableId: string;
+    position: number;
+    cells: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        rowId: string;
+        columnId: string;
+        value?: unknown;
+    }[];
+    createdBy?: string | null | undefined;
+    updatedBy?: string | null | undefined;
+}, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    tableId: string;
+    position: number;
+    cells: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        rowId: string;
+        columnId: string;
+        value?: unknown;
+    }[];
+    createdBy?: string | null | undefined;
+    updatedBy?: string | null | undefined;
+}>;
+export declare const tableViewDtoSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    name: z.ZodString;
+    config: z.ZodUnknown;
+    createdBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    tableId: string;
+    config?: unknown;
+    createdBy?: string | null | undefined;
+}, {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    tableId: string;
+    config?: unknown;
+    createdBy?: string | null | undefined;
+}>;
+export declare const dataTableDtoSchema: z.ZodObject<{
+    id: z.ZodString;
+    orgId: z.ZodString;
+    name: z.ZodString;
+    description: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    columns: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        tableId: z.ZodString;
+        name: z.ZodString;
+        slug: z.ZodString;
+        type: z.ZodNativeEnum<typeof ColumnType>;
+        position: z.ZodNumber;
+        config: z.ZodOptional<z.ZodUnknown>;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        type: ColumnType;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: unknown;
+    }, {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        type: ColumnType;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: unknown;
+    }>, "many">>;
+    rows: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        tableId: z.ZodString;
+        position: z.ZodNumber;
+        cells: z.ZodArray<z.ZodObject<{
+            id: z.ZodString;
+            rowId: z.ZodString;
+            columnId: z.ZodString;
+            value: z.ZodOptional<z.ZodNullable<z.ZodUnknown>>;
+            createdAt: z.ZodString;
+            updatedAt: z.ZodString;
+        }, "strip", z.ZodTypeAny, {
+            id: string;
+            createdAt: string;
+            updatedAt: string;
+            rowId: string;
+            columnId: string;
+            value?: unknown;
+        }, {
+            id: string;
+            createdAt: string;
+            updatedAt: string;
+            rowId: string;
+            columnId: string;
+            value?: unknown;
+        }>, "many">;
+        createdBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        updatedBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        position: number;
+        cells: {
+            id: string;
+            createdAt: string;
+            updatedAt: string;
+            rowId: string;
+            columnId: string;
+            value?: unknown;
+        }[];
+        createdBy?: string | null | undefined;
+        updatedBy?: string | null | undefined;
+    }, {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        position: number;
+        cells: {
+            id: string;
+            createdAt: string;
+            updatedAt: string;
+            rowId: string;
+            columnId: string;
+            value?: unknown;
+        }[];
+        createdBy?: string | null | undefined;
+        updatedBy?: string | null | undefined;
+    }>, "many">>;
+    views: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        tableId: z.ZodString;
+        name: z.ZodString;
+        config: z.ZodUnknown;
+        createdBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        createdAt: z.ZodString;
+        updatedAt: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        config?: unknown;
+        createdBy?: string | null | undefined;
+    }, {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        config?: unknown;
+        createdBy?: string | null | undefined;
+    }>, "many">>;
+    createdBy: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    orgId: string;
+    createdBy?: string | null | undefined;
+    description?: string | null | undefined;
+    columns?: {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        type: ColumnType;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: unknown;
+    }[] | undefined;
+    rows?: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        position: number;
+        cells: {
+            id: string;
+            createdAt: string;
+            updatedAt: string;
+            rowId: string;
+            columnId: string;
+            value?: unknown;
+        }[];
+        createdBy?: string | null | undefined;
+        updatedBy?: string | null | undefined;
+    }[] | undefined;
+    views?: {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        config?: unknown;
+        createdBy?: string | null | undefined;
+    }[] | undefined;
+}, {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    orgId: string;
+    createdBy?: string | null | undefined;
+    description?: string | null | undefined;
+    columns?: {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        type: ColumnType;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: unknown;
+    }[] | undefined;
+    rows?: {
+        id: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        position: number;
+        cells: {
+            id: string;
+            createdAt: string;
+            updatedAt: string;
+            rowId: string;
+            columnId: string;
+            value?: unknown;
+        }[];
+        createdBy?: string | null | undefined;
+        updatedBy?: string | null | undefined;
+    }[] | undefined;
+    views?: {
+        id: string;
+        name: string;
+        createdAt: string;
+        updatedAt: string;
+        tableId: string;
+        config?: unknown;
+        createdBy?: string | null | undefined;
+    }[] | undefined;
+}>;
+export declare const tableAuditDtoSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    actorId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    action: z.ZodString;
+    payload: z.ZodUnknown;
+    createdAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    createdAt: string;
+    tableId: string;
+    action: string;
+    actorId?: string | null | undefined;
+    payload?: unknown;
+}, {
+    id: string;
+    createdAt: string;
+    tableId: string;
+    action: string;
+    actorId?: string | null | undefined;
+    payload?: unknown;
+}>;
+export declare const createTableDtoSchema: z.ZodObject<{
+    name: z.ZodString;
+    description: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    description?: string | undefined;
+}, {
+    name: string;
+    description?: string | undefined;
+}>;
+export declare const createColumnDtoSchema: z.ZodObject<{
+    tableId: z.ZodString;
+    name: z.ZodString;
+    type: z.ZodNativeEnum<typeof ColumnType>;
+    config: z.ZodOptional<z.ZodUnknown>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    type: ColumnType;
+    tableId: string;
+    config?: unknown;
+}, {
+    name: string;
+    type: ColumnType;
+    tableId: string;
+    config?: unknown;
+}>;
+export declare const updateColumnDtoSchema: z.ZodEffects<z.ZodObject<{
+    name: z.ZodOptional<z.ZodString>;
+    position: z.ZodOptional<z.ZodNumber>;
+    config: z.ZodOptional<z.ZodUnknown>;
+}, "strip", z.ZodTypeAny, {
+    name?: string | undefined;
+    config?: unknown;
+    position?: number | undefined;
+}, {
+    name?: string | undefined;
+    config?: unknown;
+    position?: number | undefined;
+}>, {
+    name?: string | undefined;
+    config?: unknown;
+    position?: number | undefined;
+}, {
+    name?: string | undefined;
+    config?: unknown;
+    position?: number | undefined;
+}>;
+export declare const createRowDtoSchema: z.ZodObject<{
+    tableId: z.ZodString;
+    afterRowId: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    tableId: string;
+    afterRowId?: string | undefined;
+}, {
+    tableId: string;
+    afterRowId?: string | undefined;
+}>;
+export declare const patchCellsDtoSchema: z.ZodObject<{
+    rowId: z.ZodString;
+    cells: z.ZodArray<z.ZodObject<{
+        columnId: z.ZodString;
+        value: z.ZodUnknown;
+    }, "strip", z.ZodTypeAny, {
+        columnId: string;
+        value?: unknown;
+    }, {
+        columnId: string;
+        value?: unknown;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    rowId: string;
+    cells: {
+        columnId: string;
+        value?: unknown;
+    }[];
+}, {
+    rowId: string;
+    cells: {
+        columnId: string;
+        value?: unknown;
+    }[];
+}>;
+export declare const reorderRowsDtoSchema: z.ZodObject<{
+    order: z.ZodArray<z.ZodObject<{
+        rowId: z.ZodString;
+        position: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        rowId: string;
+        position: number;
+    }, {
+        rowId: string;
+        position: number;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    order: {
+        rowId: string;
+        position: number;
+    }[];
+}, {
+    order: {
+        rowId: string;
+        position: number;
+    }[];
+}>;
+export declare const createViewDtoSchema: z.ZodObject<{
+    tableId: z.ZodString;
+    name: z.ZodString;
+    config: z.ZodUnknown;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    tableId: string;
+    config?: unknown;
+}, {
+    name: string;
+    tableId: string;
+    config?: unknown;
+}>;
+export declare const updateViewDtoSchema: z.ZodEffects<z.ZodObject<{
+    name: z.ZodOptional<z.ZodString>;
+    config: z.ZodOptional<z.ZodUnknown>;
+}, "strip", z.ZodTypeAny, {
+    name?: string | undefined;
+    config?: unknown;
+}, {
+    name?: string | undefined;
+    config?: unknown;
+}>, {
+    name?: string | undefined;
+    config?: unknown;
+}, {
+    name?: string | undefined;
+    config?: unknown;
+}>;
 export type Org = z.infer<typeof orgSchema>;
 export type Property = z.infer<typeof propertySchema>;
 export type User = z.infer<typeof userSchema>;
@@ -1084,3 +1607,18 @@ export type PublicDashboard = z.infer<typeof publicDashboardSchema>;
 export type PublicDashboardListResponse = z.infer<typeof publicDashboardListResponseSchema>;
 export type CreatePublicDashboardRequest = z.infer<typeof createPublicDashboardRequestSchema>;
 export type UpdatePublicDashboardRequest = z.infer<typeof updatePublicDashboardRequestSchema>;
+export type ColumnTypeValue = z.infer<typeof columnTypeSchema>;
+export type TableCellDto = z.infer<typeof tableCellDtoSchema>;
+export type TableColumnDto = z.infer<typeof tableColumnDtoSchema>;
+export type TableRowDto = z.infer<typeof tableRowDtoSchema>;
+export type TableViewDto = z.infer<typeof tableViewDtoSchema>;
+export type DataTableDto = z.infer<typeof dataTableDtoSchema>;
+export type TableAuditDto = z.infer<typeof tableAuditDtoSchema>;
+export type CreateTableDto = z.infer<typeof createTableDtoSchema>;
+export type CreateColumnDto = z.infer<typeof createColumnDtoSchema>;
+export type UpdateColumnDto = z.infer<typeof updateColumnDtoSchema>;
+export type CreateRowDto = z.infer<typeof createRowDtoSchema>;
+export type PatchCellsDto = z.infer<typeof patchCellsDtoSchema>;
+export type ReorderRowsDto = z.infer<typeof reorderRowsDtoSchema>;
+export type CreateViewDto = z.infer<typeof createViewDtoSchema>;
+export type UpdateViewDto = z.infer<typeof updateViewDtoSchema>;

--- a/packages/shared/dist/schemas.js
+++ b/packages/shared/dist/schemas.js
@@ -255,3 +255,120 @@ export const updatePublicDashboardRequestSchema = z
     .refine((payload) => Object.keys(payload).length > 0, {
     message: "Update payload cannot be empty"
 });
+export var ColumnType;
+(function (ColumnType) {
+    ColumnType["TEXT"] = "TEXT";
+    ColumnType["NUMBER"] = "NUMBER";
+    ColumnType["DATE"] = "DATE";
+    ColumnType["BOOLEAN"] = "BOOLEAN";
+    ColumnType["SELECT"] = "SELECT";
+    ColumnType["REFERENCE"] = "REFERENCE";
+})(ColumnType || (ColumnType = {}));
+export const columnTypeSchema = z.nativeEnum(ColumnType);
+export const tableCellDtoSchema = z.object({
+    id: z.string(),
+    rowId: z.string(),
+    columnId: z.string(),
+    value: z.unknown().nullable().optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const tableColumnDtoSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    type: columnTypeSchema,
+    position: z.number(),
+    config: z.unknown().optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const tableRowDtoSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    position: z.number(),
+    cells: z.array(tableCellDtoSchema),
+    createdBy: z.string().nullable().optional(),
+    updatedBy: z.string().nullable().optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const tableViewDtoSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    name: z.string(),
+    config: z.unknown(),
+    createdBy: z.string().nullable().optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const dataTableDtoSchema = z.object({
+    id: z.string(),
+    orgId: z.string(),
+    name: z.string(),
+    description: z.string().nullable().optional(),
+    columns: z.array(tableColumnDtoSchema).optional(),
+    rows: z.array(tableRowDtoSchema).optional(),
+    views: z.array(tableViewDtoSchema).optional(),
+    createdBy: z.string().nullable().optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true })
+});
+export const tableAuditDtoSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    actorId: z.string().nullable().optional(),
+    action: z.string(),
+    payload: z.unknown(),
+    createdAt: z.string().datetime({ offset: true })
+});
+export const createTableDtoSchema = z.object({
+    name: z.string().min(1),
+    description: z.string().optional()
+});
+export const createColumnDtoSchema = z.object({
+    tableId: z.string(),
+    name: z.string().min(1),
+    type: columnTypeSchema,
+    config: z.unknown().optional()
+});
+export const updateColumnDtoSchema = z
+    .object({
+    name: z.string().optional(),
+    position: z.number().int().optional(),
+    config: z.unknown().optional()
+})
+    .refine((payload) => Object.keys(payload).length > 0, {
+    message: "Update payload cannot be empty"
+});
+export const createRowDtoSchema = z.object({
+    tableId: z.string(),
+    afterRowId: z.string().optional()
+});
+export const patchCellsDtoSchema = z.object({
+    rowId: z.string(),
+    cells: z.array(z.object({
+        columnId: z.string(),
+        value: z.unknown()
+    }))
+});
+export const reorderRowsDtoSchema = z.object({
+    order: z.array(z.object({
+        rowId: z.string(),
+        position: z.number().int()
+    }))
+});
+export const createViewDtoSchema = z.object({
+    tableId: z.string(),
+    name: z.string().min(1),
+    config: z.unknown()
+});
+export const updateViewDtoSchema = z
+    .object({
+    name: z.string().optional(),
+    config: z.unknown().optional()
+})
+    .refine((payload) => Object.keys(payload).length > 0, {
+    message: "Update payload cannot be empty"
+});


### PR DESCRIPTION
## Summary
- regenerate the shared API schema artifacts to include the tables DTO exports consumed by the frontend tables client
- align the TableGrid column type picker with the shared `ColumnType` enum to satisfy strict type checking

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68e06ab1abdc8322bf2b0e8a6baf7242