### PR TITLE
Fix Prisma schema and JSON typing for backend

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "@prisma/client": "^5.22.0",
     "express": "^4.19.2",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
     "esbuild": "^0.24.0",
     "bullmq": "^4.16.0",
     "class-transformer": "^0.5.1",

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -53,9 +53,9 @@ model Org {
   name           String
   properties     Property[]
   roles          UserOrgRole[]
+  users          User[]
   sops           SOP[]
   billingItems   BillingItem[]
-  reports        ReportSnapshot[]
   thresholds     KPIThreshold[]
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
@@ -64,10 +64,15 @@ model Org {
 model User {
   id        String        @id @default(cuid())
   email     String        @unique
+  username  String?       @unique
   name      String?
+  passwordHash String?
+  org       Org?          @relation(fields: [orgId], references: [id])
+  orgId     String?
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
   roles     UserOrgRole[]
+  assignedTasks Task[]   @relation("TaskAssignee")
 }
 
 model UserOrgRole {
@@ -77,7 +82,7 @@ model UserOrgRole {
   org        Org       @relation(fields: [orgId], references: [id])
   orgId      String
   role       UserRole
-  property   Property? @relation(fields: [propertyId], references: [id])
+  property   Property? @relation("PropertyUserRoles", fields: [propertyId], references: [id])
   propertyId String?
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
@@ -116,8 +121,10 @@ model Property {
   sourceAccounts       SourceAccount[]
   tickets              Ticket[]
   tasks                Task[]
+  userRoles            UserOrgRole[]     @relation("PropertyUserRoles")
   billingItems         BillingItem[]
   scrapeJobs           ScrapeJob[]
+  findings             Finding[]         @relation("PropertyFindings")
 }
 
 model SourceAccount {
@@ -201,7 +208,7 @@ model Lead {
   events       LeadEvent[]
   conversions  ConversionEvent[]
 
-  @@unique([propertyId, externalId], name: "uniq_lead_property_external")
+  @@unique([propertyId, externalId])
   @@index([propertyId, createdAt], name: "idx_lead_property_created")
 }
 
@@ -230,7 +237,7 @@ model Application {
   approvedAt  DateTime?
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
-  leases      Lease[]
+  leases      Lease[]            @relation("ApplicationLeases")
 
   @@index([propertyId, submittedAt], name: "idx_application_property_submitted")
 }
@@ -243,6 +250,8 @@ model Lease {
   propertyId  String
   unit        Unit?       @relation(fields: [unitId], references: [id])
   unitId      String?
+  application Application? @relation("ApplicationLeases", fields: [applicationId], references: [id])
+  applicationId String?
   startDate   DateTime
   endDate     DateTime?
   status      LeaseStatus
@@ -413,7 +422,7 @@ model Task {
   propertyId  String?
   title       String
   status      String     @default("PENDING")
-  assignee    User?      @relation(fields: [assigneeId], references: [id])
+  assignee    User?      @relation("TaskAssignee", fields: [assigneeId], references: [id])
   assigneeId  String?
   dueAt       DateTime?
   createdAt   DateTime   @default(now())
@@ -460,7 +469,7 @@ model Finding {
   id         String        @id @default(cuid())
   job        ScrapeJob?    @relation(fields: [jobId], references: [id])
   jobId      String?
-  property   Property?     @relation(fields: [propertyId], references: [id])
+  property   Property?     @relation("PropertyFindings", fields: [propertyId], references: [id])
   propertyId String?
   message    String
   severity   AlertSeverity @default(MEDIUM)
@@ -516,6 +525,8 @@ model TableColumn {
   config    Json?
   createdAt DateTime    @default(now())
   updatedAt DateTime    @updatedAt
+
+  cells     TableCell[]
 
   @@unique([tableId, slug])
   @@index([tableId, position])

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -128,6 +128,10 @@ export class AuthService {
       throw new UnauthorizedException("Invalid credentials");
     }
 
+    if (!user.passwordHash) {
+      throw new UnauthorizedException("Invalid credentials");
+    }
+
     const userWithCredentials = user as UserWithCredentials;
 
     const isPasswordValid = this.verifyPassword(password, userWithCredentials.passwordHash);

--- a/apps/backend/src/dev-providers/dev-providers.service.ts
+++ b/apps/backend/src/dev-providers/dev-providers.service.ts
@@ -379,10 +379,18 @@ export class DevProvidersService {
   }
 
   private asJson(value: unknown): Prisma.InputJsonValue {
+    if (value === undefined || value === null) {
+      return Prisma.JsonNull;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+
     try {
-      return JSON.parse(JSON.stringify(value)) as Prisma.JsonValue;
+      return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
     } catch {
-      return String(value);
+      return String(value) as Prisma.InputJsonValue;
     }
   }
 

--- a/apps/backend/src/jobs/etl.processor.ts
+++ b/apps/backend/src/jobs/etl.processor.ts
@@ -27,6 +27,22 @@ interface EtlJobPayload {
 
 let dependencies: EtlProcessorDependencies | null = null;
 
+function toJsonInput(value: unknown): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+  if (value === undefined || value === null) {
+    return Prisma.JsonNull;
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+  } catch {
+    return String(value) as Prisma.InputJsonValue;
+  }
+}
+
 export function configureEtlProcessor(deps: EtlProcessorDependencies) {
   dependencies = deps;
 }
@@ -350,7 +366,7 @@ async function syncGoogleBusiness(
         text: review.comment ?? "",
         responseText: review.reviewReply?.comment ?? null,
         respondedAt: review.reviewReply?.updateTime ? new Date(review.reviewReply.updateTime) : null,
-        rawPayload: review
+        rawPayload: toJsonInput(review)
       },
       create: {
         id: reviewId,
@@ -362,7 +378,7 @@ async function syncGoogleBusiness(
         at: createdAt,
         responseText: review.reviewReply?.comment ?? null,
         respondedAt: review.reviewReply?.updateTime ? new Date(review.reviewReply.updateTime) : null,
-        rawPayload: review
+        rawPayload: toJsonInput(review)
       }
     });
   }

--- a/apps/backend/src/prisma/prisma.service.ts
+++ b/apps/backend/src/prisma/prisma.service.ts
@@ -1,6 +1,7 @@
 import { INestApplication, Injectable, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PrismaClient } from "@prisma/client";
+import process from "node:process";
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
@@ -35,7 +36,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
   }
 
   async enableShutdownHooks(app: INestApplication) {
-    this.$on("beforeExit", async () => {
+    process.on("beforeExit", async () => {
       await app.close();
     });
   }

--- a/apps/backend/src/providers/mock-integrations.service.ts
+++ b/apps/backend/src/providers/mock-integrations.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import type { WeeklyReportResponse } from "@shared/api";
 
 import {
   getAlerts,
@@ -54,7 +55,7 @@ export class MockIntegrationsService {
     return getReviews(propertyId);
   }
 
-  getWeeklyReport() {
+  getWeeklyReport(): WeeklyReportResponse {
     this.ensureMockMode();
     return sampleWeeklyReport;
   }

--- a/apps/backend/src/providers/sample-data.ts
+++ b/apps/backend/src/providers/sample-data.ts
@@ -4,7 +4,8 @@ import type {
   LatestReviewsResponse,
   OccupancyMetricsResponse,
   PipelineMetricsResponse,
-  PropertiesResponse
+  PropertiesResponse,
+  WeeklyReportResponse
 } from "@shared/api";
 
 const now = Date.now();
@@ -341,7 +342,7 @@ export function getAlerts(propertyId?: string): { alerts: Alert[] } {
   };
 }
 
-export const sampleWeeklyReport = {
+export const sampleWeeklyReport: WeeklyReportResponse = {
   generatedAt: new Date(now - 1000 * 60 * 60 * 24 * 3).toISOString(),
   highlights: [
     "Occupancy improved across the portfolio with Atrium Center leading at 94%",

--- a/apps/backend/src/public-dashboards/public-dashboards.service.ts
+++ b/apps/backend/src/public-dashboards/public-dashboards.service.ts
@@ -24,7 +24,7 @@ export class PublicDashboardsService {
       subdomain,
       orgId: payload.orgId,
       propertyId: payload.propertyId ?? null,
-      config: payload.config ?? { widgets: [] },
+      config: this.toJsonInput(payload.config ?? { widgets: [] }),
       isActive: payload.isActive ?? true
     };
 
@@ -51,7 +51,7 @@ export class PublicDashboardsService {
       data.propertyId = payload.propertyId || null;
     }
     if (payload.config !== undefined) {
-      data.config = payload.config;
+      data.config = this.toJsonInput(payload.config);
     }
     if (payload.isActive !== undefined) {
       data.isActive = payload.isActive;
@@ -107,5 +107,21 @@ export class PublicDashboardsService {
     }
 
     throw error;
+  }
+
+  private toJsonInput(value: unknown): Prisma.InputJsonValue {
+    if (value === undefined || value === null) {
+      return Prisma.JsonNull;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+    } catch {
+      return String(value) as Prisma.InputJsonValue;
+    }
   }
 }

--- a/apps/backend/src/sources/sources.service.ts
+++ b/apps/backend/src/sources/sources.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Prisma, SourceAccountType } from "@prisma/client";
+import type { SourceAccount } from "@prisma/client";
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypto";
 
 import { CreateSourceDto, CredentialPayload, SourceTypeDto, UpdateSourceDto } from "./sources.dto";
@@ -19,7 +20,7 @@ interface ProviderValidationResult {
   message?: string;
 }
 
-interface SourceSummary {
+export interface SourceSummary {
   id: string;
   name?: string | null;
   propertyId?: string;
@@ -215,9 +216,9 @@ export class SourcesService {
     return { ok: true, mode: "immediate" };
   }
 
-  private encryptCredential(credential: CredentialPayload): Prisma.JsonValue {
+  private encryptCredential(credential: CredentialPayload): Prisma.InputJsonValue {
     if (!this.encryptionKey) {
-      return credential as Prisma.JsonObject;
+      return this.toJsonInput(credential);
     }
 
     const iv = randomBytes(12);
@@ -227,7 +228,7 @@ export class SourcesService {
     const authTag = cipher.getAuthTag();
 
     const packed = Buffer.concat([iv, authTag, encrypted]).toString("base64");
-    return { enc: packed };
+    return { enc: packed } as Prisma.JsonObject;
   }
 
   private decryptCredential(value: unknown): CredentialPayload {
@@ -275,7 +276,7 @@ export class SourcesService {
     return { source: updated, validation };
   }
 
-  private async validate(source: Prisma.SourceAccount): Promise<ProviderValidationResult> {
+  private async validate(source: SourceAccount): Promise<ProviderValidationResult> {
     const credential = this.decryptCredential(source.credential);
 
     try {
@@ -304,7 +305,7 @@ export class SourcesService {
     return result;
   }
 
-  private toSummary(source: Prisma.SourceAccount): SourceSummary {
+  private toSummary(source: SourceAccount): SourceSummary {
     const type = PRISMA_TO_DTO[source.type];
     if (!type) {
       throw new Error(`Cannot map source type ${source.type}`);
@@ -322,5 +323,21 @@ export class SourcesService {
       createdAt: source.createdAt.toISOString(),
       updatedAt: source.updatedAt.toISOString()
     };
+  }
+
+  private toJsonInput(value: unknown): Prisma.InputJsonValue {
+    if (value === undefined || value === null) {
+      return Prisma.JsonNull;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+    } catch {
+      return String(value) as Prisma.InputJsonValue;
+    }
   }
 }

--- a/apps/backend/src/tables/tables.service.ts
+++ b/apps/backend/src/tables/tables.service.ts
@@ -97,7 +97,7 @@ export class TablesService {
           slug,
           type: dto.type as PrismaColumnType,
           position: nextPosition,
-          config: dto.config ?? null
+          ...(dto.config !== undefined ? { config: this.serializeJson(dto.config) } : {})
         }
       });
 
@@ -133,13 +133,13 @@ export class TablesService {
       }
 
       if (dto.config !== undefined) {
-        data.config = dto.config;
+        data.config = this.serializeJson(dto.config);
       }
 
       if (dto.type && dto.type !== column.type) {
         data.type = dto.type as PrismaColumnType;
         if (dto.type !== PrismaColumnType.SELECT && dto.config === undefined) {
-          data.config = null;
+          data.config = Prisma.JsonNull;
         }
       }
 
@@ -333,6 +333,10 @@ export class TablesService {
 
         const normalizedValue = this.normalizeIncomingValue(column.type, cell.value);
 
+        if (normalizedValue === undefined) {
+          continue;
+        }
+
         await tx.tableCell.upsert({
           where: {
             rowId_columnId: {
@@ -401,7 +405,7 @@ export class TablesService {
       data: {
         tableId: dto.tableId,
         name: dto.name,
-        config: dto.config,
+        config: this.serializeJson(dto.config),
         createdBy: actorId ?? undefined
       }
     });
@@ -420,12 +424,17 @@ export class TablesService {
       throw new NotFoundException("View not found");
     }
 
+    const data: Prisma.TableViewUpdateInput = {
+      name: dto.name ?? view.name
+    };
+
+    if (dto.config !== undefined) {
+      data.config = this.serializeJson(dto.config);
+    }
+
     const updated = await this.prisma.tableView.update({
       where: { id },
-      data: {
-        name: dto.name ?? view.name,
-        config: dto.config ?? view.config
-      }
+      data
     });
 
     await this.logAudit(this.prisma, view.tableId, actorId, "UPDATE_VIEW", {
@@ -576,7 +585,7 @@ export class TablesService {
               slug,
               type: PrismaColumnType.TEXT,
               position: nextColumnPosition++,
-              config: null
+              config: Prisma.JsonNull
             }
           });
           nameMap.set(normalizedName.toLowerCase(), column);
@@ -730,7 +739,7 @@ export class TablesService {
         tableId,
         actorId: actorId ?? undefined,
         action,
-        payload
+        payload: this.serializeJson(payload)
       }
     });
   }
@@ -756,13 +765,36 @@ export class TablesService {
     return base || "column";
   }
 
-  private normalizeIncomingValue(type: PrismaColumnType, value: unknown): unknown {
+  private serializeJson(value: unknown): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+    if (value === undefined || value === null) {
+      return Prisma.JsonNull;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+    } catch {
+      return String(value) as Prisma.InputJsonValue;
+    }
+  }
+
+  private normalizeIncomingValue(
+    type: PrismaColumnType,
+    value: unknown
+  ): Prisma.InputJsonValue | typeof Prisma.JsonNull | undefined {
     if (value === undefined) {
       return undefined;
     }
 
     if (value === null) {
-      return null;
+      return Prisma.JsonNull;
     }
 
     if (type === PrismaColumnType.TEXT) {
@@ -773,7 +805,7 @@ export class TablesService {
       const trimmed = value.trim();
 
       if (!trimmed) {
-        return null;
+        return Prisma.JsonNull;
       }
 
       value = trimmed;
@@ -782,11 +814,11 @@ export class TablesService {
     switch (type) {
       case PrismaColumnType.NUMBER: {
         const numberValue = typeof value === "number" ? value : Number(value);
-        return Number.isFinite(numberValue) ? numberValue : null;
+        return Number.isFinite(numberValue) ? numberValue : Prisma.JsonNull;
       }
       case PrismaColumnType.DATE: {
         const date = new Date(value as string);
-        return Number.isNaN(date.getTime()) ? null : date.toISOString();
+        return Number.isNaN(date.getTime()) ? Prisma.JsonNull : date.toISOString();
       }
       case PrismaColumnType.BOOLEAN: {
         if (typeof value === "boolean") {
@@ -807,7 +839,7 @@ export class TablesService {
           }
         }
 
-        return null;
+        return Prisma.JsonNull;
       }
       case PrismaColumnType.SELECT:
       case PrismaColumnType.REFERENCE: {
@@ -815,16 +847,17 @@ export class TablesService {
           const trimmed = value.trim();
           if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
             try {
-              return JSON.parse(trimmed);
+              return this.serializeJson(JSON.parse(trimmed));
             } catch {
-              return value;
+              return this.serializeJson(value);
             }
           }
         }
-        return value;
+
+        return this.serializeJson(value);
       }
       default:
-        return value;
+        return this.serializeJson(value);
     }
   }
 


### PR DESCRIPTION
## Summary
- add optional username/password fields plus org linkage to the Prisma User model and restore the compound Lead lookup used during ETL upserts
- guard login against users without stored hashes and move the shutdown hook to Node's process event to match Prisma 5 typings
- normalize JSON serialization for dev providers, ETL review payloads, public dashboard config, source credentials, and tables CRUD so the new Prisma client accepts the data
- type the mock weekly report data and declare the `date-fns` dependency required by the metrics service build

## Testing
- pnpm --filter apps-backend typecheck *(fails: Prisma engine download blocked with 403)*
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter apps-backend typecheck *(fails: prisma CLI missing after dependency reinstall failed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e4906ed9b083228f4dd282adf7de33