### PR TITLE
fix(json): make Prisma.JsonNull assignable to InputJsonValue

### DIFF
--- a/apps/backend/src/dev-providers/dev-providers.service.ts
+++ b/apps/backend/src/dev-providers/dev-providers.service.ts
@@ -9,6 +9,7 @@ import type { ProviderManifest } from "@shared/api";
 import { ProviderManifest as ProviderManifestSchema } from "@shared/api";
 
 import { PrismaService } from "../prisma/prisma.service";
+import { JSON_NULL } from "../util/json";
 
 const EXECUTION_TIMEOUT_MS = 5_000;
 const RESPONSE_SIZE_LIMIT = 10 * 1024 * 1024;
@@ -380,7 +381,7 @@ export class DevProvidersService {
 
   private asJson(value: unknown): Prisma.InputJsonValue {
     if (value === undefined || value === null) {
-      return Prisma.JsonNull;
+      return JSON_NULL;
     }
 
     if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {

--- a/apps/backend/src/public-dashboards/public-dashboards.service.ts
+++ b/apps/backend/src/public-dashboards/public-dashboards.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import { Prisma } from "@prisma/client";
 
 import { PrismaService } from "../prisma/prisma.service";
+import { JSON_NULL } from "../util/json";
 import { CreatePublicDashboardDto } from "./dto/create-public-dashboard.dto";
 import { UpdatePublicDashboardDto } from "./dto/update-public-dashboard.dto";
 
@@ -111,7 +112,7 @@ export class PublicDashboardsService {
 
   private toJsonInput(value: unknown): Prisma.InputJsonValue {
     if (value === undefined || value === null) {
-      return Prisma.JsonNull;
+      return JSON_NULL;
     }
 
     if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {

--- a/apps/backend/src/sources/sources.service.ts
+++ b/apps/backend/src/sources/sources.service.ts
@@ -8,6 +8,7 @@ import { CreateSourceDto, CredentialPayload, SourceTypeDto, UpdateSourceDto } fr
 import { configureEtlProcessor, processEtlJob } from "../jobs/etl.processor";
 import { JobsService } from "../jobs/jobs.service";
 import { PrismaService } from "../prisma/prisma.service";
+import { JSON_NULL } from "../util/json";
 import { EntrataProvider } from "../providers/entrata.provider";
 import { Ga4Provider } from "../providers/ga4.provider";
 import { GoogleBusinessProvider } from "../providers/gbp.provider";
@@ -327,7 +328,7 @@ export class SourcesService {
 
   private toJsonInput(value: unknown): Prisma.InputJsonValue {
     if (value === undefined || value === null) {
-      return Prisma.JsonNull;
+      return JSON_NULL;
     }
 
     if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {

--- a/apps/backend/src/util/json.ts
+++ b/apps/backend/src/util/json.ts
@@ -1,0 +1,4 @@
+import { Prisma } from "@prisma/client";
+
+export const JSON_NULL = Prisma.JsonNull as unknown as Prisma.InputJsonValue;
+export const DB_NULL = Prisma.DbNull;


### PR DESCRIPTION
## Summary
- create a shared json utility that exports assignable Prisma null constants
- update backend services to use the shared JSON null helper instead of Prisma.JsonNull directly

## Testing
- pnpm -C apps/backend build *(fails: Prisma engine download checksum 403 in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e537aad5b08322b3cde5eec43b8598