### PR TITLE
feat(tables): add quick search and column presets

### DIFF
--- a/apps/frontend/components/tables/TableGrid.tsx
+++ b/apps/frontend/components/tables/TableGrid.tsx
@@ -20,8 +20,10 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import {
   ColumnDef,
+  FilterFn,
   flexRender,
   getCoreRowModel,
+  getFilteredRowModel,
   useReactTable
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -34,6 +36,7 @@ import {
   FolderPlus,
   Plus,
   Rows,
+  Search,
   Trash2
 } from "lucide-react";
 
@@ -91,6 +94,13 @@ interface TableGridProps {
 }
 
 const COLUMN_TYPE_ENUM = ColumnType.enum;
+
+const SEARCHABLE_COLUMN_TYPES = new Set<ColumnKind>([
+  COLUMN_TYPE_ENUM.TEXT,
+  COLUMN_TYPE_ENUM.NUMBER,
+  COLUMN_TYPE_ENUM.BOOLEAN,
+  COLUMN_TYPE_ENUM.DATE
+]);
 
 const COLUMN_TYPE_OPTIONS: Array<{ label: string; value: ColumnKind }> = [
   { label: "Text", value: COLUMN_TYPE_ENUM.TEXT },
@@ -214,6 +224,51 @@ function getCellValue(row: TableRowDto, columnId: string) {
     (entry: TableRowDto["cells"][number]) => entry.columnId === columnId
   );
   return cell?.value ?? null;
+}
+
+function stringifyValueForSearch(column: TableColumnDto, value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (column.type === COLUMN_TYPE_ENUM.BOOLEAN) {
+    if (typeof value === "boolean") {
+      return value ? "true" : "false";
+    }
+    if (typeof value === "number") {
+      return value !== 0 ? "true" : "false";
+    }
+    if (typeof value === "string") {
+      const normalized = value.toLowerCase();
+      if (["true", "1", "yes", "y", "on"].includes(normalized)) {
+        return "true";
+      }
+      if (["false", "0", "no", "n", "off"].includes(normalized)) {
+        return "false";
+      }
+    }
+  }
+
+  if (column.type === COLUMN_TYPE_ENUM.NUMBER) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value.toString();
+    }
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed.toString();
+    }
+  }
+
+  if (column.type === COLUMN_TYPE_ENUM.DATE) {
+    const date = value instanceof Date ? value : new Date(String(value));
+    if (!Number.isNaN(date.getTime())) {
+      const iso = date.toISOString();
+      const locale = `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`.trim();
+      return `${iso} ${locale}`.trim();
+    }
+  }
+
+  return String(value);
 }
 
 type ReferenceConfig = {
@@ -424,8 +479,35 @@ export function TableGrid({ tableId }: TableGridProps) {
   const [importSummary, setImportSummary] = useState<{ createdColumns: number; createdRows: number } | null>(null);
   const [editingColumnId, setEditingColumnId] = useState<string | null>(null);
   const [editingColumnName, setEditingColumnName] = useState("");
+  const [globalQuery, setGlobalQuery] = useState("");
+  const [debouncedGlobalQuery, setDebouncedGlobalQuery] = useState("");
 
   const reorderDisabled = Boolean(filters.length || sorts.length);
+
+  const orderedViewColumns = useMemo(() => {
+    const byId = new Map(columns.map((column: TableColumnDto) => [column.id, column] as const));
+    const seen = new Set<string>();
+    const ordered: TableColumnDto[] = [];
+
+    for (const columnId of columnOrder) {
+      const column = byId.get(columnId);
+      if (column && !seen.has(column.id)) {
+        ordered.push(column);
+        seen.add(column.id);
+      }
+    }
+
+    if (seen.size < columns.length) {
+      for (const column of columns) {
+        if (!seen.has(column.id)) {
+          ordered.push(column);
+          seen.add(column.id);
+        }
+      }
+    }
+
+    return ordered;
+  }, [columns, columnOrder]);
 
   useEffect(() => {
     setColumnOrder(baseColumnOrder);
@@ -438,6 +520,14 @@ export function TableGrid({ tableId }: TableGridProps) {
       setNewColumnOptions("");
     }
   }, [isAddColumnOpen]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedGlobalQuery(globalQuery);
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [globalQuery]);
 
   useEffect(() => {
     setColumnVisibility((prev) => {
@@ -519,6 +609,38 @@ export function TableGrid({ tableId }: TableGridProps) {
     });
   }, [sortedRows, columns]);
 
+  const searchableColumns = useMemo(() => {
+    return columns.filter(
+      (column) => (columnVisibility[column.id] ?? true) && SEARCHABLE_COLUMN_TYPES.has(column.type)
+    );
+  }, [columns, columnVisibility]);
+
+  const globalFilterFn = useMemo<FilterFn<GridRow>>(
+    () =>
+      (row, _columnId, filterValue) => {
+        const query = String(filterValue ?? "").trim().toLowerCase();
+
+        if (!query) {
+          return true;
+        }
+
+        if (!searchableColumns.length) {
+          return false;
+        }
+
+        for (const column of searchableColumns) {
+          const rawValue = row.original[column.id];
+          const text = stringifyValueForSearch(column, rawValue).toLowerCase();
+          if (text && text.includes(query)) {
+            return true;
+          }
+        }
+
+        return false;
+      },
+    [searchableColumns]
+  );
+
   const handleRowDragEnd = useCallback(
     (event: DragEndEvent) => {
       if (reorderDisabled) {
@@ -544,9 +666,16 @@ export function TableGrid({ tableId }: TableGridProps) {
   );
 
   const handleToggleColumnVisibility = useCallback(
-    (columnId: string) => {
+    (columnId: string, nextVisible?: boolean) => {
       setColumnVisibility((prev) => {
-        const next = { ...prev, [columnId]: !prev[columnId] };
+        const current = prev[columnId] ?? true;
+        const resolved = typeof nextVisible === "boolean" ? nextVisible : !current;
+
+        if (resolved === current) {
+          return prev;
+        }
+
+        const next = { ...prev, [columnId]: resolved };
         if (activeViewId) {
           const config = buildConfig({ filters, sorts, columnVisibility: next, columnOrder });
           updateViewMutation.mutate({ id: activeViewId, payload: { config } });
@@ -776,14 +905,17 @@ export function TableGrid({ tableId }: TableGridProps) {
     columns: columnDefs,
     state: {
       columnOrder: tableColumnOrder,
-      columnVisibility
+      columnVisibility,
+      globalFilter: debouncedGlobalQuery
     },
     onColumnOrderChange: (updater) => {
       const nextOrder = typeof updater === "function" ? (updater as (old: string[]) => string[])(tableColumnOrder) : updater;
       const filtered = nextOrder.filter((id) => id !== "__select__" && id !== "__position__");
       setColumnOrder(filtered);
     },
-    getCoreRowModel: getCoreRowModel()
+    globalFilterFn,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel()
   });
 
   const parentRef = useRef<HTMLDivElement | null>(null);
@@ -976,7 +1108,23 @@ export function TableGrid({ tableId }: TableGridProps) {
           onRename={handleRenameView}
           onDelete={handleDeleteView}
           isSaving={createViewMutation.isPending}
+          columns={orderedViewColumns}
+          columnVisibility={columnVisibility}
+          onToggleColumnVisibility={(columnId, visible) =>
+            handleToggleColumnVisibility(columnId, visible)
+          }
         />
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            value={globalQuery}
+            onChange={(event) => setGlobalQuery(event.target.value)}
+            placeholder="Quick search"
+            aria-label="Quick search"
+            className="h-8 w-56 rounded-full border border-border/60 bg-white/70 pl-8 pr-3 text-sm focus-visible:ring-0"
+          />
+        </div>
         <div className="flex flex-wrap items-center gap-2 rounded-full border border-border/60 bg-white/70 px-3 py-1">
           <Filter className="h-4 w-4 text-muted-foreground" />
           <span className="text-xs font-medium text-muted-foreground">Filters</span>

--- a/apps/frontend/components/tables/ViewMenu.tsx
+++ b/apps/frontend/components/tables/ViewMenu.tsx
@@ -3,10 +3,11 @@
 import { useMemo } from "react";
 import { Check, ChevronDown, PlusCircle, Trash2 } from "lucide-react";
 
-import { type TableViewDto } from "@/lib/api/tables";
+import { type TableColumnDto, type TableViewDto } from "@/lib/api/tables";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -22,6 +23,9 @@ interface ViewMenuProps {
   onRename: (viewId: string) => void;
   onDelete: (viewId: string) => void;
   isSaving?: boolean;
+  columns: TableColumnDto[];
+  columnVisibility: Record<string, boolean>;
+  onToggleColumnVisibility: (columnId: string, visible: boolean) => void;
 }
 
 export function ViewMenu({
@@ -31,7 +35,10 @@ export function ViewMenu({
   onSaveCurrent,
   onRename,
   onDelete,
-  isSaving
+  isSaving,
+  columns,
+  columnVisibility,
+  onToggleColumnVisibility
 }: ViewMenuProps) {
   const activeView = useMemo(() => views.find((view) => view.id === activeViewId), [views, activeViewId]);
   const label = activeView ? activeView.name : "Default view";
@@ -79,6 +86,23 @@ export function ViewMenu({
             </DropdownMenuItem>
           </>
         ) : null}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+          Columns
+        </DropdownMenuLabel>
+        {columns.length ? (
+          columns.map((column) => (
+            <DropdownMenuCheckboxItem
+              key={column.id}
+              checked={columnVisibility[column.id] ?? true}
+              onCheckedChange={(value) => onToggleColumnVisibility(column.id, value === true)}
+            >
+              {column.name}
+            </DropdownMenuCheckboxItem>
+          ))
+        ) : (
+          <DropdownMenuItem disabled>No columns</DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -484,16 +484,23 @@ export const reorderRowsDtoSchema = z.object({
   )
 });
 
+const viewConfigSchema = z
+  .object({
+    hidden: z.array(z.string()).optional(),
+    columnOrder: z.array(z.string()).optional()
+  })
+  .passthrough();
+
 export const createViewDtoSchema = z.object({
   tableId: z.string(),
   name: z.string().min(1),
-  config: z.unknown()
+  config: viewConfigSchema
 });
 
 export const updateViewDtoSchema = z
   .object({
     name: z.string().optional(),
-    config: z.unknown().optional()
+    config: viewConfigSchema.optional()
   })
   .refine((payload) => Object.keys(payload).length > 0, {
     message: "Update payload cannot be empty"
@@ -626,11 +633,11 @@ export const ReorderRowsDto = z.object({
 export const CreateViewDto = z.object({
   tableId: z.string(),
   name: z.string(),
-  config: z.any(),
+  config: viewConfigSchema,
 });
 export const UpdateViewDto = z.object({
   name: z.string().optional(),
-  config: z.any().optional(),
+  config: viewConfigSchema.optional(),
 });
 
 export type TColumnType = z.infer<typeof ColumnType>;


### PR DESCRIPTION
## Summary
- add a debounced quick search toolbar field and hook it into TanStack Table's global filter so only visible columns are searched
- surface per-view column visibility controls in the view dropdown and persist both visibility and order changes
- tighten the shared view config schema to accept hidden columns and column ordering metadata

## Testing
- pnpm --filter apps-frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68e6906bd1f8832294c2f767418ae4fa