### PR TITLE
chore: refresh pnpm-lock for CI

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,13 +5,16 @@
   "scripts": {
     "dev": "nest start --watch",
     "start": "nest start",
+    "start:prod": "node dist/main.js",
     "prebuild": "pnpm prisma generate",
     "build": "nest build",
     "lint": "eslint ./src --ext .ts",
     "pretypecheck": "pnpm prisma generate",
     "typecheck": "tsc --noEmit",
     "test": "echo \"No backend tests yet\"",
-    "prisma": "prisma"
+    "prisma": "prisma",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.7",


### PR DESCRIPTION
## Summary
- add the missing backend scripts (`start:prod`, `prisma:generate`, `prisma:migrate`) so CI can invoke them directly

## Testing
- pnpm -w install *(fails: 403 Forbidden from registry.npmjs.org via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e48757aad883229140a77d792f518a