### PR TITLE
Live Dashboards responsive pass + performance polish

### DIFF
--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -17,33 +17,31 @@ export default async function DashboardPage() {
   const isAdmin = role === "admin";
 
   return (
-    <div className="space-y-6">
-      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
-        <DashboardView role={role} />
-      </div>
+    <div className="space-y-6 pb-16">
+      <DashboardView role={role} />
       {isAdmin ? (
-        <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <div className="rounded-3xl border border-border/60 bg-white/85 p-6 shadow-sm supports-[backdrop-filter]:bg-white/70">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-foreground">Accelerate your rollout</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
+            <div className="space-y-2">
+              <h2 className="text-[clamp(1.125rem,2vw,1.375rem)] font-semibold text-foreground">Accelerate your rollout</h2>
+              <p className="text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground">
                 Connect marketing sources and publish a live dashboard for your teams in minutes.
               </p>
             </div>
             <div className="flex flex-wrap gap-3">
               <Link
                 href="/admin/sources"
-                className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/80 px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover"
+                className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-white px-4 py-2 text-[clamp(.9rem,1.5vw,1rem)] font-medium text-foreground shadow-sm transition hover:shadow-md"
               >
                 Connect a source
-                <ArrowRight className="h-4 w-4" />
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </Link>
               <Link
                 href="/reports"
-                className="inline-flex items-center gap-2 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-sm font-semibold text-brand-primary transition hover:bg-brand-primary/20"
+                className="inline-flex items-center gap-2 rounded-full border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-[clamp(.9rem,1.5vw,1rem)] font-semibold text-brand-primary transition hover:bg-brand-primary/20"
               >
                 Publish a live dashboard
-                <ArrowRight className="h-4 w-4" />
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </Link>
             </div>
           </div>

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -4,10 +4,9 @@ import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { AppProviders } from "@/components/providers/app-providers";
-import { Sidebar } from "@/components/shell/sidebar";
-import { Topbar } from "@/components/shell/topbar";
+import { AppChrome } from "@/components/shell/app-chrome";
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
 
 export const metadata: Metadata = {
   title: "Astalla Dashboard",
@@ -36,17 +35,11 @@ export default function RootLayout({
       <body className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-white font-sans text-slate-900 antialiased">
         <AppProviders>
           {isPublicHost ? (
-            <main className="min-h-screen">{children}</main>
+            <main className="min-h-screen">
+              <div className="mx-auto min-h-screen w-full max-w-[1200px] px-4 py-8 sm:px-6 lg:px-8">{children}</div>
+            </main>
           ) : (
-            <div className="flex min-h-screen">
-              <Sidebar />
-              <div className="flex min-h-screen flex-1 flex-col bg-transparent">
-                <Topbar />
-                <main className="flex-1 min-h-0 p-6">
-                  <div className="mx-auto flex max-w-6xl flex-col gap-6">{children}</div>
-                </main>
-              </div>
-            </div>
+            <AppChrome>{children}</AppChrome>
           )}
         </AppProviders>
       </body>

--- a/apps/frontend/app/public/page.tsx
+++ b/apps/frontend/app/public/page.tsx
@@ -1,58 +1,114 @@
-"use client";
+import { Share2 } from "lucide-react";
+import type { Metadata } from "next";
 
-import { useSearchParams } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+interface PublicDashboardProps {
+  searchParams: Record<string, string | string[] | undefined>;
+}
 
-export default function PublicDashboard() {
-  const searchParams = useSearchParams();
-  const host = searchParams.get("x-host") || "";
+interface PublicDashboardResponse {
+  title?: string;
+  widgets?: Array<{ id?: string; label?: string; value?: string }>;
+}
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ["public-dashboard", host],
-    queryFn: async () => {
-      if (!host) {
-        throw new Error("missing host");
-      }
-      const response = await fetch(`/api/public/resolve?host=${encodeURIComponent(host)}`, {
-        cache: "no-store"
-      });
-      if (!response.ok) {
-        throw new Error("not found");
-      }
-      return response.json();
-    }
-  });
+export const metadata: Metadata = {
+  title: "Astalla Live Dashboard",
+  description: "Public performance overview powered by Astalla"
+};
 
-  if (isLoading) {
-    return <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">Loading dashboard…</div>;
+async function loadDashboard(host: string): Promise<PublicDashboardResponse | null> {
+  if (!host) {
+    return null;
   }
 
-  if (isError || !data) {
-    return <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">Dashboard not found.</div>;
+  const apiBaseUrl =
+    process.env.NEXT_PUBLIC_API_BASE_URL ?? process.env.API_BASE_URL ?? process.env.BACKEND_URL;
+
+  if (!apiBaseUrl) {
+    return null;
+  }
+
+  const response = await fetch(`${apiBaseUrl}/public/resolve?host=${encodeURIComponent(host)}`, {
+    headers: { "x-internal": "1" },
+    next: { revalidate: 120 }
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return response.json();
+}
+
+export default async function PublicDashboard({ searchParams }: PublicDashboardProps) {
+  const hostParam = searchParams["x-host"];
+  const host = Array.isArray(hostParam) ? hostParam[0] ?? "" : hostParam ?? "";
+
+  const data = await loadDashboard(host);
+
+  if (!host) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center justify-center px-4 text-center text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground sm:px-6 lg:px-8">
+        Provide a host via the <code className="rounded bg-slate-100 px-2 py-1 text-foreground">x-host</code> query parameter to view a live dashboard.
+      </main>
+    );
+  }
+
+  if (!data) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center justify-center px-4 text-center text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground sm:px-6 lg:px-8">
+        Dashboard unavailable. Please confirm the share link or try again later.
+      </main>
+    );
   }
 
   const widgets = Array.isArray(data.widgets) ? data.widgets : [];
 
   return (
-    <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 py-12">
-      <header className="space-y-2 text-center">
-        <h1 className="text-3xl font-semibold text-foreground">{data.title}</h1>
-        <p className="text-sm text-muted-foreground">Read-only experience powered by Astalla.</p>
+    <main className="mx-auto min-h-screen w-full max-w-[1200px] px-4 pb-16 pt-10 sm:px-6 lg:px-8">
+      <header className="flex flex-col gap-4 border-b border-border/60 pb-6 text-center md:flex-row md:items-center md:justify-between md:text-left">
+        <div className="space-y-2">
+          <p className="text-[clamp(.8rem,1.4vw,.95rem)] font-semibold uppercase tracking-[0.25em] text-muted-foreground">
+            Live dashboard
+          </p>
+          <h1 className="text-[clamp(1.5rem,3vw,2.25rem)] font-semibold text-foreground">{data.title ?? "Property performance"}</h1>
+          <p className="text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground">
+            Read-only snapshot generated with Astalla.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center gap-2 self-center rounded-full border border-border/60 bg-white px-4 py-2 text-[clamp(.9rem,1.5vw,1rem)] font-medium text-foreground shadow-sm transition hover:shadow-md"
+          aria-label="Share dashboard"
+        >
+          <Share2 className="h-4 w-4" aria-hidden="true" />
+          Share
+        </button>
       </header>
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+
+      <section
+        aria-label="Dashboard widgets"
+        className="mt-8 grid grid-cols-1 gap-3 md:grid-cols-6 md:gap-4"
+      >
         {widgets.length === 0 ? (
-          <div className="col-span-full rounded-2xl border border-dashed border-border/70 bg-white/80 p-10 text-center text-sm text-muted-foreground">
+          <div className="md:col-span-6 rounded-3xl border border-dashed border-border/70 bg-white/70 p-10 text-center text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground shadow-sm">
             Dashboard widgets will appear here once the owner publishes a layout.
           </div>
         ) : (
-          widgets.map((widget: any) => (
-            <div key={widget.id ?? widget.label} className="card-surface rounded-2xl border bg-white/90 p-5 shadow-card">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">{widget.label ?? widget.id}</div>
-              <div className="mt-2 text-3xl font-semibold text-foreground">{widget.value ?? "—"}</div>
-            </div>
+          widgets.map((widget) => (
+            <article
+              key={widget.id ?? widget.label ?? crypto.randomUUID()}
+              className="flex min-h-[120px] flex-col justify-between rounded-3xl border border-border/60 bg-white/85 p-5 text-left shadow-sm supports-[backdrop-filter]:bg-white/70"
+            >
+              <p className="text-[clamp(.9rem,1.5vw,1rem)] font-medium text-muted-foreground">
+                {widget.label ?? widget.id ?? "Widget"}
+              </p>
+              <p className="text-[clamp(1.5rem,3vw,2.25rem)] font-semibold text-foreground">
+                {widget.value ?? "—"}
+              </p>
+            </article>
           ))
         )}
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/apps/frontend/components/dashboard/alerts-panel.tsx
+++ b/apps/frontend/components/dashboard/alerts-panel.tsx
@@ -47,8 +47,8 @@ export function AlertsPanel({ alerts, isLoading, isError, onRetry }: AlertsPanel
   }, [activeAlertId, alerts]);
 
   return (
-    <div className="flex h-full flex-col rounded-3xl border border-border/80 bg-card shadow-sm">
-      <header className="flex items-center justify-between gap-4 border-b border-border/60 px-6 py-4">
+    <div className="flex h-full flex-col rounded-3xl border border-border/60 bg-white/85 shadow-sm supports-[backdrop-filter]:bg-white/70">
+      <header className="flex items-center justify-between gap-4 border-b border-border/60 px-5 py-4">
         <div className="flex items-center gap-3">
           <div className="relative">
             <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
@@ -61,8 +61,8 @@ export function AlertsPanel({ alerts, isLoading, isError, onRetry }: AlertsPanel
             ) : null}
           </div>
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Signals</p>
-            <h3 className="text-lg font-semibold text-foreground">Alerts & notifications</h3>
+            <p className="text-[clamp(.75rem,1.2vw,.875rem)] font-semibold uppercase tracking-[0.28em] text-muted-foreground">Signals</p>
+            <h3 className="text-[clamp(1.125rem,2vw,1.375rem)] font-semibold text-foreground">Alerts & notifications</h3>
           </div>
         </div>
         <Button type="button" variant="ghost" size="icon" onClick={onRetry} disabled={isLoading} aria-label="Refresh alerts">
@@ -112,35 +112,35 @@ export function AlertsPanel({ alerts, isLoading, isError, onRetry }: AlertsPanel
                           <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
                           {alert.severity}
                         </span>
-                        <span className="text-xs text-muted-foreground">{formatRelativeTime(alert.occurredAt)}</span>
+                        <span className="text-[clamp(.8rem,1.4vw,.9rem)] text-muted-foreground">{formatRelativeTime(alert.occurredAt)}</span>
                       </div>
-                      <p className="text-sm font-semibold text-foreground">{alert.label}</p>
-                      <p className="text-sm text-muted-foreground line-clamp-2">{alert.detail}</p>
+                      <p className="text-[clamp(.95rem,1.5vw,1.05rem)] font-semibold text-foreground">{alert.label}</p>
+                      <p className="text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground line-clamp-2">{alert.detail}</p>
                     </button>
                   );
                 })}
               </div>
-              <div className="border-t border-border/60 px-6 py-4">
+              <div className="border-t border-border/60 px-5 py-4">
                 {alerts.find((alert) => alert.id === activeAlertId) ? (
                   (() => {
                     const activeAlert = alerts.find((alert) => alert.id === activeAlertId)!;
                     return (
                       <div className="space-y-2">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Details</p>
-                        <p className="text-sm font-semibold text-foreground">{activeAlert.label}</p>
-                        <p className="text-sm leading-6 text-muted-foreground">{activeAlert.detail}</p>
+                        <p className="text-[clamp(.75rem,1.2vw,.875rem)] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Details</p>
+                        <p className="text-[clamp(.95rem,1.5vw,1.05rem)] font-semibold text-foreground">{activeAlert.label}</p>
+                        <p className="text-[clamp(.9rem,1.5vw,1rem)] leading-6 text-muted-foreground">{activeAlert.detail}</p>
                       </div>
                     );
                   })()
                 ) : (
-                  <p className="text-sm text-muted-foreground">Select an alert to view the full context.</p>
+                  <p className="text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground">Select an alert to view the full context.</p>
                 )}
               </div>
             </div>
           ) : (
             <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-12 text-center">
-              <p className="text-sm font-medium text-foreground">No alerts right now.</p>
-              <p className="text-sm text-muted-foreground">We&apos;ll notify you as soon as we detect something noteworthy.</p>
+              <p className="text-[clamp(.95rem,1.5vw,1.05rem)] font-medium text-foreground">No alerts right now.</p>
+              <p className="text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground">We&apos;ll notify you as soon as we detect something noteworthy.</p>
             </div>
           )
         ) : null}

--- a/apps/frontend/components/dashboard/dashboard-card.tsx
+++ b/apps/frontend/components/dashboard/dashboard-card.tsx
@@ -26,23 +26,22 @@ export function DashboardCard({
   return (
     <Card
       className={cn(
-        "rounded-3xl border border-border bg-card/95 text-card-foreground shadow-sm transition-all",
-        "supports-[backdrop-filter]:bg-card/90 supports-[backdrop-filter]:backdrop-blur",
+        "text-card-foreground transition-shadow supports-[backdrop-filter]:backdrop-blur",
         "hover:shadow-md focus-within:shadow-md",
         className
       )}
     >
-      <div className={cn("flex flex-col", dense ? "p-6" : "p-7")}>
+      <div className={cn("flex flex-col", dense ? "p-5" : "p-6")}>
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="space-y-1.5">
-            <h2 className="text-base font-semibold tracking-tight text-foreground sm:text-lg">{title}</h2>
+            <h2 className="text-[clamp(1.125rem,2vw,1.375rem)] font-semibold tracking-tight text-foreground">{title}</h2>
             {description ? (
-              <p className="text-sm text-foreground/80">{description}</p>
+              <p className="text-[clamp(.9rem,1.5vw,1rem)] text-foreground/80">{description}</p>
             ) : null}
           </div>
           {action ? <div className="shrink-0 space-y-2 text-sm text-muted-foreground">{action}</div> : null}
         </div>
-        <Separator className="mt-5 bg-border/80" />
+        <Separator className="mt-5 bg-border/70" />
         <div className={cn("pt-5", dense ? "space-y-4" : "space-y-5", contentClassName)}>{children}</div>
       </div>
     </Card>

--- a/apps/frontend/components/dashboard/dashboard-shell.tsx
+++ b/apps/frontend/components/dashboard/dashboard-shell.tsx
@@ -7,7 +7,6 @@ import type { ReactNode } from "react";
 import { Search } from "lucide-react";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import type { MeResponse } from "@shared/api";
 
@@ -37,64 +36,56 @@ export default function DashboardShell({
   ];
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="px-6 pt-10">
-        <div className="mx-auto w-full max-w-7xl">
-          <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-border bg-panel/95 px-6 py-5 shadow-sm supports-[backdrop-filter]:backdrop-blur">
-            <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/80">
-                {user.orgId ? user.orgId : "Astalla internal"}
-              </p>
-              <h1 className="text-2xl font-semibold text-foreground">Operations control center</h1>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <ThemeToggle />
-              <div className="hidden items-center gap-2 rounded-full border border-border/60 bg-card px-4 py-2 text-xs text-muted-foreground sm:flex">
-                <Search className="h-4 w-4" aria-hidden="true" />
-                <span>Search workspaces</span>
-              </div>
-              <div className="flex items-center gap-3 rounded-full border border-border/70 bg-card px-3 py-2 shadow-sm">
-                <div className="text-right">
-                  <p className="text-sm font-semibold text-foreground">{displayName}</p>
-                  <p className="text-xs text-muted-foreground">{displayEmail}</p>
-                </div>
-                <Avatar className="h-9 w-9 bg-primary/10">
-                  <AvatarFallback className="bg-transparent text-sm font-semibold text-primary">
-                    {initials}
-                  </AvatarFallback>
-                </Avatar>
-              </div>
-              {role ? (
-                <span className="inline-flex items-center rounded-full border border-border/70 bg-card px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {role}
-                </span>
-              ) : null}
-            </div>
+    <div className="flex flex-col gap-6 pb-20">
+      <header className="rounded-3xl border border-border/60 bg-white/80 p-6 shadow-sm supports-[backdrop-filter]:backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/80">
+              {user.orgId ? user.orgId : "Astalla internal"}
+            </p>
+            <h1 className="text-[clamp(1.5rem,3vw,2rem)] font-semibold text-foreground">Operations control center</h1>
           </div>
-          <nav className="mt-6 flex flex-wrap items-center gap-3 text-sm font-medium text-muted-foreground">
-            {links.map((link) => {
-              const isActive = pathname === link.href;
-              return (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className={cn(
-                    "rounded-full border border-transparent px-4 py-1.5 transition hover:text-foreground",
-                    isActive && "border-border bg-card text-foreground"
-                  )}
-                >
-                  {link.label}
-                </Link>
-              );
-            })}
-          </nav>
+          <div className="flex flex-wrap items-center gap-3">
+            <ThemeToggle />
+            <div className="hidden items-center gap-2 rounded-full border border-border/60 bg-card px-4 py-2 text-xs text-muted-foreground sm:flex">
+              <Search className="h-4 w-4" aria-hidden="true" />
+              <span>Search workspaces</span>
+            </div>
+            <div className="flex items-center gap-3 rounded-full border border-border/70 bg-card px-3 py-2 shadow-sm">
+              <div className="text-right">
+                <p className="text-sm font-semibold text-foreground">{displayName}</p>
+                <p className="text-xs text-muted-foreground">{displayEmail}</p>
+              </div>
+              <Avatar className="h-9 w-9 bg-primary/10">
+                <AvatarFallback className="bg-transparent text-sm font-semibold text-primary">{initials}</AvatarFallback>
+              </Avatar>
+            </div>
+            {role ? (
+              <span className="inline-flex items-center rounded-full border border-border/70 bg-card px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {role}
+              </span>
+            ) : null}
+          </div>
         </div>
+        <nav className="mt-5 flex flex-wrap items-center gap-3 text-sm font-medium text-muted-foreground">
+          {links.map((link) => {
+            const isActive = pathname === link.href;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cn(
+                  "rounded-full border border-transparent px-4 py-1.5 transition hover:text-foreground",
+                  isActive && "border-border bg-card text-foreground"
+                )}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
       </header>
-      <ScrollArea className="flex-1">
-        <main className="mx-auto w-full max-w-7xl px-6 pb-16 pt-10">
-          <div className="flex flex-col gap-8 pb-12 sm:gap-9 lg:gap-10">{children}</div>
-        </main>
-      </ScrollArea>
+      <div className="flex flex-col gap-8 pb-4 sm:gap-9 lg:gap-10">{children}</div>
     </div>
   );
 }

--- a/apps/frontend/components/dashboard/dashboard-view.tsx
+++ b/apps/frontend/components/dashboard/dashboard-view.tsx
@@ -154,16 +154,18 @@ export function DashboardView({ role }: DashboardViewProps) {
 
   return (
     <DashboardShell user={meQuery.data ?? fallbackUser} role={role}>
-      <section>
-        <PropertySelector
-          properties={propertyOptions}
-          selectedPropertyId={selectedProperty}
-          onPropertyChange={setSelectedProperty}
-          timeRange={timeRange}
-          onTimeRangeChange={setTimeRange}
-          disabled={propertiesQuery.isLoading}
-          onCreateProperty={handleCreateProperty}
-        />
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-6 md:gap-4">
+        <div className="md:col-span-6">
+          <PropertySelector
+            properties={propertyOptions}
+            selectedPropertyId={selectedProperty}
+            onPropertyChange={setSelectedProperty}
+            timeRange={timeRange}
+            onTimeRangeChange={setTimeRange}
+            disabled={propertiesQuery.isLoading}
+            onCreateProperty={handleCreateProperty}
+          />
+        </div>
       </section>
 
       {propertiesQuery.isError ? (
@@ -206,7 +208,7 @@ export function DashboardView({ role }: DashboardViewProps) {
       ) : null}
 
       {!shouldShowEmptyState ? (
-        <section className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+        <section className="grid grid-cols-1 gap-3 md:grid-cols-6 md:gap-4">
           <MetricCard
             title="Average occupancy"
             value={occupancyQuery.data ? formatPercent(occupancyQuery.data.occupancyRate) : "--"}
@@ -223,6 +225,7 @@ export function DashboardView({ role }: DashboardViewProps) {
             isLoading={occupancyQuery.isPending && !occupancyQuery.data}
             isError={occupancyQuery.isError}
             onRetry={() => occupancyQuery.refetch()}
+            className="min-h-[120px] md:col-span-2"
           />
           <MetricCard
             title="Pipeline conversions"
@@ -248,6 +251,7 @@ export function DashboardView({ role }: DashboardViewProps) {
             isLoading={pipelineQuery.isPending && !pipelineQuery.data}
             isError={pipelineQuery.isError}
             onRetry={() => pipelineQuery.refetch()}
+            className="min-h-[120px] md:col-span-2"
           />
           <MetricCard
             title="Cost per lead"
@@ -261,12 +265,13 @@ export function DashboardView({ role }: DashboardViewProps) {
             isLoading={costQuery.isPending && !costQuery.data}
             isError={costQuery.isError}
             onRetry={() => costQuery.refetch()}
+            className="min-h-[120px] md:col-span-2"
           />
         </section>
       ) : null}
 
       {!shouldShowEmptyState ? (
-        <section className="grid gap-5 lg:grid-cols-[1.6fr,1fr]">
+        <section className="grid grid-cols-1 gap-3 md:grid-cols-6 md:gap-4">
           <DashboardCard
             title={selectedPropertyName ? `${selectedPropertyName} reviews` : "Resident feedback"}
             description="Latest resident sentiment and response coverage"
@@ -276,6 +281,7 @@ export function DashboardView({ role }: DashboardViewProps) {
                 Refresh
               </Button>
             }
+            className="md:col-span-4 min-h-[120px]"
           >
             {reviewsQuery.isLoading ? (
               <div className="flex items-center justify-center py-16">
@@ -336,16 +342,18 @@ export function DashboardView({ role }: DashboardViewProps) {
             ) : null}
           </DashboardCard>
 
-          <AlertsPanel
-            alerts={alertsQuery.data?.alerts}
-            isLoading={alertsQuery.isLoading}
-            isError={alertsQuery.isError}
-            onRetry={() => alertsQuery.refetch()}
-          />
+          <div className="md:col-span-2 min-h-[120px]">
+            <AlertsPanel
+              alerts={alertsQuery.data?.alerts}
+              isLoading={alertsQuery.isLoading}
+              isError={alertsQuery.isError}
+              onRetry={() => alertsQuery.refetch()}
+            />
+          </div>
         </section>
       ) : null}
 
-      <section className="pb-6">
+      <section className="grid grid-cols-1 gap-3 pb-6 md:grid-cols-6 md:gap-4">
         <DashboardCard
           title="Portfolio performance"
           description="Track contracts, SLAs and incident load across properties"
@@ -365,6 +373,7 @@ export function DashboardView({ role }: DashboardViewProps) {
             )
           }
           contentClassName="-mt-2"
+          className="md:col-span-6"
         >
           <OperationsTable canEdit={role === "admin"} />
         </DashboardCard>

--- a/apps/frontend/components/dashboard/metric-card.tsx
+++ b/apps/frontend/components/dashboard/metric-card.tsx
@@ -44,17 +44,17 @@ export function MetricCard({
   const trendColor = trend === "down" ? "text-red-500" : trend === "up" ? "text-emerald-500" : "text-muted-foreground";
 
   return (
-    <Card className={cn("h-full rounded-3xl border border-border bg-card/95 shadow-sm", className)} data-testid={testId}>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0 p-7 pb-4">
+    <Card className={cn("h-full transition-shadow hover:shadow-md focus-within:shadow-md", className)} data-testid={testId}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 p-6 pb-4">
         <div className="flex flex-col">
-          <CardTitle className="text-base font-semibold text-foreground/95">{title}</CardTitle>
-          <span className="mt-3 text-3xl font-semibold tracking-tight text-foreground">
+          <CardTitle className="text-[clamp(1.125rem,2vw,1.375rem)] font-semibold text-foreground/95">{title}</CardTitle>
+          <span className="mt-3 text-[clamp(1.75rem,3vw,2.25rem)] font-semibold tracking-tight text-foreground">
             {isLoading || isError ? "--" : value}
           </span>
         </div>
         {!isLoading && !isError && TrendIcon ? <TrendIcon className={cn("h-5 w-5", trendColor)} /> : null}
       </CardHeader>
-      <CardContent className="space-y-4 p-7 pt-0">
+      <CardContent className="space-y-4 p-6 pt-0">
         {isLoading ? (
           <div className="flex h-24 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-5 w-5 animate-spin" />
@@ -73,15 +73,15 @@ export function MetricCard({
         ) : null}
         {!isLoading && !isError ? (
           <div className="space-y-3">
-            {helperText ? <p className="text-sm text-foreground/75">{helperText}</p> : null}
+            {helperText ? <p className="text-[clamp(.9rem,1.5vw,1rem)] text-foreground/75">{helperText}</p> : null}
             {typeof change === "number" ? (
-              <p className="text-sm text-foreground/70">
+              <p className="text-[clamp(.9rem,1.5vw,1rem)] text-foreground/70">
                 {change > 0 ? "+" : ""}
                 {(change * 100).toFixed(1)}% vs. last period
               </p>
             ) : null}
             {trendPoints && trendPoints.length > 1 ? (
-              <div className="rounded-2xl border border-border bg-card-contrast/60 p-3 shadow-sm">
+              <div className="rounded-2xl border border-border/60 bg-card-contrast/60 p-3 shadow-sm">
                 <Sparkline points={trendPoints} formatter={trendFormatter} />
               </div>
             ) : null}

--- a/apps/frontend/components/dashboard/property-selector.tsx
+++ b/apps/frontend/components/dashboard/property-selector.tsx
@@ -92,26 +92,26 @@ export function PropertySelector({
   };
 
   return (
-    <div className="flex flex-col gap-5 rounded-3xl border border-border bg-panel/95 p-7 shadow-sm supports-[backdrop-filter]:backdrop-blur">
+    <div className="flex flex-col gap-5 rounded-3xl border border-border/60 bg-white/85 p-6 shadow-sm supports-[backdrop-filter]:bg-white/70">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <MapPin className="h-5 w-5" aria-hidden="true" />
           </span>
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Portfolio</p>
-            <h2 className="text-xl font-semibold text-foreground">Property insights</h2>
+            <p className="text-[clamp(.75rem,1.2vw,.875rem)] font-semibold uppercase tracking-[0.28em] text-muted-foreground">Portfolio</p>
+            <h2 className="text-[clamp(1.125rem,2vw,1.375rem)] font-semibold text-foreground">Property insights</h2>
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor="property-select">
+          <label className="text-[clamp(.8rem,1.4vw,.9rem)] font-medium uppercase tracking-wide text-muted-foreground" htmlFor="property-select">
             Property
           </label>
           <div className="relative">
             <select
               id="property-select"
               className={cn(
-                "appearance-none rounded-full border border-border bg-card px-4 py-2 pr-10 text-sm font-medium text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                "appearance-none rounded-full border border-border/60 bg-card px-4 py-2 pr-10 text-sm font-medium text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 disabled && "cursor-not-allowed opacity-60"
               )}
               value={selectedPropertyId ?? ""}
@@ -131,8 +131,8 @@ export function PropertySelector({
         </div>
       </div>
       <div className="flex flex-wrap items-center gap-3">
-        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Time range</span>
-        <div className="flex rounded-full border border-border bg-card p-1 shadow-sm">
+        <span className="text-[clamp(.75rem,1.2vw,.875rem)] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Time range</span>
+        <div className="flex rounded-full border border-border/60 bg-card p-1 shadow-sm">
           {TIME_RANGES.map((option) => (
             <Button
               key={option.value}
@@ -152,7 +152,7 @@ export function PropertySelector({
         </div>
       </div>
       {properties.length === 0 ? (
-        <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-border/80 bg-card/40 p-5 text-sm text-muted-foreground">
+        <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-border/80 bg-card/40 p-5 text-[clamp(.9rem,1.5vw,1rem)] text-muted-foreground">
           <p className="font-medium text-foreground">No properties yet. Add one to get started.</p>
           <Button type="button" size="sm" className="w-fit gap-2" onClick={() => setIsDialogOpen(true)}>
             <Plus className="h-4 w-4" /> Add property

--- a/apps/frontend/components/shell/app-chrome.tsx
+++ b/apps/frontend/components/shell/app-chrome.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+
+import { BottomNav } from "@/components/shell/bottom-nav";
+
+import { Sidebar } from "./sidebar";
+import { Topbar } from "./topbar";
+
+interface AppChromeProps {
+  children: ReactNode;
+}
+
+export function AppChrome({ children }: AppChromeProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    if (!sidebarOpen) {
+      return;
+    }
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [sidebarOpen]);
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex min-h-screen flex-1 flex-col">
+        <Topbar onToggleSidebar={() => setSidebarOpen((open) => !open)} isSidebarOpen={sidebarOpen} />
+        <main className="flex-1 min-h-0 pb-20">
+          <div className="mx-auto w-full max-w-[1200px] px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+            {children}
+          </div>
+        </main>
+      </div>
+
+      {sidebarOpen ? (
+        <div className="md:hidden" aria-hidden={!sidebarOpen}>
+          <div
+            className="fixed inset-0 z-40 bg-slate-900/40 backdrop-blur-sm"
+            role="presentation"
+            onClick={() => setSidebarOpen(false)}
+          />
+          <div
+            className="fixed inset-y-0 left-0 z-50 w-64 overflow-y-auto rounded-r-3xl border-r border-border/60 bg-white shadow-2xl transition"
+            role="dialog"
+            aria-label="Navigation menu"
+            aria-modal="true"
+          >
+            <Sidebar variant="mobile" onNavigate={() => setSidebarOpen(false)} onClose={() => setSidebarOpen(false)} />
+          </div>
+        </div>
+      ) : null}
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/frontend/components/shell/bottom-nav.tsx
+++ b/apps/frontend/components/shell/bottom-nav.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { shellNavItems } from "@/components/shell/nav-items";
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      className="fixed bottom-0 inset-x-0 z-40 border-t border-border/60 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 md:hidden"
+      aria-label="Primary navigation"
+    >
+      <ul className="grid grid-cols-5 text-xs">
+        {shellNavItems.map((item) => {
+          const active = pathname?.startsWith(item.href);
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className="flex flex-col items-center justify-center gap-1 py-2.5 text-[clamp(.8rem,1.6vw,.95rem)]"
+                aria-current={active ? "page" : undefined}
+              >
+                <item.icon className={`h-4 w-4 ${active ? "text-brand-primary" : "text-muted-foreground"}`} aria-hidden="true" />
+                <span className={active ? "font-medium text-brand-primary" : "text-muted-foreground"}>{item.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/frontend/components/shell/nav-items.ts
+++ b/apps/frontend/components/shell/nav-items.ts
@@ -1,0 +1,19 @@
+import type { Route } from "next";
+import type { LucideIcon } from "lucide-react";
+import { BarChart3, FileChartLine, LayoutDashboard, PlugZap, Table2 } from "lucide-react";
+
+type ShellNavItem = {
+  href: Route;
+  label: string;
+  icon: LucideIcon;
+};
+
+export const shellNavItems: ShellNavItem[] = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/tables", label: "Tables", icon: Table2 },
+  { href: "/admin/sources", label: "Sources", icon: PlugZap },
+  { href: "/reports", label: "Reports", icon: FileChartLine }
+];
+
+export type { ShellNavItem };

--- a/apps/frontend/components/shell/sidebar.tsx
+++ b/apps/frontend/components/shell/sidebar.tsx
@@ -1,48 +1,57 @@
 "use client";
 
 import Link from "next/link";
-import type { Route } from "next";
 import { usePathname } from "next/navigation";
-import type { LucideIcon } from "lucide-react";
-import { BarChart3, FileChartLine, LayoutDashboard, PlugZap, Table2 } from "lucide-react";
+import { X } from "lucide-react";
 
-type SidebarItem = {
-  href: Route;
-  label: string;
-  icon: LucideIcon;
-};
+import { shellNavItems } from "@/components/shell/nav-items";
 
-const items: SidebarItem[] = [
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/analytics", label: "Analytics", icon: BarChart3 },
-  { href: "/tables", label: "Tables", icon: Table2 },
-  { href: "/admin/sources", label: "Sources / Connections", icon: PlugZap },
-  { href: "/reports", label: "Reports", icon: FileChartLine }
-];
+interface SidebarProps {
+  variant?: "desktop" | "mobile";
+  onNavigate?: () => void;
+  onClose?: () => void;
+}
 
-export function Sidebar() {
+export function Sidebar({ variant = "desktop", onNavigate, onClose }: SidebarProps) {
   const path = usePathname();
 
+  const containerClasses =
+    variant === "desktop"
+      ? "sticky top-0 hidden h-screen w-64 shrink-0 border-r border-border/60 bg-white/80 backdrop-blur-xl md:block"
+      : "flex h-full w-64 flex-col bg-white shadow-xl";
+
   return (
-    <aside className="sticky top-0 hidden h-screen w-64 shrink-0 border-r bg-white/75 backdrop-blur-xl lg:block">
-      <div className="flex h-16 items-center border-b px-6 text-lg font-semibold tracking-tight">
+    <aside className={containerClasses}>
+      <div className="flex h-16 items-center justify-between gap-4 border-b border-border/60 px-6 text-lg font-semibold tracking-tight">
         <span className="text-brand-primary">Astalla</span>
+        {variant === "mobile" ? (
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border/60 text-sm text-foreground transition hover:bg-slate-100"
+          >
+            <span className="sr-only">Close navigation</span>
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
-      <nav className="space-y-1 px-3 py-4">
-        {items.map(({ href, label, icon: Icon }) => {
+      <nav className="flex-1 space-y-1 px-3 py-4">
+        {shellNavItems.map(({ href, label, icon: Icon }) => {
           const active = path?.startsWith(href);
           return (
             <Link
               key={href}
               href={href}
-              className={`group flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition ${
+              className={`group flex items-center gap-3 rounded-xl px-3 py-2 text-sm transition ${
                 active
                   ? "bg-brand-primary/10 font-medium text-brand-primary"
                   : "text-muted-foreground hover:bg-white hover:text-foreground"
               }`}
+              aria-current={active ? "page" : undefined}
+              onClick={onNavigate}
             >
-              <Icon className="h-4 w-4" />
-              <span>{label}</span>
+              <Icon className="h-4 w-4" aria-hidden="true" />
+              <span className="text-[clamp(.9rem,1.5vw,1rem)]">{label}</span>
             </Link>
           );
         })}

--- a/apps/frontend/components/shell/topbar.tsx
+++ b/apps/frontend/components/shell/topbar.tsx
@@ -1,23 +1,41 @@
 "use client";
 
-import { Search, UserCircle2 } from "lucide-react";
+import { Menu, Search, UserCircle2, X } from "lucide-react";
 
-export function Topbar() {
+interface TopbarProps {
+  onToggleSidebar: () => void;
+  isSidebarOpen: boolean;
+}
+
+export function Topbar({ onToggleSidebar, isSidebarOpen }: TopbarProps) {
   return (
-    <header className="sticky top-0 z-30 border-b border-border/80 bg-white/70 backdrop-blur-xl">
-      <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-6">
-        <div className="ml-auto flex items-center gap-4">
+    <header className="sticky top-0 z-30 border-b border-border/60 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70">
+      <div className="mx-auto flex h-16 w-full max-w-[1200px] items-center gap-3 px-4 sm:px-6 lg:px-8">
+        <button
+          type="button"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-white shadow-sm transition hover:bg-slate-50 md:hidden"
+          onClick={onToggleSidebar}
+          aria-label={isSidebarOpen ? "Close navigation" : "Open navigation"}
+        >
+          {isSidebarOpen ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
+        </button>
+
+        <div className="ml-auto flex items-center gap-3">
           <div className="relative hidden md:block">
             <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
             <input
-              className="w-64 rounded-lg border border-border/80 bg-white/80 py-2 pl-9 pr-3 text-sm text-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/40"
+              className="w-64 rounded-full border border-border/60 bg-white/80 py-2 pl-9 pr-3 text-sm text-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/40"
               placeholder="Search…"
               type="search"
+              aria-label="Search"
             />
           </div>
-          <button className="inline-flex items-center gap-2 rounded-lg border border-border/80 bg-white/80 px-3 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-cardHover">
-            <UserCircle2 className="h-4 w-4" />
-            Account
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-white px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:shadow-md"
+          >
+            <UserCircle2 className="h-4 w-4" aria-hidden="true" />
+            <span className="text-[clamp(.9rem,1.5vw,1rem)]">Account</span>
           </button>
         </div>
       </div>

--- a/apps/frontend/components/ui/card.tsx
+++ b/apps/frontend/components/ui/card.tsx
@@ -6,7 +6,10 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-xl border bg-card text-card-foreground shadow-sm", className)}
+      className={cn(
+        "rounded-3xl border border-border/60 bg-white/85 text-card-foreground shadow-sm supports-[backdrop-filter]:bg-white/70",
+        className
+      )}
       {...props}
     />
   )
@@ -22,7 +25,14 @@ CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+    <h3
+      ref={ref}
+      className={cn(
+        "text-[clamp(1.125rem,2vw,1.375rem)] font-semibold leading-tight tracking-tight",
+        className
+      )}
+      {...props}
+    />
   )
 );
 CardTitle.displayName = "CardTitle";


### PR DESCRIPTION
## Summary
- add a responsive application shell with a collapsible sidebar and mobile bottom navigation
- reflow dashboard metrics and cards into a mobile-first grid with refreshed typography and density
- rebuild the public dashboard page for server rendering and responsive display

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68e44a9eaaec8322b059330a9202bbb5