### PR TITLE
Fix backend build by generating Prisma client

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "nest start --watch",
     "start": "nest start",
+    "prebuild": "pnpm prisma generate",
     "build": "nest build",
     "lint": "eslint ./src --ext .ts",
     "pretypecheck": "pnpm prisma generate",
@@ -32,7 +33,8 @@
     "rxjs": "^7.8.1",
     "vm2": "^3.9.19",
     "yjs": "^13.6.15",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "prisma": "^5.22.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.7",
@@ -44,7 +46,6 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.31.0",
-    "prisma": "^5.22.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.6.3"

--- a/apps/backend/src/tables/tables.controller.ts
+++ b/apps/backend/src/tables/tables.controller.ts
@@ -13,6 +13,7 @@ import {
   UseInterceptors
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
+import type { Buffer } from "node:buffer";
 import {
   CreateColumnDto,
   CreateRowDto,
@@ -24,6 +25,10 @@ import {
   UpdateViewDto
 } from "@shared/api";
 import type { Response } from "express";
+
+type UploadedCsvFile = {
+  buffer: Buffer;
+};
 
 import { TablesService } from "./tables.service";
 
@@ -132,7 +137,7 @@ export class TablesController {
 
   @Post(":id/import.csv")
   @UseInterceptors(FileInterceptor("file"))
-  async importCsv(@Param("id") id: string, @UploadedFile() file: Express.Multer.File) {
+  async importCsv(@Param("id") id: string, @UploadedFile() file: UploadedCsvFile) {
     if (!file) {
       throw new BadRequestException("file is required");
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
       yjs:
         specifier: ^13.6.15
         version: 13.6.27
@@ -92,9 +95,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      prisma:
-        specifier: ^5.22.0
-        version: 5.22.0
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.18.8)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- ensure the backend build runs `prisma generate` before compiling so the Prisma client includes the latest schema
- relax the CSV upload handler typing to avoid relying on the Express.Multer type helper
- install the Prisma CLI as a runtime dependency so build hooks can execute in production environments

## Testing
- pnpm --filter apps-backend build *(fails in container: Prisma engine download blocked by 403 from binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68e470372f008322ad4759a8598ba1ab