### PR TITLE
Fix Prisma schema relations for backend models

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -55,7 +55,6 @@ model Org {
   roles          UserOrgRole[]
   sops           SOP[]
   billingItems   BillingItem[]
-  reports        ReportSnapshot[]
   thresholds     KPIThreshold[]
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
@@ -68,6 +67,7 @@ model User {
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
   roles     UserOrgRole[]
+  assignedTasks Task[]   @relation("TaskAssignee")
 }
 
 model UserOrgRole {
@@ -77,7 +77,7 @@ model UserOrgRole {
   org        Org       @relation(fields: [orgId], references: [id])
   orgId      String
   role       UserRole
-  property   Property? @relation(fields: [propertyId], references: [id])
+  property   Property? @relation("PropertyUserRoles", fields: [propertyId], references: [id])
   propertyId String?
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
@@ -116,8 +116,10 @@ model Property {
   sourceAccounts       SourceAccount[]
   tickets              Ticket[]
   tasks                Task[]
+  userRoles            UserOrgRole[]     @relation("PropertyUserRoles")
   billingItems         BillingItem[]
   scrapeJobs           ScrapeJob[]
+  findings             Finding[]         @relation("PropertyFindings")
 }
 
 model SourceAccount {
@@ -230,7 +232,7 @@ model Application {
   approvedAt  DateTime?
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
-  leases      Lease[]
+  leases      Lease[]            @relation("ApplicationLeases")
 
   @@index([propertyId, submittedAt], name: "idx_application_property_submitted")
 }
@@ -243,6 +245,8 @@ model Lease {
   propertyId  String
   unit        Unit?       @relation(fields: [unitId], references: [id])
   unitId      String?
+  application Application? @relation("ApplicationLeases", fields: [applicationId], references: [id])
+  applicationId String?
   startDate   DateTime
   endDate     DateTime?
   status      LeaseStatus
@@ -413,7 +417,7 @@ model Task {
   propertyId  String?
   title       String
   status      String     @default("PENDING")
-  assignee    User?      @relation(fields: [assigneeId], references: [id])
+  assignee    User?      @relation("TaskAssignee", fields: [assigneeId], references: [id])
   assigneeId  String?
   dueAt       DateTime?
   createdAt   DateTime   @default(now())
@@ -460,7 +464,7 @@ model Finding {
   id         String        @id @default(cuid())
   job        ScrapeJob?    @relation(fields: [jobId], references: [id])
   jobId      String?
-  property   Property?     @relation(fields: [propertyId], references: [id])
+  property   Property?     @relation("PropertyFindings", fields: [propertyId], references: [id])
   propertyId String?
   message    String
   severity   AlertSeverity @default(MEDIUM)
@@ -516,6 +520,8 @@ model TableColumn {
   config    Json?
   createdAt DateTime    @default(now())
   updatedAt DateTime    @updatedAt
+
+  cells     TableCell[]
 
   @@unique([tableId, slug])
   @@index([tableId, position])


### PR DESCRIPTION
## Summary
- add missing back-relations for tasks, property roles, findings, leases, and table columns to satisfy Prisma relation validation
- remove the unused Org.reports relation that lacked a matching field on ReportSnapshot

## Testing
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter apps-backend prisma:generate *(fails in sandbox: 403 fetching Prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_68e4906ed9b083228f4dd282adf7de33