### PR TITLE
build: bundle shared api before backend build

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
     "dev": "nest start --watch",
     "start": "nest start",
     "start:prod": "node dist/main.js",
-    "prebuild": "pnpm prisma generate",
+    "prebuild": "pnpm prisma generate && pnpm -C ../../packages/shared build",
     "build": "nest build",
     "lint": "eslint ./src --ext .ts",
     "pretypecheck": "pnpm prisma generate",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "format": "pnpm -r format --if-present"
+    "format": "pnpm -r format --if-present",
+    "prebuild:backend": "pnpm -C packages/shared build"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,21 +1,22 @@
 {
   "name": "@shared/api",
+  "version": "0.0.0",
   "private": true,
-  "version": "0.1.0",
   "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./schemas": {
-      "types": "./dist/schemas.d.ts",
-      "import": "./dist/schemas.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "clean": "rimraf dist || rm -rf dist",
+    "build": "tsup src/index.ts --dts --format esm,cjs --sourcemap --out-dir dist",
     "typecheck": "tsc --noEmit",
     "lint": "echo \"No shared lint configured yet\"",
     "test": "echo \"No shared tests yet\""
@@ -24,6 +25,8 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.1.0",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./schemas.js";
+export * from "./schemas";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,16 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": false,
     "outDir": "dist",
     "rootDir": "src",
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "target": "ES2020",
     "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add tsup build pipeline for @shared/api with dist outputs and proper exports
- ensure shared package TypeScript config matches bundler output and index re-exports schemas
- run shared build ahead of backend build via workspace scripts and backend prebuild hook

## Testing
- `pnpm -C packages/shared build` *(fails: tsup not available in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e56e3f8cc08322b0fb6b93d7145362