### PR TITLE
api(build): exclude test files from production build

### DIFF
--- a/apps/astalla-api/package.json
+++ b/apps/astalla-api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "tsc && NODE_ENV=test node --test dist/**/*.test.js",
     "start": "node dist/index.js",
     "start:prod": "node dist/index.js",

--- a/apps/astalla-api/tsconfig.build.json
+++ b/apps/astalla-api/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a build-specific TypeScript configuration that excludes test files
- update the API build script to compile using the new configuration so production builds skip tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ba14861ac8322b728dacf019828ee