### PR TITLE
Dev Studio for Sources: Monaco editor + Validate/Run + Logs

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -158,6 +158,7 @@ model ProviderScript {
   version   Int           @default(1)
   status    ScriptStatus  @default(DRAFT)
   code      String
+  readme    String?
   createdBy String?
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt

--- a/apps/backend/src/dev-providers/dev-providers.controller.ts
+++ b/apps/backend/src/dev-providers/dev-providers.controller.ts
@@ -4,6 +4,7 @@ import { DevProvidersService } from "./dev-providers.service";
 
 interface SaveScriptDto {
   code: string;
+  readme?: string;
   createdBy?: string;
 }
 
@@ -11,9 +12,7 @@ interface PublishDto {
   publishedBy?: string;
 }
 
-interface RunActionDto {
-  actionKey: string;
-  params?: unknown;
+interface RunDto {
   createdBy?: string;
 }
 
@@ -31,7 +30,7 @@ export class DevProvidersController {
     if (!body?.code) {
       throw new BadRequestException("Code is required");
     }
-    return this.devProvidersService.saveDraft(sourceId, body.code, body.createdBy);
+    return this.devProvidersService.saveDraft(sourceId, body.code, body.readme, body.createdBy);
   }
 
   @Post(":sourceId/publish")
@@ -45,11 +44,8 @@ export class DevProvidersController {
   }
 
   @Post(":sourceId/run")
-  runAction(@Param("sourceId") sourceId: string, @Body() body: RunActionDto) {
-    if (!body?.actionKey) {
-      throw new BadRequestException("actionKey is required");
-    }
-    return this.devProvidersService.runAction(sourceId, body.actionKey, body.params, body.createdBy);
+  run(@Param("sourceId") sourceId: string, @Body() body: RunDto) {
+    return this.devProvidersService.run(sourceId, body?.createdBy);
   }
 
   @Get(":sourceId/logs")

--- a/apps/backend/src/dev-providers/dev-providers.service.ts
+++ b/apps/backend/src/dev-providers/dev-providers.service.ts
@@ -1,9 +1,16 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { Prisma, ScriptStatus, SourceAccountType } from "@prisma/client";
+import {
+  ApplicationStatus,
+  LeaseStatus,
+  Prisma,
+  ReviewProvider,
+  ScriptStatus,
+  SourceAccountType
+} from "@prisma/client";
 import { transform } from "esbuild";
 import { VM } from "vm2";
-import { createDecipheriv, createHash } from "crypto";
+import { createDecipheriv, createHash, randomUUID } from "crypto";
 
 import type { ProviderManifest } from "@shared/api";
 import { ProviderManifest as ProviderManifestSchema } from "@shared/api";
@@ -11,14 +18,67 @@ import { ProviderManifest as ProviderManifestSchema } from "@shared/api";
 import { PrismaService } from "../prisma/prisma.service";
 import { JSON_NULL } from "../util/json";
 
-const EXECUTION_TIMEOUT_MS = 5_000;
+const EXECUTION_TIMEOUT_MS = 15_000;
 const RESPONSE_SIZE_LIMIT = 10 * 1024 * 1024;
 const REQUEST_COOLDOWN_MS = 1_000;
+const MAX_RUN_ROWS = 1_000;
+
+const DEFAULT_SCRIPT_TEMPLATE = `import type { ProviderManifest } from "@shared/api";
+
+export const manifest: ProviderManifest = {
+  name: "Sample Provider",
+  actions: []
+};
+
+export async function validate(creds: Record<string, unknown>, ctx: ProviderContext) {
+  ctx.log("Validating credentials for", manifest.name);
+  await ctx.fetchJson("https://example.com/status");
+  return { ok: true };
+}
+
+export async function run(creds: Record<string, unknown>, ctx: ProviderContext) {
+  ctx.log("Running", manifest.name);
+
+  const rows = await ctx.fetchJson("https://example.com/data");
+
+  if (Array.isArray(rows)) {
+    await ctx.upsertRows("leads", rows.map((row) => ({
+      externalId: String(row.id),
+      source: row.source ?? "Demo",
+      createdAt: row.createdAt
+    })));
+  }
+
+  return { inserted: Array.isArray(rows) ? rows.length : 0 };
+}
+
+interface ProviderContext {
+  fetchJson: typeof fetchJson;
+  log: (...args: unknown[]) => void;
+  upsertRows: (table: string, rows: unknown[]) => Promise<number>;
+}
+
+async function fetchJson(input: RequestInfo | URL, init?: RequestInit) {
+  const response = await fetch(input, init);
+  return response.json();
+}
+`;
+
+const DEFAULT_README = `# Pack Studio
+
+Use this studio to iterate on provider scripts. The runtime exposes:
+
+- ctx.fetchJson(url, init?) – validated network requests with JSON parsing
+- ctx.log(...args) – capture structured logs for validation and runs
+- ctx.upsertRows(table, rows) – persist data (limit 1k rows per run)
+
+Validate frequently and prefer small test runs.`;
 
 type ProviderModuleExports = {
   manifest?: ProviderManifest;
   validate?: (creds: Record<string, unknown>, ctx: ProviderExecutionContext) => unknown | Promise<unknown>;
   actions?: Record<string, ProviderActionHandler>;
+  run?: (creds: Record<string, unknown>, ctx: ProviderExecutionContext) => unknown | Promise<unknown>;
 };
 
 type ProviderActionHandler = (
@@ -29,6 +89,9 @@ type ProviderActionHandler = (
 
 interface ProviderExecutionContext {
   fetch: typeof fetch;
+  fetchJson: (input: Parameters<typeof fetch>[0], init?: RequestInit) => Promise<unknown>;
+  log: (...args: unknown[]) => void;
+  upsertRows: (table: string, rows: unknown[]) => Promise<number>;
 }
 
 interface SandboxResult {
@@ -37,6 +100,13 @@ interface SandboxResult {
     log: (...args: unknown[]) => void;
   };
   logs: string[];
+}
+
+interface ExecutionContextOptions {
+  allowWrites: boolean;
+  propertyId: string;
+  runId: string;
+  onRowsPersisted?: (total: number) => void;
 }
 
 @Injectable()
@@ -54,7 +124,13 @@ export class DevProvidersService {
   async getScriptBySource(sourceId: string) {
     const script = await this.prisma.providerScript.findUnique({ where: { sourceId } });
     if (!script) {
-      return { code: "", status: ScriptStatus.DRAFT, version: 1, manifest: null };
+      return {
+        code: DEFAULT_SCRIPT_TEMPLATE,
+        readme: DEFAULT_README,
+        status: ScriptStatus.DRAFT,
+        version: 1,
+        manifest: null
+      };
     }
 
     let manifest: ProviderManifest | null = null;
@@ -70,24 +146,26 @@ export class DevProvidersService {
 
     return {
       code: script.code,
+      readme: script.readme ?? DEFAULT_README,
       status: script.status,
       version: script.version,
       manifest
     };
   }
 
-  async saveDraft(sourceId: string, code: string, createdBy?: string) {
+  async saveDraft(sourceId: string, code: string, readme?: string, createdBy?: string) {
     const existing = await this.prisma.providerScript.findUnique({ where: { sourceId } });
     const nextVersion = existing ? (existing.code === code ? existing.version : existing.version + 1) : 1;
 
     const saved = await this.prisma.providerScript.upsert({
       where: { sourceId },
-      update: { code, status: ScriptStatus.DRAFT, version: nextVersion },
-      create: { sourceId, code, status: ScriptStatus.DRAFT, version: 1, createdBy }
+      update: { code, readme, status: ScriptStatus.DRAFT, version: nextVersion },
+      create: { sourceId, code, readme, status: ScriptStatus.DRAFT, version: 1, createdBy }
     });
 
     return {
       code: saved.code,
+      readme: saved.readme ?? DEFAULT_README,
       status: saved.status,
       version: saved.version
     };
@@ -126,7 +204,11 @@ export class DevProvidersService {
     }
 
     const credential = this.decryptCredential(source.credential);
-    const ctx: ProviderExecutionContext = { fetch: sandbox.fetch };
+    const ctx = this.createExecutionContext(sandbox, {
+      allowWrites: false,
+      propertyId: source.propertyId,
+      runId: randomUUID()
+    });
 
     const started = Date.now();
     try {
@@ -139,12 +221,12 @@ export class DevProvidersService {
       };
     } catch (error) {
       this.logger.warn(`Validation failed for ${sourceId}: ${(error as Error).message}`);
-      throw error;
+      this.wrapScriptError(error, sandbox.logs);
     }
   }
 
-  async runAction(sourceId: string, actionKey: string, params: unknown, createdBy?: string) {
-    const { source, script } = await this.loadSourceAndScript(sourceId, true);
+  async run(sourceId: string, createdBy?: string) {
+    const { source, script } = await this.loadSourceAndScript(sourceId);
     if (!script) {
       throw new NotFoundException("No script available");
     }
@@ -153,13 +235,22 @@ export class DevProvidersService {
     const sandbox = this.makeSandbox(source.type);
     const module = this.instantiateModule(compiled, sandbox.console);
 
-    if (!module.actions || typeof module.actions[actionKey] !== "function") {
-      throw new BadRequestException(`Action ${actionKey} not found in script`);
+    if (typeof module.run !== "function") {
+      throw new BadRequestException("Script does not export a run function");
     }
 
-    const handler = module.actions[actionKey] as ProviderActionHandler;
     const credential = this.decryptCredential(source.credential);
-    const ctx: ProviderExecutionContext = { fetch: sandbox.fetch };
+    const runId = randomUUID();
+    let rowsPersisted = 0;
+
+    const ctx = this.createExecutionContext(sandbox, {
+      allowWrites: true,
+      propertyId: source.propertyId,
+      runId,
+      onRowsPersisted: (total) => {
+        rowsPersisted = total;
+      }
+    });
 
     const started = Date.now();
     let ok = false;
@@ -167,27 +258,29 @@ export class DevProvidersService {
     let errorMessage: string | undefined;
 
     try {
-      const rawResult = await this.runWithTimeout(handler(credential, params, ctx), EXECUTION_TIMEOUT_MS);
+      const rawResult = await this.runWithTimeout(module.run(credential, ctx), EXECUTION_TIMEOUT_MS);
       ok = true;
-      responseJson = this.asJson({ result: rawResult, logs: sandbox.logs });
+      responseJson = this.asJson({ result: rawResult, logs: sandbox.logs, rowsPersisted });
       return {
         ok: true,
         result: rawResult,
+        rowsPersisted,
         logs: sandbox.logs,
         latencyMs: Date.now() - started
       };
     } catch (error) {
       errorMessage = (error as Error).message;
-      responseJson = this.asJson({ logs: sandbox.logs });
-      throw error;
+      responseJson = this.asJson({ logs: sandbox.logs, rowsPersisted });
+      this.logger.error(`Run failed for ${sourceId}: ${(error as Error).message}`);
+      this.wrapScriptError(error, sandbox.logs);
     } finally {
       await this.prisma.sourceActionLog.create({
         data: {
           sourceId,
-          action: actionKey,
+          action: "run",
           ok,
           latencyMs: ok ? Date.now() - started : null,
-          request: this.asJson({ params }),
+          request: this.asJson({ runId }),
           response: responseJson,
           error: errorMessage,
           createdBy
@@ -282,6 +375,59 @@ export class DevProvidersService {
     };
   }
 
+  private createExecutionContext(sandbox: SandboxResult, options: ExecutionContextOptions): ProviderExecutionContext {
+    let totalRows = 0;
+
+    const fetchJson: ProviderExecutionContext["fetchJson"] = async (input, init) => {
+      const response = await sandbox.fetch(input, init);
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status} ${response.statusText}`);
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.toLowerCase().includes("json")) {
+        throw new Error("Expected JSON response");
+      }
+
+      try {
+        return await response.json();
+      } catch (error) {
+        throw new Error(`Failed to parse JSON response: ${(error as Error).message}`);
+      }
+    };
+
+    const log: ProviderExecutionContext["log"] = (...args) => {
+      sandbox.console.log(...args);
+    };
+
+    const upsertRows: ProviderExecutionContext["upsertRows"] = async (table, rows) => {
+      if (!options.allowWrites) {
+        throw new Error("upsertRows is not available during validation");
+      }
+      if (!Array.isArray(rows)) {
+        throw new Error("rows must be an array");
+      }
+      if (rows.length === 0) {
+        return 0;
+      }
+      if (totalRows + rows.length > MAX_RUN_ROWS) {
+        throw new Error(`Row limit exceeded. Only ${MAX_RUN_ROWS} rows are allowed per run.`);
+      }
+
+      const processed = await this.persistRows(table, rows, options.propertyId, options.runId);
+      totalRows += processed;
+      options.onRowsPersisted?.(totalRows);
+      return processed;
+    };
+
+    return {
+      fetch: sandbox.fetch,
+      fetchJson,
+      log,
+      upsertRows
+    };
+  }
+
   private allowedDomainsForSource(type: SourceAccountType): string[] {
     switch (type) {
       case SourceAccountType.ENTRATA:
@@ -295,6 +441,463 @@ export class DevProvidersService {
       default:
         return [];
     }
+  }
+
+  private async persistRows(table: string, rows: unknown[], propertyId: string, runId: string) {
+    switch (table) {
+      case "leads":
+        return this.persistLeads(rows, propertyId);
+      case "leadEvents":
+      case "lead_events":
+        return this.persistLeadEvents(rows, propertyId);
+      case "applications":
+        return this.persistApplications(rows, propertyId);
+      case "leases":
+        return this.persistLeases(rows, propertyId);
+      case "conversionEvents":
+      case "conversion_events":
+        return this.persistConversionEvents(rows, propertyId, runId);
+      case "channelSpend":
+      case "channel_spend":
+        return this.persistChannelSpend(rows, propertyId, runId);
+      case "reviews":
+        return this.persistReviews(rows, propertyId, runId);
+      default:
+        throw new Error(`Unsupported table '${table}'. Allowed tables: leads, leadEvents, applications, leases, conversionEvents, channelSpend, reviews.`);
+    }
+  }
+
+  private async persistLeads(rows: unknown[], propertyId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "lead");
+      const externalId = this.ensureString(record.externalId, "lead.externalId");
+      const source = this.optionalString(record.source) ?? "Custom";
+      const createdAt = this.parseOptionalDate(record.createdAt, "lead.createdAt");
+      const cost = this.toDecimal(record.cost, "lead.cost");
+
+      const updateData: Prisma.LeadUpdateInput = {
+        source
+      };
+      if (cost !== undefined) {
+        updateData.cost = cost;
+      }
+      const gclid = this.optionalString(record.gclid);
+      if (gclid !== undefined) {
+        updateData.gclid = gclid;
+      }
+      const gbraid = this.optionalString(record.gbraid);
+      if (gbraid !== undefined) {
+        updateData.gbraid = gbraid;
+      }
+      const wbraid = this.optionalString(record.wbraid);
+      if (wbraid !== undefined) {
+        updateData.wbraid = wbraid;
+      }
+
+      const createData: Prisma.LeadCreateInput = {
+        propertyId,
+        externalId,
+        source,
+        createdAt: createdAt ?? new Date()
+      };
+      if (cost !== undefined) {
+        createData.cost = cost;
+      }
+      if (gclid !== undefined) {
+        createData.gclid = gclid;
+      }
+      if (gbraid !== undefined) {
+        createData.gbraid = gbraid;
+      }
+      if (wbraid !== undefined) {
+        createData.wbraid = wbraid;
+      }
+
+      await this.prisma.lead.upsert({
+        where: {
+          propertyId_externalId: {
+            propertyId,
+            externalId
+          }
+        },
+        update: updateData,
+        create: createData
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private async persistLeadEvents(rows: unknown[], propertyId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "leadEvent");
+      const id = this.optionalString(record.id) ?? this.deterministicId("leadEvent", propertyId, record.leadId, record.leadExternalId, record.type, record.occurredAt);
+      const type = this.ensureString(record.type, "leadEvent.type");
+      const occurredAt = this.parseDate(record.occurredAt ?? record.occurred_at ?? record.timestamp, "leadEvent.occurredAt");
+      const meta = record.meta !== undefined ? this.asJson(record.meta) : undefined;
+
+      const leadId = await this.resolveLeadId(propertyId, record);
+
+      await this.prisma.leadEvent.upsert({
+        where: { id },
+        update: {
+          leadId,
+          type,
+          occurredAt,
+          ...(meta !== undefined ? { meta } : {})
+        },
+        create: {
+          id,
+          leadId,
+          propertyId,
+          type,
+          occurredAt,
+          ...(meta !== undefined ? { meta } : {})
+        }
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private async persistApplications(rows: unknown[], propertyId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "application");
+      const leadId = await this.resolveLeadId(propertyId, record);
+      const status = this.parseEnum(ApplicationStatus, record.status, "application.status");
+      const submittedAt = this.parseDate(record.submittedAt ?? record.submitted_at, "application.submittedAt");
+      const approvedAt = this.parseOptionalDate(record.approvedAt ?? record.approved_at, "application.approvedAt");
+
+      await this.prisma.application.upsert({
+        where: { leadId },
+        update: {
+          status,
+          submittedAt,
+          approvedAt: approvedAt ?? null
+        },
+        create: {
+          propertyId,
+          leadId,
+          status,
+          submittedAt,
+          ...(approvedAt ? { approvedAt } : {})
+        }
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private async persistLeases(rows: unknown[], propertyId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "lease");
+      const leadId = await this.resolveLeadId(propertyId, record);
+      const status = this.parseEnum(LeaseStatus, record.status, "lease.status");
+      const startDate = this.parseDate(record.startDate ?? record.start_date, "lease.startDate");
+      const endDate = this.parseOptionalDate(record.endDate ?? record.end_date, "lease.endDate");
+      const moveOutAt = this.parseOptionalDate(record.moveOutAt ?? record.move_out_at, "lease.moveOutAt");
+      const unitId = this.optionalString(record.unitId ?? record.unit_id);
+      const applicationId = this.optionalString(record.applicationId ?? record.application_id);
+
+      await this.prisma.lease.upsert({
+        where: { leadId },
+        update: {
+          status,
+          startDate,
+          endDate: endDate ?? null,
+          moveOutAt: moveOutAt ?? null,
+          unitId: unitId ?? null,
+          applicationId: applicationId ?? null
+        },
+        create: {
+          propertyId,
+          leadId,
+          status,
+          startDate,
+          ...(endDate ? { endDate } : {}),
+          ...(moveOutAt ? { moveOutAt } : {}),
+          ...(unitId ? { unitId } : {}),
+          ...(applicationId ? { applicationId } : {})
+        }
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private async persistConversionEvents(rows: unknown[], propertyId: string, runId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "conversionEvent");
+      const id = this.optionalString(record.id) ?? this.deterministicId("conversion", propertyId, record.type, record.day, runId, processed);
+      const type = this.ensureString(record.type, "conversionEvent.type");
+      const day = this.parseDate(record.day ?? record.date, "conversionEvent.day");
+      const count = this.parseInteger(record.count ?? record.value, "conversionEvent.count");
+      const leadId = record.leadId ? this.optionalString(record.leadId) : undefined;
+      const leadExternalId = this.optionalString(record.leadExternalId ?? record.lead_external_id);
+      const resolvedLeadId = leadId ?? (leadExternalId ? await this.lookupLeadId(propertyId, leadExternalId) : undefined);
+      const gclid = this.optionalString(record.gclid);
+      const gbraid = this.optionalString(record.gbraid);
+      const wbraid = this.optionalString(record.wbraid);
+
+      await this.prisma.conversionEvent.upsert({
+        where: { id },
+        update: {
+          type,
+          day,
+          count,
+          leadId: resolvedLeadId ?? null,
+          gclid: gclid ?? null,
+          gbraid: gbraid ?? null,
+          wbraid: wbraid ?? null
+        },
+        create: {
+          id,
+          propertyId,
+          type,
+          day,
+          count,
+          ...(resolvedLeadId ? { leadId: resolvedLeadId } : {}),
+          ...(gclid ? { gclid } : {}),
+          ...(gbraid ? { gbraid } : {}),
+          ...(wbraid ? { wbraid } : {})
+        }
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private async persistChannelSpend(rows: unknown[], propertyId: string, runId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "channelSpend");
+      const id = this.optionalString(record.id) ?? this.deterministicId("channelSpend", propertyId, record.channel, record.day, runId, processed);
+      const channel = this.ensureString(record.channel, "channelSpend.channel");
+      const day = this.parseDate(record.day ?? record.date, "channelSpend.day");
+      const campaignId = this.optionalString(record.campaignId ?? record.campaign_id);
+      const cost = this.toDecimal(record.cost, "channelSpend.cost");
+      if (cost === undefined) {
+        throw new Error("channelSpend.cost is required");
+      }
+      const currency = this.optionalString(record.currency);
+
+      await this.prisma.channelSpend.upsert({
+        where: { id },
+        update: {
+          channel,
+          day,
+          campaignId: campaignId ?? null,
+          cost,
+          currency: currency ?? "USD"
+        },
+        create: {
+          id,
+          propertyId,
+          channel,
+          day,
+          cost,
+          ...(campaignId ? { campaignId } : {}),
+          ...(currency ? { currency } : {})
+        }
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private async persistReviews(rows: unknown[], propertyId: string, runId: string) {
+    let processed = 0;
+    for (const row of rows) {
+      const record = this.ensureRecord(row, "review");
+      const id = this.optionalString(record.id) ?? this.deterministicId("review", propertyId, record.at, record.authorName ?? record.author ?? record.text, runId, processed);
+      const rating = this.parseInteger(record.rating, "review.rating");
+      const text = this.ensureString(record.text ?? record.body, "review.text");
+      const at = this.parseDate(record.at ?? record.timestamp, "review.at");
+      const provider = record.provider ? this.parseEnum(ReviewProvider, record.provider, "review.provider") : ReviewProvider.GBP;
+      const authorName = this.optionalString(record.authorName ?? record.author);
+      const reviewerEmail = this.optionalString(record.reviewerEmail ?? record.email);
+      const reviewerPhoto = this.optionalString(record.reviewerPhoto ?? record.photoUrl);
+      const responseText = this.optionalString(record.responseText ?? record.response_text);
+      const respondedAt = this.parseOptionalDate(record.respondedAt ?? record.responded_at, "review.respondedAt");
+      const rawPayload = record.rawPayload !== undefined ? this.asJson(record.rawPayload) : undefined;
+
+      await this.prisma.review.upsert({
+        where: { id },
+        update: {
+          provider,
+          rating,
+          text,
+          at,
+          authorName: authorName ?? null,
+          reviewerEmail: reviewerEmail ?? null,
+          reviewerPhoto: reviewerPhoto ?? null,
+          responseText: responseText ?? null,
+          respondedAt: respondedAt ?? null,
+          ...(rawPayload !== undefined ? { rawPayload } : {})
+        },
+        create: {
+          id,
+          propertyId,
+          provider,
+          rating,
+          text,
+          at,
+          ...(authorName ? { authorName } : {}),
+          ...(reviewerEmail ? { reviewerEmail } : {}),
+          ...(reviewerPhoto ? { reviewerPhoto } : {}),
+          ...(responseText ? { responseText } : {}),
+          ...(respondedAt ? { respondedAt } : {}),
+          ...(rawPayload !== undefined ? { rawPayload } : {})
+        }
+      });
+      processed += 1;
+    }
+    return processed;
+  }
+
+  private ensureRecord(value: unknown, context: string): Record<string, unknown> {
+    if (!value || typeof value !== "object") {
+      throw new Error(`${context} row must be an object`);
+    }
+    return value as Record<string, unknown>;
+  }
+
+  private ensureString(value: unknown, field: string): string {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`${field} must be a non-empty string`);
+    }
+    return value.trim();
+  }
+
+  private optionalString(value: unknown): string | undefined {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    }
+    return undefined;
+  }
+
+  private parseDate(value: unknown, field: string): Date {
+    const date = this.parseOptionalDate(value, field);
+    if (!date) {
+      throw new Error(`${field} is required and must be a valid date or ISO string`);
+    }
+    return date;
+  }
+
+  private parseOptionalDate(value: unknown, field: string): Date | undefined {
+    if (value === undefined || value === null || value === "") {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      if (Number.isNaN(value.getTime())) {
+        throw new Error(`${field} is not a valid date`);
+      }
+      return value;
+    }
+    if (typeof value === "string") {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        throw new Error(`${field} is not a valid ISO date string`);
+      }
+      return date;
+    }
+    if (typeof value === "number") {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        throw new Error(`${field} is not a valid timestamp`);
+      }
+      return date;
+    }
+    throw new Error(`${field} must be a Date, ISO string, or timestamp`);
+  }
+
+  private parseEnum<T extends Record<string, string>>(enumObject: T, value: unknown, field: string): T[keyof T] {
+    if (typeof value !== "string") {
+      throw new Error(`${field} must be a string`);
+    }
+    const normalized = value.toUpperCase();
+    const match = Object.values(enumObject).find((item) => item.toUpperCase() === normalized);
+    if (!match) {
+      throw new Error(`${field} must be one of: ${Object.values(enumObject).join(", ")}`);
+    }
+    return match as T[keyof T];
+  }
+
+  private parseInteger(value: unknown, field: string): number {
+    if (value === undefined || value === null) {
+      throw new Error(`${field} is required`);
+    }
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`${field} must be a finite number`);
+    }
+    return Math.trunc(parsed);
+  }
+
+  private toDecimal(value: unknown, field: string): Prisma.Decimal | undefined {
+    if (value === undefined || value === null || value === "") {
+      return undefined;
+    }
+    const numeric = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(numeric)) {
+      throw new Error(`${field} must be a finite number`);
+    }
+    return new Prisma.Decimal(numeric);
+  }
+
+  private async resolveLeadId(propertyId: string, record: Record<string, unknown>) {
+    const explicitLeadId = this.optionalString(record.leadId ?? record.lead_id);
+    if (explicitLeadId) {
+      return explicitLeadId;
+    }
+    const leadExternalId = this.ensureString(record.leadExternalId ?? record.lead_external_id, "lead.leadExternalId");
+    const lead = await this.prisma.lead.findUnique({
+      where: {
+        propertyId_externalId: {
+          propertyId,
+          externalId: leadExternalId
+        }
+      }
+    });
+    if (!lead) {
+      throw new Error(`Lead with externalId ${leadExternalId} not found for property ${propertyId}`);
+    }
+    return lead.id;
+  }
+
+  private async lookupLeadId(propertyId: string, externalId: string) {
+    const lead = await this.prisma.lead.findUnique({
+      where: {
+        propertyId_externalId: {
+          propertyId,
+          externalId
+        }
+      }
+    });
+    return lead?.id;
+  }
+
+  private deterministicId(...parts: unknown[]) {
+    const hash = createHash("sha256");
+    for (const part of parts) {
+      hash.update(String(part ?? ""));
+      hash.update("|");
+    }
+    return hash.digest("hex").slice(0, 32);
+  }
+
+  private wrapScriptError(error: unknown, logs: string[]): never {
+    if (error instanceof BadRequestException) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new BadRequestException({ message, logs });
   }
 
   private instantiateModule(code: string, consoleOverride?: SandboxResult["console"]): ProviderModuleExports {

--- a/apps/backend/src/sources/sources.controller.ts
+++ b/apps/backend/src/sources/sources.controller.ts
@@ -12,6 +12,11 @@ export class SourcesController {
     return this.sourcesService.list(this.shouldUseMock(mockHeader));
   }
 
+  @Get(":id")
+  get(@Param("id") id: string) {
+    return this.sourcesService.getDetail(id);
+  }
+
   @Post()
   create(@Body() dto: CreateSourceDto) {
     return this.sourcesService.create({

--- a/apps/backend/src/sources/sources.service.ts
+++ b/apps/backend/src/sources/sources.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Prisma, SourceAccountType } from "@prisma/client";
 import type { SourceAccount } from "@prisma/client";
@@ -143,6 +143,33 @@ export class SourcesService {
       }
       throw error;
     }
+  }
+
+  async getDetail(id: string) {
+    const source = await this.prisma.sourceAccount.findUnique({
+      where: { id },
+      include: {
+        property: {
+          select: {
+            id: true,
+            name: true
+          }
+        }
+      }
+    });
+
+    if (!source) {
+      throw new NotFoundException("Source not found");
+    }
+
+    const summary = this.toSummary(source);
+    const credential = this.decryptCredential(source.credential);
+
+    return {
+      ...summary,
+      propertyName: source.property?.name ?? null,
+      credentialSummary: this.summarizeCredential(credential)
+    };
   }
 
   async create(dto: CreateSourceDto & { credential: CredentialPayload }) {
@@ -304,6 +331,40 @@ export class SourcesService {
       return { ok: result };
     }
     return result;
+  }
+
+  private summarizeCredential(value: Record<string, unknown> | null | undefined) {
+    if (!value) {
+      return [];
+    }
+
+    return Object.entries(value).map(([key, raw]) => {
+      const present =
+        raw !== null &&
+        raw !== undefined &&
+        !(typeof raw === "string" && raw.trim().length === 0);
+
+      let preview: string | undefined;
+      if (!present) {
+        preview = undefined;
+      } else if (typeof raw === "string") {
+        preview = "••••";
+      } else if (Array.isArray(raw)) {
+        preview = `${raw.length} item${raw.length === 1 ? "" : "s"}`;
+      } else if (typeof raw === "number" || typeof raw === "boolean") {
+        preview = typeof raw;
+      } else if (typeof raw === "object") {
+        preview = "object";
+      } else {
+        preview = "set";
+      }
+
+      return {
+        key,
+        present,
+        preview
+      };
+    });
   }
 
   private toSummary(source: SourceAccount): SourceSummary {

--- a/apps/frontend/app/admin/sources/[id]/studio/page.tsx
+++ b/apps/frontend/app/admin/sources/[id]/studio/page.tsx
@@ -1,0 +1,29 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { SourceStudioView } from "./studio-view";
+import { authOptions } from "@/lib/auth-options";
+
+interface SourceStudioPageProps {
+  params: { id: string };
+}
+
+export default async function SourceStudioPage({ params }: SourceStudioPageProps) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  if (session.user?.role !== "admin") {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="card-surface rounded-2xl border bg-white/90 p-6 shadow-card">
+        <SourceStudioView sourceId={params.id} />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/admin/sources/[id]/studio/studio-view.tsx
+++ b/apps/frontend/app/admin/sources/[id]/studio/studio-view.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Play,
+  Save,
+  UploadCloud
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  ApiError,
+  getProviderScript,
+  getSourceDetail,
+  listProviderLogs,
+  publishProviderScript,
+  runProviderScript,
+  saveProviderScript,
+  validateProviderScript
+} from "@/lib/api/sources";
+import { cn } from "@/lib/utils";
+import type { ProviderRunResponse, ProviderValidateResponse, SourceActionLogEntry } from "@shared/api";
+
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[420px] items-center justify-center text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  )
+});
+
+type TabKey = "script" | "readme";
+
+interface SourceStudioViewProps {
+  sourceId: string;
+}
+
+interface ActionFeedback {
+  type: "save" | "validate" | "run" | "publish";
+  success: boolean;
+  message: string;
+  logs?: string[];
+  latencyMs?: number;
+  rowsPersisted?: number;
+}
+
+function extractError(error: unknown): { message: string; logs?: string[] } {
+  if (error instanceof ApiError) {
+    const data = error.data;
+    if (data && typeof data === "object") {
+      const raw = data as Record<string, unknown>;
+      const logs = Array.isArray(raw.logs) ? (raw.logs as unknown[]).map((item) => String(item)) : undefined;
+      const message = typeof raw.message === "string" ? raw.message : error.message;
+      return { message, logs };
+    }
+    return { message: error.message };
+  }
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+  return { message: "Unexpected error" };
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function parseLog(entry: SourceActionLogEntry) {
+  const response = entry.response && typeof entry.response === "object" ? (entry.response as Record<string, unknown>) : null;
+  const logs = response && Array.isArray(response.logs) ? (response.logs as unknown[]).map((item) => String(item)) : [];
+  const rows = response && typeof response.rowsPersisted === "number" ? (response.rowsPersisted as number) : undefined;
+  return { logs, rowsPersisted: rows };
+}
+
+export function SourceStudioView({ sourceId }: SourceStudioViewProps) {
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<TabKey>("script");
+  const [code, setCode] = useState("");
+  const [readme, setReadme] = useState("");
+  const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const scriptQuery = useQuery({
+    queryKey: ["provider-script", sourceId],
+    queryFn: () => getProviderScript(sourceId)
+  });
+
+  const detailQuery = useQuery({
+    queryKey: ["source-detail", sourceId],
+    queryFn: () => getSourceDetail(sourceId)
+  });
+
+  const logsQuery = useQuery({
+    queryKey: ["provider-logs", sourceId],
+    queryFn: () => listProviderLogs(sourceId),
+    refetchInterval: 15_000
+  });
+
+  useEffect(() => {
+    if (!scriptQuery.data) {
+      return;
+    }
+    setCode(scriptQuery.data.code ?? "");
+    setReadme(scriptQuery.data.readme ?? "");
+  }, [scriptQuery.data]);
+
+  const persistDraft = useCallback(
+    async (options?: { silent?: boolean }) => {
+      setIsSaving(true);
+      try {
+        const saved = await saveProviderScript(sourceId, { code, readme });
+        queryClient.setQueryData(["provider-script", sourceId], saved);
+        if (!options?.silent) {
+          setFeedback({ type: "save", success: true, message: "Draft saved." });
+        }
+        return saved;
+      } catch (error) {
+        const { message } = extractError(error);
+        if (!options?.silent) {
+          setFeedback({ type: "save", success: false, message });
+        }
+        throw error;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [code, readme, queryClient, sourceId]
+  );
+
+  const validateMutation = useMutation({
+    mutationFn: async () => {
+      await persistDraft({ silent: true });
+      return validateProviderScript(sourceId);
+    },
+    onSuccess: (data) => handleValidateSuccess(data),
+    onError: (error) => handleActionError("validate", error)
+  });
+
+  const runMutation = useMutation({
+    mutationFn: async () => {
+      await persistDraft({ silent: true });
+      return runProviderScript(sourceId);
+    },
+    onSuccess: (data) => handleRunSuccess(data),
+    onError: (error) => handleActionError("run", error)
+  });
+
+  const publishMutation = useMutation({
+    mutationFn: async () => {
+      const saved = await persistDraft({ silent: true });
+      queryClient.setQueryData(["provider-script", sourceId], saved);
+      return publishProviderScript(sourceId);
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["provider-script", sourceId], data);
+      setFeedback({ type: "publish", success: true, message: "Draft published." });
+    },
+    onError: (error) => handleActionError("publish", error)
+  });
+
+  const handleValidateSuccess = useCallback(
+    (data: ProviderValidateResponse) => {
+      setFeedback({
+        type: "validate",
+        success: data.ok,
+        message: data.ok
+          ? `Validation succeeded${data.latencyMs ? ` (${data.latencyMs} ms)` : ""}.`
+          : "Validation completed with warnings.",
+        logs: data.logs ?? [],
+        latencyMs: data.latencyMs
+      });
+      logsQuery.refetch();
+    },
+    [logsQuery]
+  );
+
+  const handleRunSuccess = useCallback(
+    (data: ProviderRunResponse) => {
+      setFeedback({
+        type: "run",
+        success: data.ok,
+        message: data.rowsPersisted !== undefined
+          ? `Run completed (${data.rowsPersisted} rows persisted).`
+          : "Run completed.",
+        logs: data.logs ?? [],
+        rowsPersisted: data.rowsPersisted,
+        latencyMs: data.latencyMs
+      });
+      logsQuery.refetch();
+    },
+    [logsQuery]
+  );
+
+  const handleActionError = useCallback(
+    (type: ActionFeedback["type"], error: unknown) => {
+      const { message, logs } = extractError(error);
+      setFeedback({ type, success: false, message, logs });
+      logsQuery.refetch();
+    },
+    [logsQuery]
+  );
+
+  const actionsDisabled =
+    isSaving || validateMutation.isPending || runMutation.isPending || publishMutation.isPending || scriptQuery.isLoading;
+
+  const credentialSummary = detailQuery.data?.credentialSummary ?? [];
+  const status = detailQuery.data?.status ?? "UNVERIFIED";
+
+  const tabs = useMemo(
+    () => [
+      { key: "script" as const, label: "Script.ts" },
+      { key: "readme" as const, label: "README.md" }
+    ],
+    []
+  );
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <div className="flex flex-col gap-4">
+        {scriptQuery.isError ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            Unable to load the current draft. Refresh the page to try again.
+          </div>
+        ) : null}
+        <div className="overflow-hidden rounded-xl border">
+          <div className="flex border-b bg-slate-50">
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                className={cn(
+                  "px-4 py-2 text-sm font-medium",
+                  activeTab === tab.key
+                    ? "border-b-2 border-primary text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+                onClick={() => setActiveTab(tab.key)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className="bg-background">
+            <MonacoEditor
+              height="480px"
+              language={activeTab === "script" ? "typescript" : "markdown"}
+              path={activeTab === "script" ? "Script.ts" : "README.md"}
+              value={activeTab === "script" ? code : readme}
+              onChange={(value) => {
+                if (activeTab === "script") {
+                  setCode(value ?? "");
+                } else {
+                  setReadme(value ?? "");
+                }
+              }}
+              options={{
+                minimap: { enabled: false },
+                fontSize: 14,
+                scrollBeyondLastLine: false,
+                automaticLayout: true
+              }}
+            />
+          </div>
+        </div>
+
+        {feedback ? (
+          <div
+            className={cn(
+              "rounded-xl border px-4 py-3 text-sm",
+              feedback.success
+                ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+                : "border-red-200 bg-red-50 text-red-800"
+            )}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  {feedback.success ? (
+                    <CheckCircle2 className="h-4 w-4" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4" />
+                  )}
+                  <span>{feedback.message}</span>
+                </div>
+                {feedback.rowsPersisted !== undefined ? (
+                  <p className="text-xs text-emerald-900">
+                    Rows persisted: {feedback.rowsPersisted.toLocaleString()}
+                  </p>
+                ) : null}
+                {feedback.latencyMs !== undefined ? (
+                  <p className="text-xs text-muted-foreground">Latency: {feedback.latencyMs} ms</p>
+                ) : null}
+              </div>
+              <button className="text-xs underline" onClick={() => setFeedback(null)}>
+                Dismiss
+              </button>
+            </div>
+            {feedback.logs && feedback.logs.length > 0 ? (
+              <pre className="mt-3 max-h-48 overflow-y-auto rounded-lg bg-slate-900/90 p-3 font-mono text-xs text-slate-100">
+                {feedback.logs.join("\n")}
+              </pre>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+  <div className="space-y-4">
+        <div className="rounded-xl border p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-foreground">Connection</h2>
+            <span
+              className={cn(
+                "rounded-full px-2 py-0.5 text-xs font-medium",
+                status === "CONNECTED" && "bg-emerald-100 text-emerald-700",
+                status === "ERROR" && "bg-red-100 text-red-700",
+                status === "UNVERIFIED" && "bg-amber-100 text-amber-700"
+              )}
+            >
+              {status}
+            </span>
+          </div>
+          <Separator className="my-3" />
+          {detailQuery.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading details…</p>
+          ) : detailQuery.isError ? (
+            <p className="text-sm text-red-600">Unable to load source details.</p>
+          ) : detailQuery.data ? (
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <div>
+                <span className="font-medium text-foreground">Name:</span> {detailQuery.data.name ?? "—"}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">Type:</span> {detailQuery.data.type}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">Property:</span> {detailQuery.data.propertyName ?? "—"}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">Created:</span> {formatDateTime(detailQuery.data.createdAt)}
+              </div>
+            </div>
+          ) : null}
+
+          <Separator className="my-3" />
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Credentials</h3>
+          {credentialSummary.length === 0 ? (
+            <p className="mt-2 text-sm text-muted-foreground">No credential fields stored for this source.</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {credentialSummary.map((item) => (
+                <div
+                  key={item.key}
+                  className="flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-muted-foreground"
+                >
+                  <span className="font-medium text-foreground">{item.key}</span>
+                  <span>{item.present ? item.preview ?? "set" : "missing"}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-xl border p-4">
+          <h2 className="text-sm font-semibold text-foreground">Actions</h2>
+          <div className="mt-3 flex flex-col gap-2">
+            <Button
+              variant="outline"
+              onClick={() => persistDraft()}
+              disabled={actionsDisabled}
+            >
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+              Save draft
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => validateMutation.mutate()}
+              disabled={actionsDisabled || validateMutation.isPending}
+            >
+              {validateMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle2 className="mr-2 h-4 w-4" />
+              )}
+              Validate
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => runMutation.mutate()}
+              disabled={actionsDisabled || runMutation.isPending}
+            >
+              {runMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="mr-2 h-4 w-4" />
+              )}
+              Run
+            </Button>
+            <Button
+              onClick={() => publishMutation.mutate()}
+              disabled={actionsDisabled || publishMutation.isPending}
+            >
+              {publishMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <UploadCloud className="mr-2 h-4 w-4" />
+              )}
+              Publish
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-foreground">Logs</h2>
+            <Button variant="ghost" size="sm" onClick={() => logsQuery.refetch()} disabled={logsQuery.isFetching}>
+              {logsQuery.isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Refresh
+            </Button>
+          </div>
+          <Separator className="my-3" />
+          {logsQuery.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading logs…</p>
+          ) : logsQuery.isError ? (
+            <p className="text-sm text-red-600">Unable to load logs.</p>
+          ) : logsQuery.data && logsQuery.data.length > 0 ? (
+            <ScrollArea className="max-h-[320px]">
+              <div className="space-y-3 pr-2">
+                {logsQuery.data.map((entry) => {
+                  const parsed = parseLog(entry);
+                  return (
+                    <div key={entry.id} className="rounded-lg border px-3 py-2 text-xs">
+                      <div className="flex items-center justify-between font-semibold">
+                        <span>{entry.action}</span>
+                        <span className={entry.ok ? "text-emerald-600" : "text-red-600"}>
+                          {entry.ok ? "OK" : "Error"}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-muted-foreground">{formatDateTime(entry.createdAt)}</div>
+                      {entry.error ? (
+                        <div className="mt-2 text-red-600">{entry.error}</div>
+                      ) : null}
+                      {parsed.rowsPersisted !== undefined ? (
+                        <div className="mt-1 text-muted-foreground">
+                          Rows persisted: {parsed.rowsPersisted.toLocaleString()}
+                        </div>
+                      ) : null}
+                      {parsed.logs.length > 0 ? (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-muted-foreground">Logs</summary>
+                          <pre className="mt-2 whitespace-pre-wrap rounded bg-slate-900/90 p-2 font-mono text-[11px] text-slate-100">
+                            {parsed.logs.join("\n")}
+                          </pre>
+                        </details>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          ) : (
+            <p className="text-sm text-muted-foreground">No logs recorded yet.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/admin/sources/sources-view.tsx
+++ b/apps/frontend/app/admin/sources/sources-view.tsx
@@ -1,9 +1,10 @@
 
 "use client";
 
+import Link from "next/link";
 import { useCallback, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, Pencil, Play, Plus, Trash } from "lucide-react";
+import { Code2, Loader2, Pencil, Play, Plus, Trash } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -579,6 +580,11 @@ export function SourcesAdminView() {
               ) : null}
             </div>
             <div className="flex flex-wrap items-center gap-2">
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/admin/sources/${source.id}/studio`}>
+                  <Code2 className="mr-2 h-4 w-4" /> Open in Studio
+                </Link>
+              </Button>
               <Button
                 variant="outline"
                 size="sm"

--- a/apps/frontend/lib/api/sources.ts
+++ b/apps/frontend/lib/api/sources.ts
@@ -1,15 +1,36 @@
 import {
   createSourceRequestSchema,
   listSourcesResponseSchema,
+  providerRunResponseSchema,
+  providerScriptSchema,
+  providerValidateResponseSchema,
+  sourceActionLogListSchema,
+  sourceDetailSchema,
   sourceMutationResponseSchema,
   updateSourceRequestSchema,
   type CreateSourceRequest,
   type ListSourcesResponse,
+  type ProviderRunResponse,
+  type ProviderScriptResponse,
+  type ProviderValidateResponse,
+  type SourceActionLogEntry,
+  type SourceDetail,
   type SourceMutationResponse,
   type UpdateSourceRequest
 } from "@shared/api";
 
 import { apiBaseUrl, isMockMode } from "../utils";
+
+export class ApiError extends Error {
+  status: number;
+  data?: unknown;
+
+  constructor(message: string, status: number, data?: unknown) {
+    super(message);
+    this.status = status;
+    this.data = data;
+  }
+}
 
 type SchemaParser<T> = { parse: (data: unknown) => T };
 
@@ -36,17 +57,29 @@ async function request<T>(
     }
   });
 
+  const rawBody = await response.text();
+  let parsedBody: unknown = undefined;
+
+  if (rawBody) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      parsedBody = rawBody;
+    }
+  }
+
   if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Request failed for ${path}: ${response.status} ${body}`);
+    const message = typeof parsedBody === "object" && parsedBody && "message" in parsedBody
+      ? String((parsedBody as { message?: unknown }).message)
+      : `Request failed for ${path}: ${response.status}`;
+    throw new ApiError(message, response.status, parsedBody);
   }
 
   if (!schema) {
     return;
   }
 
-  const json = await response.json();
-  return schema.parse(json);
+  return schema.parse(parsedBody ?? {});
 }
 
 export async function listSources(): Promise<ListSourcesResponse> {
@@ -83,4 +116,74 @@ export async function deleteSource(id: string): Promise<void> {
 
 export async function runSource(id: string): Promise<void> {
   await request(`/admin/sources/${id}/run`, { method: "POST" });
+}
+
+export async function getSourceDetail(id: string): Promise<SourceDetail> {
+  return request<SourceDetail>(`/admin/sources/${id}`, { method: "GET" }, sourceDetailSchema) as Promise<SourceDetail>;
+}
+
+export async function getProviderScript(sourceId: string): Promise<ProviderScriptResponse> {
+  return request<ProviderScriptResponse>(
+    `/admin/dev/providers/${sourceId}/script`,
+    { method: "GET" },
+    providerScriptSchema
+  ) as Promise<ProviderScriptResponse>;
+}
+
+export async function saveProviderScript(
+  sourceId: string,
+  payload: { code: string; readme?: string }
+): Promise<ProviderScriptResponse> {
+  const body = JSON.stringify(payload);
+  return request<ProviderScriptResponse>(
+    `/admin/dev/providers/${sourceId}/script`,
+    {
+      method: "POST",
+      body
+    },
+    providerScriptSchema
+  ) as Promise<ProviderScriptResponse>;
+}
+
+export async function publishProviderScript(
+  sourceId: string,
+  publishedBy?: string
+): Promise<ProviderScriptResponse> {
+  const body = publishedBy ? JSON.stringify({ publishedBy }) : undefined;
+  return request<ProviderScriptResponse>(
+    `/admin/dev/providers/${sourceId}/publish`,
+    {
+      method: "POST",
+      ...(body ? { body } : {})
+    },
+    providerScriptSchema
+  ) as Promise<ProviderScriptResponse>;
+}
+
+export async function validateProviderScript(sourceId: string): Promise<ProviderValidateResponse> {
+  return request<ProviderValidateResponse>(
+    `/admin/dev/providers/${sourceId}/validate`,
+    { method: "POST" },
+    providerValidateResponseSchema
+  ) as Promise<ProviderValidateResponse>;
+}
+
+export async function runProviderScript(sourceId: string, createdBy?: string): Promise<ProviderRunResponse> {
+  const body = createdBy ? JSON.stringify({ createdBy }) : undefined;
+  return request<ProviderRunResponse>(
+    `/admin/dev/providers/${sourceId}/run`,
+    {
+      method: "POST",
+      ...(body ? { body } : {})
+    },
+    providerRunResponseSchema
+  ) as Promise<ProviderRunResponse>;
+}
+
+export async function listProviderLogs(sourceId: string): Promise<SourceActionLogEntry[]> {
+  return request<SourceActionLogEntry[]>(
+    `/admin/dev/providers/${sourceId}/logs`,
+    { method: "GET" },
+    sourceActionLogListSchema
+  ) as Promise<SourceActionLogEntry[]>;
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query-devtools": "^5.59.8",
     "@tanstack/react-table": "^8.20.5",
     "@tanstack/react-virtual": "^3.8.7",
+    "@monaco-editor/react": "^4.6.0",
     "autoprefixer": "^10.4.19",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -40,7 +41,8 @@
     "react-dom": "18.3.1",
     "tailwind-merge": "^2.5.3",
     "tailwindcss": "^3.4.13",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "monaco-editor": "^0.50.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.2",

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -246,6 +246,55 @@ export const sourceAccountSchema = z.object({
   updatedAt: z.string().datetime({ offset: true })
 });
 
+export const credentialSummaryItemSchema = z.object({
+  key: z.string(),
+  present: z.boolean(),
+  preview: z.string().optional()
+});
+
+export const sourceDetailSchema = sourceAccountSchema.extend({
+  propertyName: z.string().nullable().optional(),
+  credentialSummary: z.array(credentialSummaryItemSchema)
+});
+
+export const providerScriptSchema = z.object({
+  code: z.string(),
+  readme: z.string().optional(),
+  status: ScriptStatusEnum,
+  version: z.number(),
+  manifest: ProviderManifest.nullable().optional()
+});
+
+export const providerValidateResponseSchema = z.object({
+  ok: z.boolean(),
+  result: z.unknown().optional(),
+  latencyMs: z.number().optional(),
+  logs: z.array(z.string()).optional()
+});
+
+export const providerRunResponseSchema = z.object({
+  ok: z.boolean(),
+  result: z.unknown().optional(),
+  rowsPersisted: z.number().optional(),
+  latencyMs: z.number().optional(),
+  logs: z.array(z.string()).optional()
+});
+
+export const sourceActionLogSchema = z.object({
+  id: z.string(),
+  sourceId: z.string(),
+  action: z.string(),
+  ok: z.boolean(),
+  latencyMs: z.number().nullable().optional(),
+  request: z.unknown().nullable().optional(),
+  response: z.unknown().nullable().optional(),
+  error: z.string().nullable().optional(),
+  createdBy: z.string().nullable().optional(),
+  createdAt: z.string().datetime({ offset: true })
+});
+
+export const sourceActionLogListSchema = z.array(sourceActionLogSchema);
+
 export const listSourcesResponseSchema = z.object({
   sources: z.array(sourceAccountSchema)
 });
@@ -476,10 +525,16 @@ export type PropertiesResponse = z.infer<typeof propertiesResponseSchema>;
 export type SourceType = z.infer<typeof sourceTypeSchema>;
 export type SourceStatus = z.infer<typeof sourceStatusSchema>;
 export type SourceAccount = z.infer<typeof sourceAccountSchema>;
+export type CredentialSummaryItem = z.infer<typeof credentialSummaryItemSchema>;
+export type SourceDetail = z.infer<typeof sourceDetailSchema>;
 export type ListSourcesResponse = z.infer<typeof listSourcesResponseSchema>;
 export type CreateSourceRequest = z.infer<typeof createSourceRequestSchema>;
 export type UpdateSourceRequest = z.infer<typeof updateSourceRequestSchema>;
 export type SourceMutationResponse = z.infer<typeof sourceMutationResponseSchema>;
+export type ProviderScriptResponse = z.infer<typeof providerScriptSchema>;
+export type ProviderValidateResponse = z.infer<typeof providerValidateResponseSchema>;
+export type ProviderRunResponse = z.infer<typeof providerRunResponseSchema>;
+export type SourceActionLogEntry = z.infer<typeof sourceActionLogSchema>;
 export type PublicDashboard = z.infer<typeof publicDashboardSchema>;
 export type PublicDashboardListResponse = z.infer<typeof publicDashboardListResponseSchema>;
 export type CreatePublicDashboardRequest = z.infer<typeof createPublicDashboardRequestSchema>;


### PR DESCRIPTION
## Summary
- extend dev provider backend to support README drafts, sandboxed run execution with row limits, and credential summaries for sources
- publish new shared schemas and API client utilities for provider studio actions and source detail/log retrieval
- build the admin studio interface with Monaco editing, credentials panel, Validate/Run/Publish actions, auto-refreshing logs, and link it from the sources list

## Testing
- pnpm -C apps/frontend lint
- pnpm -C apps/backend lint *(fails: existing lint/import-order issues and a prefer-const error in tables service)*
- pnpm -C apps/backend prisma generate *(fails: Prisma engine download blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c7df8e688322835f699d247403af