### PR TITLE
feat(shared): expose table schemas

### DIFF
--- a/apps/frontend/components/tables/TableGrid.tsx
+++ b/apps/frontend/components/tables/TableGrid.tsx
@@ -89,13 +89,15 @@ interface TableGridProps {
   tableId: string;
 }
 
+const COLUMN_TYPE_ENUM = ColumnType.enum;
+
 const COLUMN_TYPE_OPTIONS: Array<{ label: string; value: ColumnKind }> = [
-  { label: "Text", value: ColumnType.TEXT },
-  { label: "Number", value: ColumnType.NUMBER },
-  { label: "Date", value: ColumnType.DATE },
-  { label: "Boolean", value: ColumnType.BOOLEAN },
-  { label: "Select", value: ColumnType.SELECT },
-  { label: "Reference", value: ColumnType.REFERENCE }
+  { label: "Text", value: COLUMN_TYPE_ENUM.TEXT },
+  { label: "Number", value: COLUMN_TYPE_ENUM.NUMBER },
+  { label: "Date", value: COLUMN_TYPE_ENUM.DATE },
+  { label: "Boolean", value: COLUMN_TYPE_ENUM.BOOLEAN },
+  { label: "Select", value: COLUMN_TYPE_ENUM.SELECT },
+  { label: "Reference", value: COLUMN_TYPE_ENUM.REFERENCE }
 ];
 
 function parseViewConfig(value: unknown): ViewConfig {
@@ -350,7 +352,7 @@ export function TableGrid({ tableId }: TableGridProps) {
   const [activeViewId, setActiveViewId] = useState<string | null>(null);
   const [isAddColumnOpen, setIsAddColumnOpen] = useState(false);
   const [newColumnName, setNewColumnName] = useState("");
-  const [newColumnType, setNewColumnType] = useState<ColumnKind>(ColumnType.TEXT);
+  const [newColumnType, setNewColumnType] = useState<ColumnKind>(COLUMN_TYPE_ENUM.TEXT);
   const [isImportOpen, setIsImportOpen] = useState(false);
   const [importSummary, setImportSummary] = useState<{ createdColumns: number; createdRows: number } | null>(null);
   const [editingColumnId, setEditingColumnId] = useState<string | null>(null);
@@ -663,7 +665,7 @@ export function TableGrid({ tableId }: TableGridProps) {
     const name = newColumnName.trim() || "New column";
     await createColumnMutation.mutateAsync({ name, type: newColumnType });
     setNewColumnName("");
-    setNewColumnType(ColumnType.TEXT);
+    setNewColumnType(COLUMN_TYPE_ENUM.TEXT);
     setIsAddColumnOpen(false);
   };
 

--- a/packages/shared/dist/schemas.d.ts
+++ b/packages/shared/dist/schemas.d.ts
@@ -1,17 +1,91 @@
 import { z } from "zod";
+export declare const ColumnType: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
+export declare const ScriptStatusEnum: z.ZodEnum<["DRAFT", "PUBLISHED"]>;
+export declare const ProviderActionParam: z.ZodObject<{
+    name: z.ZodString;
+    schema: z.ZodOptional<z.ZodAny>;
+    required: z.ZodOptional<z.ZodBoolean>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    schema?: any;
+    required?: boolean | undefined;
+}, {
+    name: string;
+    schema?: any;
+    required?: boolean | undefined;
+}>;
+export declare const ProviderManifest: z.ZodObject<{
+    name: z.ZodString;
+    actions: z.ZodArray<z.ZodObject<{
+        key: z.ZodString;
+        label: z.ZodString;
+        params: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            name: z.ZodString;
+            schema: z.ZodOptional<z.ZodAny>;
+            required: z.ZodOptional<z.ZodBoolean>;
+        }, "strip", z.ZodTypeAny, {
+            name: string;
+            schema?: any;
+            required?: boolean | undefined;
+        }, {
+            name: string;
+            schema?: any;
+            required?: boolean | undefined;
+        }>, "many">>;
+    }, "strip", z.ZodTypeAny, {
+        key: string;
+        label: string;
+        params?: {
+            name: string;
+            schema?: any;
+            required?: boolean | undefined;
+        }[] | undefined;
+    }, {
+        key: string;
+        label: string;
+        params?: {
+            name: string;
+            schema?: any;
+            required?: boolean | undefined;
+        }[] | undefined;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    actions: {
+        key: string;
+        label: string;
+        params?: {
+            name: string;
+            schema?: any;
+            required?: boolean | undefined;
+        }[] | undefined;
+    }[];
+}, {
+    name: string;
+    actions: {
+        key: string;
+        label: string;
+        params?: {
+            name: string;
+            schema?: any;
+            required?: boolean | undefined;
+        }[] | undefined;
+    }[];
+}>;
+export type ProviderManifest = z.infer<typeof ProviderManifest>;
 export declare const orgSchema: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
     createdAt: z.ZodString;
     updatedAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
 }, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
 }>;
@@ -28,8 +102,8 @@ export declare const propertySchema: z.ZodObject<{
     propertyCode: z.ZodOptional<z.ZodString>;
     region: z.ZodOptional<z.ZodString>;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
     address: string;
@@ -40,8 +114,8 @@ export declare const propertySchema: z.ZodObject<{
     propertyCode?: string | undefined;
     region?: string | undefined;
 }, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
     address: string;
@@ -185,13 +259,13 @@ export declare const leadEventSchema: z.ZodObject<{
     type: z.ZodEnum<["created", "contacted", "toured", "applied", "approved", "denied", "leased"]>;
     occurredAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     type: "created" | "contacted" | "toured" | "applied" | "approved" | "denied" | "leased";
+    id: string;
     leadId: string;
     occurredAt: string;
 }, {
-    id: string;
     type: "created" | "contacted" | "toured" | "applied" | "approved" | "denied" | "leased";
+    id: string;
     leadId: string;
     occurredAt: string;
 }>;
@@ -201,13 +275,13 @@ export declare const applicationSchema: z.ZodObject<{
     status: z.ZodEnum<["pending", "approved", "denied", "cancelled"]>;
     submittedAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     status: "approved" | "denied" | "pending" | "cancelled";
+    id: string;
     leadId: string;
     submittedAt: string;
 }, {
-    id: string;
     status: "approved" | "denied" | "pending" | "cancelled";
+    id: string;
     leadId: string;
     submittedAt: string;
 }>;
@@ -219,15 +293,15 @@ export declare const leaseSchema: z.ZodObject<{
     endDate: z.ZodString;
     status: z.ZodEnum<["draft", "active", "terminated", "expired"]>;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     status: "draft" | "active" | "terminated" | "expired";
+    id: string;
     propertyId: string;
     leadId: string;
     startDate: string;
     endDate: string;
 }, {
-    id: string;
     status: "draft" | "active" | "terminated" | "expired";
+    id: string;
     propertyId: string;
     leadId: string;
     startDate: string;
@@ -602,15 +676,15 @@ export declare const alertSchema: z.ZodObject<{
     severity: z.ZodEnum<["high", "medium", "low"]>;
     occurredAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
+    label: string;
     id: string;
     occurredAt: string;
-    label: string;
     detail: string;
     severity: "high" | "medium" | "low";
 }, {
+    label: string;
     id: string;
     occurredAt: string;
-    label: string;
     detail: string;
     severity: "high" | "medium" | "low";
 }>;
@@ -622,31 +696,31 @@ export declare const alertsResponseSchema: z.ZodObject<{
         severity: z.ZodEnum<["high", "medium", "low"]>;
         occurredAt: z.ZodString;
     }, "strip", z.ZodTypeAny, {
+        label: string;
         id: string;
         occurredAt: string;
-        label: string;
         detail: string;
         severity: "high" | "medium" | "low";
     }, {
+        label: string;
         id: string;
         occurredAt: string;
-        label: string;
         detail: string;
         severity: "high" | "medium" | "low";
     }>, "many">;
 }, "strip", z.ZodTypeAny, {
     alerts: {
+        label: string;
         id: string;
         occurredAt: string;
-        label: string;
         detail: string;
         severity: "high" | "medium" | "low";
     }[];
 }, {
     alerts: {
+        label: string;
         id: string;
         occurredAt: string;
-        label: string;
         detail: string;
         severity: "high" | "medium" | "low";
     }[];
@@ -665,10 +739,10 @@ export declare const sourceAccountSchema: z.ZodObject<{
     createdAt: z.ZodString;
     updatedAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
+    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
     id: string;
     createdAt: string;
     updatedAt: string;
-    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
     enabled: boolean;
     name?: string | null | undefined;
     status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -676,10 +750,10 @@ export declare const sourceAccountSchema: z.ZodObject<{
     lastSuccessAt?: string | null | undefined;
     lastErrorAt?: string | null | undefined;
 }, {
+    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
     id: string;
     createdAt: string;
     updatedAt: string;
-    type: "ENTRATA" | "GA4" | "ADS" | "GBP";
     enabled: boolean;
     name?: string | null | undefined;
     status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -700,10 +774,10 @@ export declare const listSourcesResponseSchema: z.ZodObject<{
         createdAt: z.ZodString;
         updatedAt: z.ZodString;
     }, "strip", z.ZodTypeAny, {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -711,10 +785,10 @@ export declare const listSourcesResponseSchema: z.ZodObject<{
         lastSuccessAt?: string | null | undefined;
         lastErrorAt?: string | null | undefined;
     }, {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -724,10 +798,10 @@ export declare const listSourcesResponseSchema: z.ZodObject<{
     }>, "many">;
 }, "strip", z.ZodTypeAny, {
     sources: {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -737,10 +811,10 @@ export declare const listSourcesResponseSchema: z.ZodObject<{
     }[];
 }, {
     sources: {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -797,10 +871,10 @@ export declare const sourceMutationResponseSchema: z.ZodObject<{
         createdAt: z.ZodString;
         updatedAt: z.ZodString;
     }, "strip", z.ZodTypeAny, {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -808,10 +882,10 @@ export declare const sourceMutationResponseSchema: z.ZodObject<{
         lastSuccessAt?: string | null | undefined;
         lastErrorAt?: string | null | undefined;
     }, {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -822,10 +896,10 @@ export declare const sourceMutationResponseSchema: z.ZodObject<{
     validationMessage: z.ZodOptional<z.ZodString>;
 }, "strip", z.ZodTypeAny, {
     source: {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -836,10 +910,10 @@ export declare const sourceMutationResponseSchema: z.ZodObject<{
     validationMessage?: string | undefined;
 }, {
     source: {
+        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         id: string;
         createdAt: string;
         updatedAt: string;
-        type: "ENTRATA" | "GA4" | "ADS" | "GBP";
         enabled: boolean;
         name?: string | null | undefined;
         status?: "CONNECTED" | "ERROR" | "UNVERIFIED" | null | undefined;
@@ -862,16 +936,16 @@ export declare const propertiesResponseSchema: z.ZodObject<{
         updatedAt: z.ZodString;
         propertyCode: z.ZodOptional<z.ZodString>;
         region: z.ZodOptional<z.ZodString>;
-    }, "id" | "name" | "city" | "state" | "propertyCode" | "region">, "strip", z.ZodTypeAny, {
-        id: string;
+    }, "name" | "id" | "city" | "state" | "propertyCode" | "region">, "strip", z.ZodTypeAny, {
         name: string;
+        id: string;
         city: string;
         state: string;
         propertyCode?: string | undefined;
         region?: string | undefined;
     }, {
-        id: string;
         name: string;
+        id: string;
         city: string;
         state: string;
         propertyCode?: string | undefined;
@@ -879,8 +953,8 @@ export declare const propertiesResponseSchema: z.ZodObject<{
     }>, "many">;
 }, "strip", z.ZodTypeAny, {
     properties: {
-        id: string;
         name: string;
+        id: string;
         city: string;
         state: string;
         propertyCode?: string | undefined;
@@ -888,8 +962,8 @@ export declare const propertiesResponseSchema: z.ZodObject<{
     }[];
 }, {
     properties: {
-        id: string;
         name: string;
+        id: string;
         city: string;
         state: string;
         propertyCode?: string | undefined;
@@ -1050,15 +1124,7 @@ export declare const updatePublicDashboardRequestSchema: z.ZodEffects<z.ZodObjec
     config?: unknown;
     isActive?: boolean | undefined;
 }>;
-export declare enum ColumnType {
-    TEXT = "TEXT",
-    NUMBER = "NUMBER",
-    DATE = "DATE",
-    BOOLEAN = "BOOLEAN",
-    SELECT = "SELECT",
-    REFERENCE = "REFERENCE"
-}
-export declare const columnTypeSchema: z.ZodNativeEnum<typeof ColumnType>;
+export declare const columnTypeSchema: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
 export declare const tableCellDtoSchema: z.ZodObject<{
     id: z.ZodString;
     rowId: z.ZodString;
@@ -1086,27 +1152,27 @@ export declare const tableColumnDtoSchema: z.ZodObject<{
     tableId: z.ZodString;
     name: z.ZodString;
     slug: z.ZodString;
-    type: z.ZodNativeEnum<typeof ColumnType>;
+    type: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
     position: z.ZodNumber;
     config: z.ZodOptional<z.ZodUnknown>;
     createdAt: z.ZodString;
     updatedAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     name: string;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+    id: string;
     createdAt: string;
     updatedAt: string;
-    type: ColumnType;
     tableId: string;
     slug: string;
     position: number;
     config?: unknown;
 }, {
-    id: string;
     name: string;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+    id: string;
     createdAt: string;
     updatedAt: string;
-    type: ColumnType;
     tableId: string;
     slug: string;
     position: number;
@@ -1184,16 +1250,16 @@ export declare const tableViewDtoSchema: z.ZodObject<{
     createdAt: z.ZodString;
     updatedAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
     tableId: string;
     config?: unknown;
     createdBy?: string | null | undefined;
 }, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
     tableId: string;
@@ -1210,27 +1276,27 @@ export declare const dataTableDtoSchema: z.ZodObject<{
         tableId: z.ZodString;
         name: z.ZodString;
         slug: z.ZodString;
-        type: z.ZodNativeEnum<typeof ColumnType>;
+        type: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
         position: z.ZodNumber;
         config: z.ZodOptional<z.ZodUnknown>;
         createdAt: z.ZodString;
         updatedAt: z.ZodString;
     }, "strip", z.ZodTypeAny, {
-        id: string;
         name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
         createdAt: string;
         updatedAt: string;
-        type: ColumnType;
         tableId: string;
         slug: string;
         position: number;
         config?: unknown;
     }, {
-        id: string;
         name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
         createdAt: string;
         updatedAt: string;
-        type: ColumnType;
         tableId: string;
         slug: string;
         position: number;
@@ -1308,16 +1374,16 @@ export declare const dataTableDtoSchema: z.ZodObject<{
         createdAt: z.ZodString;
         updatedAt: z.ZodString;
     }, "strip", z.ZodTypeAny, {
-        id: string;
         name: string;
+        id: string;
         createdAt: string;
         updatedAt: string;
         tableId: string;
         config?: unknown;
         createdBy?: string | null | undefined;
     }, {
-        id: string;
         name: string;
+        id: string;
         createdAt: string;
         updatedAt: string;
         tableId: string;
@@ -1328,19 +1394,19 @@ export declare const dataTableDtoSchema: z.ZodObject<{
     createdAt: z.ZodString;
     updatedAt: z.ZodString;
 }, "strip", z.ZodTypeAny, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
     orgId: string;
     createdBy?: string | null | undefined;
     description?: string | null | undefined;
     columns?: {
-        id: string;
         name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
         createdAt: string;
         updatedAt: string;
-        type: ColumnType;
         tableId: string;
         slug: string;
         position: number;
@@ -1364,8 +1430,8 @@ export declare const dataTableDtoSchema: z.ZodObject<{
         updatedBy?: string | null | undefined;
     }[] | undefined;
     views?: {
-        id: string;
         name: string;
+        id: string;
         createdAt: string;
         updatedAt: string;
         tableId: string;
@@ -1373,19 +1439,19 @@ export declare const dataTableDtoSchema: z.ZodObject<{
         createdBy?: string | null | undefined;
     }[] | undefined;
 }, {
-    id: string;
     name: string;
+    id: string;
     createdAt: string;
     updatedAt: string;
     orgId: string;
     createdBy?: string | null | undefined;
     description?: string | null | undefined;
     columns?: {
-        id: string;
         name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
         createdAt: string;
         updatedAt: string;
-        type: ColumnType;
         tableId: string;
         slug: string;
         position: number;
@@ -1409,8 +1475,8 @@ export declare const dataTableDtoSchema: z.ZodObject<{
         updatedBy?: string | null | undefined;
     }[] | undefined;
     views?: {
-        id: string;
         name: string;
+        id: string;
         createdAt: string;
         updatedAt: string;
         tableId: string;
@@ -1453,16 +1519,16 @@ export declare const createTableDtoSchema: z.ZodObject<{
 export declare const createColumnDtoSchema: z.ZodObject<{
     tableId: z.ZodString;
     name: z.ZodString;
-    type: z.ZodNativeEnum<typeof ColumnType>;
+    type: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
     config: z.ZodOptional<z.ZodUnknown>;
 }, "strip", z.ZodTypeAny, {
     name: string;
-    type: ColumnType;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
     tableId: string;
     config?: unknown;
 }, {
     name: string;
-    type: ColumnType;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
     tableId: string;
     config?: unknown;
 }>;
@@ -1622,3 +1688,290 @@ export type PatchCellsDto = z.infer<typeof patchCellsDtoSchema>;
 export type ReorderRowsDto = z.infer<typeof reorderRowsDtoSchema>;
 export type CreateViewDto = z.infer<typeof createViewDtoSchema>;
 export type UpdateViewDto = z.infer<typeof updateViewDtoSchema>;
+export declare const TableColumnSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    name: z.ZodString;
+    slug: z.ZodString;
+    type: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
+    position: z.ZodNumber;
+    config: z.ZodOptional<z.ZodAny>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+    id: string;
+    tableId: string;
+    slug: string;
+    position: number;
+    config?: any;
+}, {
+    name: string;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+    id: string;
+    tableId: string;
+    slug: string;
+    position: number;
+    config?: any;
+}>;
+export declare const TableRowSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    position: z.ZodNumber;
+    createdAt: z.ZodString;
+    updatedAt: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    tableId: string;
+    position: number;
+}, {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    tableId: string;
+    position: number;
+}>;
+export declare const TableCellSchema: z.ZodObject<{
+    id: z.ZodString;
+    rowId: z.ZodString;
+    columnId: z.ZodString;
+    value: z.ZodOptional<z.ZodAny>;
+}, "strip", z.ZodTypeAny, {
+    id: string;
+    rowId: string;
+    columnId: string;
+    value?: any;
+}, {
+    id: string;
+    rowId: string;
+    columnId: string;
+    value?: any;
+}>;
+export declare const TableViewSchema: z.ZodObject<{
+    id: z.ZodString;
+    tableId: z.ZodString;
+    name: z.ZodString;
+    config: z.ZodAny;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    id: string;
+    tableId: string;
+    config?: any;
+}, {
+    name: string;
+    id: string;
+    tableId: string;
+    config?: any;
+}>;
+export declare const DataTableSchema: z.ZodObject<{
+    id: z.ZodString;
+    orgId: z.ZodString;
+    name: z.ZodString;
+    description: z.ZodOptional<z.ZodString>;
+    columns: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        tableId: z.ZodString;
+        name: z.ZodString;
+        slug: z.ZodString;
+        type: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
+        position: z.ZodNumber;
+        config: z.ZodOptional<z.ZodAny>;
+    }, "strip", z.ZodTypeAny, {
+        name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: any;
+    }, {
+        name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: any;
+    }>, "many">>;
+    views: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        tableId: z.ZodString;
+        name: z.ZodString;
+        config: z.ZodAny;
+    }, "strip", z.ZodTypeAny, {
+        name: string;
+        id: string;
+        tableId: string;
+        config?: any;
+    }, {
+        name: string;
+        id: string;
+        tableId: string;
+        config?: any;
+    }>, "many">>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    id: string;
+    orgId: string;
+    description?: string | undefined;
+    columns?: {
+        name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: any;
+    }[] | undefined;
+    views?: {
+        name: string;
+        id: string;
+        tableId: string;
+        config?: any;
+    }[] | undefined;
+}, {
+    name: string;
+    id: string;
+    orgId: string;
+    description?: string | undefined;
+    columns?: {
+        name: string;
+        type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+        id: string;
+        tableId: string;
+        slug: string;
+        position: number;
+        config?: any;
+    }[] | undefined;
+    views?: {
+        name: string;
+        id: string;
+        tableId: string;
+        config?: any;
+    }[] | undefined;
+}>;
+export declare const CreateTableDto: z.ZodObject<{
+    name: z.ZodString;
+    description: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    description?: string | undefined;
+}, {
+    name: string;
+    description?: string | undefined;
+}>;
+export declare const CreateColumnDto: z.ZodObject<{
+    tableId: z.ZodString;
+    name: z.ZodString;
+    type: z.ZodEnum<["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]>;
+    config: z.ZodOptional<z.ZodAny>;
+    position: z.ZodOptional<z.ZodNumber>;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+    tableId: string;
+    config?: any;
+    position?: number | undefined;
+}, {
+    name: string;
+    type: "TEXT" | "NUMBER" | "DATE" | "BOOLEAN" | "SELECT" | "REFERENCE";
+    tableId: string;
+    config?: any;
+    position?: number | undefined;
+}>;
+export declare const UpdateColumnDto: z.ZodObject<{
+    name: z.ZodOptional<z.ZodString>;
+    position: z.ZodOptional<z.ZodNumber>;
+    config: z.ZodOptional<z.ZodAny>;
+}, "strip", z.ZodTypeAny, {
+    name?: string | undefined;
+    config?: any;
+    position?: number | undefined;
+}, {
+    name?: string | undefined;
+    config?: any;
+    position?: number | undefined;
+}>;
+export declare const CreateRowDto: z.ZodObject<{
+    tableId: z.ZodString;
+    afterRowId: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    tableId: string;
+    afterRowId?: string | undefined;
+}, {
+    tableId: string;
+    afterRowId?: string | undefined;
+}>;
+export declare const PatchCellsDto: z.ZodObject<{
+    rowId: z.ZodString;
+    cells: z.ZodArray<z.ZodObject<{
+        columnId: z.ZodString;
+        value: z.ZodAny;
+    }, "strip", z.ZodTypeAny, {
+        columnId: string;
+        value?: any;
+    }, {
+        columnId: string;
+        value?: any;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    rowId: string;
+    cells: {
+        columnId: string;
+        value?: any;
+    }[];
+}, {
+    rowId: string;
+    cells: {
+        columnId: string;
+        value?: any;
+    }[];
+}>;
+export declare const ReorderRowsDto: z.ZodObject<{
+    order: z.ZodArray<z.ZodObject<{
+        rowId: z.ZodString;
+        position: z.ZodNumber;
+    }, "strip", z.ZodTypeAny, {
+        rowId: string;
+        position: number;
+    }, {
+        rowId: string;
+        position: number;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    order: {
+        rowId: string;
+        position: number;
+    }[];
+}, {
+    order: {
+        rowId: string;
+        position: number;
+    }[];
+}>;
+export declare const CreateViewDto: z.ZodObject<{
+    tableId: z.ZodString;
+    name: z.ZodString;
+    config: z.ZodAny;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+    tableId: string;
+    config?: any;
+}, {
+    name: string;
+    tableId: string;
+    config?: any;
+}>;
+export declare const UpdateViewDto: z.ZodObject<{
+    name: z.ZodOptional<z.ZodString>;
+    config: z.ZodOptional<z.ZodAny>;
+}, "strip", z.ZodTypeAny, {
+    name?: string | undefined;
+    config?: any;
+}, {
+    name?: string | undefined;
+    config?: any;
+}>;
+export type TColumnType = z.infer<typeof ColumnType>;
+export type TDataTable = z.infer<typeof DataTableSchema>;

--- a/packages/shared/dist/schemas.js
+++ b/packages/shared/dist/schemas.js
@@ -1,4 +1,19 @@
 import { z } from "zod";
+export const ColumnType = z.enum(["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]);
+export const ScriptStatusEnum = z.enum(["DRAFT", "PUBLISHED"]);
+export const ProviderActionParam = z.object({
+    name: z.string(),
+    schema: z.any().optional(),
+    required: z.boolean().optional()
+});
+export const ProviderManifest = z.object({
+    name: z.string(),
+    actions: z.array(z.object({
+        key: z.string(),
+        label: z.string(),
+        params: z.array(ProviderActionParam).optional()
+    }))
+});
 export const orgSchema = z.object({
     id: z.string(),
     name: z.string(),
@@ -255,16 +270,7 @@ export const updatePublicDashboardRequestSchema = z
     .refine((payload) => Object.keys(payload).length > 0, {
     message: "Update payload cannot be empty"
 });
-export var ColumnType;
-(function (ColumnType) {
-    ColumnType["TEXT"] = "TEXT";
-    ColumnType["NUMBER"] = "NUMBER";
-    ColumnType["DATE"] = "DATE";
-    ColumnType["BOOLEAN"] = "BOOLEAN";
-    ColumnType["SELECT"] = "SELECT";
-    ColumnType["REFERENCE"] = "REFERENCE";
-})(ColumnType || (ColumnType = {}));
-export const columnTypeSchema = z.nativeEnum(ColumnType);
+export const columnTypeSchema = ColumnType;
 export const tableCellDtoSchema = z.object({
     id: z.string(),
     rowId: z.string(),
@@ -371,4 +377,76 @@ export const updateViewDtoSchema = z
 })
     .refine((payload) => Object.keys(payload).length > 0, {
     message: "Update payload cannot be empty"
+});
+export const TableColumnSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    type: ColumnType,
+    position: z.number(),
+    config: z.any().optional(),
+});
+export const TableRowSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    position: z.number(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+});
+export const TableCellSchema = z.object({
+    id: z.string(),
+    rowId: z.string(),
+    columnId: z.string(),
+    value: z.any().optional(),
+});
+export const TableViewSchema = z.object({
+    id: z.string(),
+    tableId: z.string(),
+    name: z.string(),
+    config: z.any(),
+});
+export const DataTableSchema = z.object({
+    id: z.string(),
+    orgId: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    columns: z.array(TableColumnSchema).optional(),
+    views: z.array(TableViewSchema).optional(),
+});
+export const CreateTableDto = z.object({
+    name: z.string().min(1),
+    description: z.string().optional(),
+});
+export const CreateColumnDto = z.object({
+    tableId: z.string(),
+    name: z.string().min(1),
+    type: ColumnType,
+    config: z.any().optional(),
+    position: z.number().optional(),
+});
+export const UpdateColumnDto = z.object({
+    name: z.string().optional(),
+    position: z.number().optional(),
+    config: z.any().optional(),
+});
+export const CreateRowDto = z.object({
+    tableId: z.string(),
+    afterRowId: z.string().optional(),
+});
+export const PatchCellsDto = z.object({
+    rowId: z.string(),
+    cells: z.array(z.object({ columnId: z.string(), value: z.any() })),
+});
+export const ReorderRowsDto = z.object({
+    order: z.array(z.object({ rowId: z.string(), position: z.number() })),
+});
+export const CreateViewDto = z.object({
+    tableId: z.string(),
+    name: z.string(),
+    config: z.any(),
+});
+export const UpdateViewDto = z.object({
+    name: z.string().optional(),
+    config: z.any().optional(),
 });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const ColumnTypeEnum = z.enum(["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]);
+export const ColumnType = z.enum(["TEXT", "NUMBER", "DATE", "BOOLEAN", "SELECT", "REFERENCE"]);
 
 export const ScriptStatusEnum = z.enum(["DRAFT", "PUBLISHED"]);
 
@@ -322,16 +322,7 @@ export const updatePublicDashboardRequestSchema = z
     message: "Update payload cannot be empty"
   });
 
-export enum ColumnType {
-  TEXT = "TEXT",
-  NUMBER = "NUMBER",
-  DATE = "DATE",
-  BOOLEAN = "BOOLEAN",
-  SELECT = "SELECT",
-  REFERENCE = "REFERENCE"
-}
-
-export const columnTypeSchema = z.nativeEnum(ColumnType);
+export const columnTypeSchema = ColumnType;
 
 export const tableCellDtoSchema = z.object({
   id: z.string(),
@@ -507,3 +498,84 @@ export type PatchCellsDto = z.infer<typeof patchCellsDtoSchema>;
 export type ReorderRowsDto = z.infer<typeof reorderRowsDtoSchema>;
 export type CreateViewDto = z.infer<typeof createViewDtoSchema>;
 export type UpdateViewDto = z.infer<typeof updateViewDtoSchema>;
+
+export const TableColumnSchema = z.object({
+  id: z.string(),
+  tableId: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  type: ColumnType,
+  position: z.number(),
+  config: z.any().optional(),
+});
+
+export const TableRowSchema = z.object({
+  id: z.string(),
+  tableId: z.string(),
+  position: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const TableCellSchema = z.object({
+  id: z.string(),
+  rowId: z.string(),
+  columnId: z.string(),
+  value: z.any().optional(),
+});
+
+export const TableViewSchema = z.object({
+  id: z.string(),
+  tableId: z.string(),
+  name: z.string(),
+  config: z.any(),
+});
+
+export const DataTableSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  columns: z.array(TableColumnSchema).optional(),
+  views: z.array(TableViewSchema).optional(),
+});
+
+export const CreateTableDto = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+export const CreateColumnDto = z.object({
+  tableId: z.string(),
+  name: z.string().min(1),
+  type: ColumnType,
+  config: z.any().optional(),
+  position: z.number().optional(),
+});
+export const UpdateColumnDto = z.object({
+  name: z.string().optional(),
+  position: z.number().optional(),
+  config: z.any().optional(),
+});
+export const CreateRowDto = z.object({
+  tableId: z.string(),
+  afterRowId: z.string().optional(),
+});
+export const PatchCellsDto = z.object({
+  rowId: z.string(),
+  cells: z.array(z.object({ columnId: z.string(), value: z.any() })),
+});
+export const ReorderRowsDto = z.object({
+  order: z.array(z.object({ rowId: z.string(), position: z.number() })),
+});
+export const CreateViewDto = z.object({
+  tableId: z.string(),
+  name: z.string(),
+  config: z.any(),
+});
+export const UpdateViewDto = z.object({
+  name: z.string().optional(),
+  config: z.any().optional(),
+});
+
+export type TColumnType = z.infer<typeof ColumnType>;
+export type TDataTable = z.infer<typeof DataTableSchema>;


### PR DESCRIPTION
## Summary
- replace the shared ColumnType enum with a Zod enum and expose the lightweight table schemas and DTO validators required by the tables MVP
- regenerate the shared dist outputs so the compiled artifacts include the new exports
- update the table grid UI to consume ColumnType.enum values when presenting column type options

## Testing
- `pnpm --filter @shared/api build`
- `pnpm -r typecheck` *(fails: prisma generate cannot download engines in this environment)*
- `pnpm --filter apps-frontend typecheck` *(fails: existing dashboard tests lack global jest typings)*

------
https://chatgpt.com/codex/tasks/task_e_68e45f4fd0a88322bb9496c5c3f86bac