### PR TITLE
Fix backend build by generating Prisma client

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "nest start --watch",
     "start": "nest start",
+    "prebuild": "pnpm prisma generate",
     "build": "nest build",
     "lint": "eslint ./src --ext .ts",
     "pretypecheck": "pnpm prisma generate",

--- a/apps/backend/src/tables/tables.controller.ts
+++ b/apps/backend/src/tables/tables.controller.ts
@@ -13,6 +13,7 @@ import {
   UseInterceptors
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
+import type { Buffer } from "node:buffer";
 import {
   CreateColumnDto,
   CreateRowDto,
@@ -24,6 +25,10 @@ import {
   UpdateViewDto
 } from "@shared/api";
 import type { Response } from "express";
+
+type UploadedCsvFile = {
+  buffer: Buffer;
+};
 
 import { TablesService } from "./tables.service";
 
@@ -132,7 +137,7 @@ export class TablesController {
 
   @Post(":id/import.csv")
   @UseInterceptors(FileInterceptor("file"))
-  async importCsv(@Param("id") id: string, @UploadedFile() file: Express.Multer.File) {
+  async importCsv(@Param("id") id: string, @UploadedFile() file: UploadedCsvFile) {
     if (!file) {
       throw new BadRequestException("file is required");
     }


### PR DESCRIPTION
## Summary
- ensure the backend build runs `prisma generate` before compiling so the Prisma client includes the latest schema
- relax the CSV upload handler typing to avoid relying on the Express.Multer type helper

## Testing
- pnpm build *(fails in container: Prisma engine download blocked by 403 from binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68e470372f008322ad4759a8598ba1ab